### PR TITLE
Fix deprecation warnings

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -693,7 +693,7 @@ def not_iterable(value):
     return (
         isinstance(value, str)
         or isinstance(value, dict)
-        or not isinstance(value, collections.Iterable)
+        or not isinstance(value, collections.abc.Iterable)
     )
 
 
@@ -893,7 +893,7 @@ def expand(*args, **wildcards):
 
     def flatten(wildcards):
         for wildcard, values in wildcards.items():
-            if isinstance(values, str) or not isinstance(values, collections.Iterable):
+            if isinstance(values, str) or not isinstance(values, collections.abc.Iterable):
                 values = [values]
             yield [(wildcard, value) for value in values]
 

--- a/snakemake/remote/FTP.py
+++ b/snakemake/remote/FTP.py
@@ -64,7 +64,7 @@ class RemoteProvider(AbstractRemoteProvider):
     ):
         if isinstance(value, str):
             values = [value]
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, collections.abc.Iterable):
             values = value
         else:
             raise TypeError(

--- a/snakemake/remote/HTTP.py
+++ b/snakemake/remote/HTTP.py
@@ -51,7 +51,7 @@ class RemoteProvider(AbstractRemoteProvider):
     def remote(self, value, *args, insecure=None, **kwargs):
         if isinstance(value, str):
             values = [value]
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, collections.abc.Iterable):
             values = value
         else:
             raise TypeError(

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -395,7 +395,7 @@ class Rule:
         assert not callable(item)
         if isinstance(item, dict):
             return {k: apply(v) for k, v in item.items()}
-        elif isinstance(item, collections.Iterable) and not isinstance(item, str):
+        elif isinstance(item, collections.abc.Iterable) and not isinstance(item, str):
             return [apply(e) for e in item]
         else:
             return apply(item)

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -52,7 +52,7 @@ class REncoder:
             return "TRUE" if value else "FALSE"
         elif isinstance(value, int) or isinstance(value, float):
             return str(value)
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, collections.abc.Iterable):
             # convert all iterables to vectors
             return cls.encode_list(value)
         else:
@@ -111,7 +111,7 @@ class JuliaEncoder:
             return "true" if value else "false"
         elif isinstance(value, int) or isinstance(value, float):
             return str(value)
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, collections.abc.Iterable):
             # convert all iterables to vectors
             return cls.encode_list(value)
         else:

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -459,7 +459,7 @@ def update_config(config, overwrite_config):
 
     def _update(d, u):
         for (key, value) in u.items():
-            if isinstance(value, collections.Mapping):
+            if isinstance(value, collections.abc.Mapping):
                 d[key] = _update(d.get(key, {}), value)
             else:
                 d[key] = value


### PR DESCRIPTION
This fixes these warnings: 

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working 
```
Import abstract base classes from collections.abc