### PR TITLE
Allow for passing 0 cores to mean all available

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -791,14 +791,14 @@ def get_argument_parser(profile=None):
         "--cores",
         "--jobs",
         "-j",
-        action="store",
+        default=1,
         const=available_cpu_count(),
         nargs="?",
         metavar="N",
         type=int,
         help=(
             "Use at most N cores in parallel (default: 1). "
-            "If N is omitted, the limit is set to the number of "
+            "If N is 0 or omitted, the limit is set to the number of "
             "available cores."
         ),
     )
@@ -1685,8 +1685,8 @@ def main(argv=None):
                     file=sys.stderr,
                 )
                 sys.exit(1)
-    elif args.cores is None:
-        args.cores = 1
+    elif args.cores == 0:
+        args.cores = available_cpu_count()
 
     if args.drmaa_log_dir is not None:
         if not os.path.isabs(args.drmaa_log_dir):

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -1,0 +1,43 @@
+from snakemake import get_argument_parser, available_cpu_count
+
+
+class TestArgumentParser:
+    def test_no_cores_passed_sets_cores_to_default(self):
+        parser = get_argument_parser()
+        cli_args = ["snakemake"]
+        args = parser.parse_args(cli_args)
+
+        actual = args.cores
+        expected = 1
+
+        assert actual == expected
+
+    def test_no_cores_number_passed_sets_cores_to_number_available(self):
+        parser = get_argument_parser()
+        cli_args = ["snakemake", "--cores"]
+        args = parser.parse_args(cli_args)
+
+        actual = args.cores
+        expected = available_cpu_count()
+
+        assert actual == expected
+
+    def test_zero_cores_passed_sets_cores_to_zero(self):
+        parser = get_argument_parser()
+        cli_args = ["snakemake", "--jobs", "0"]
+        args = parser.parse_args(cli_args)
+
+        actual = args.cores
+        expected = 0
+
+        assert actual == expected
+
+    def test_two_cores_passed_sets_cores_to_two(self):
+        parser = get_argument_parser()
+        cli_args = ["snakemake", "--jobs", "2"]
+        args = parser.parse_args(cli_args)
+
+        actual = args.cores
+        expected = 2
+
+        assert actual == expected


### PR DESCRIPTION
Addresses / closes #11 

When trying to pass `None` in a snakemake profile, `None` cannot be parsed as an `int`. This PR allows `0` to be passed to `--cores/--jobs/-j` and it will use all available cores. This way cores can be set to 0 in a snakemake profile.

Apologies if I have not setup the tests in the correct way. Obviously very happy to change things to fit into the project structure better.