### PR TITLE
Fix wrong abstract method name in remote.S3 ("default_" -> "default_protocol")

### DIFF
--- a/snakemake/remote/S3.py
+++ b/snakemake/remote/S3.py
@@ -44,7 +44,7 @@ class RemoteProvider(
         return self._s3c
 
     @property  # decorator, so that this function can be access as an attribute, instead of a method
-    def default_(self):
+    def default_protocol(self):
         """The protocol that is prepended to the path when no protocol is specified."""
         return "s3://"
 


### PR DESCRIPTION
Fix wrong abstract method name "default_" to "default_protocol"

This typo causes following error when use S3.remote with `stay_on_remote=True`, and this PR fixes it.

```
TypeError in line 6 of /Users/smatsumoto/tmp/snakemake-test/lambda1/Snakefile:
unsupported operand type(s) for +: 'method' and 'str'
  File "/Users/smatsumoto/tmp/snakemake-test/lambda1/Snakefile", line 5, in <module>
  File "/Users/smatsumoto/tmp/snakemake/snakemake/remote/__init__.py", line 91, in remote
```

used Snakefile
```
from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
S3 = S3RemoteProvider()

rule all_lambda:
    input: S3.remote("net-seigot-smtest1/input/hoge.jpg", stay_on_remote=True)
    output: S3.remote("net-seigot-smtest1/output/hoge.jpg", stay_on_remote=True)
    shell: './lambda_invoker.sh smtest-lambda1.py -i input -o output {input}'
```
