### PR TITLE
Fix "default_resources" initial parameter in "Workflow.__init__"

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -87,7 +87,7 @@ class Workflow:
         default_remote_provider=None,
         default_remote_prefix="",
         run_local=True,
-        default_resources=dict(),
+        default_resources=None,
     ):
         """
         Create the controller.


### PR DESCRIPTION
### Fix

"dict()" is not appropriate value for "default_resources" because workflow.py l.933 assumes "default_resources" has "parsed" attribute which "dict()" does not have.

https://github.com/snakemake/snakemake/blob/44206be0bb278dca61a103e3b1fc873af976a554/snakemake/workflow.py#L933

As default value, "None" would be good because workflow.py l.142 checks the value, and use DefaultResources() if the value is "None".

https://github.com/snakemake/snakemake/blob/44206be0bb278dca61a103e3b1fc873af976a554/snakemake/workflow.py#L142-L146


### Issues solved

Current code produces following error when bash completion running, and this PR fix it.

```
  File "/Users/smatsumoto/tmp/snakemake-test/venv/bin/snakemake-bash-completion", line 11, in <module>
    load_entry_point('snakemake', 'console_scripts', 'snakemake-bash-completion')()
  File "/Users/smatsumoto/tmp/snakemake/snakemake/__init__.py", line 1960, in bash_completion
    workflow.include(snakefile)
  File "/Users/smatsumoto/tmp/snakemake/snakemake/workflow.py", line 851, in include
    exec(compile(code, snakefile, "exec"), self.globals)
  File "/Users/smatsumoto/tmp/snakemake-test/dir1/Snakefile", line 11, in <module>
    shell:
  File "/Users/smatsumoto/tmp/snakemake/snakemake/workflow.py", line 933, in decorate
    rule.resources = copy.deepcopy(self.default_resources.parsed)
AttributeError: 'dict' object has no attribute 'parsed'
```
