### PR TITLE
Replace symbolic link judgement in _IOFile.protected

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -282,11 +282,9 @@ class _IOFile(str):
     @property
     def protected(self):
         # symlinks are never regarded as protected
-        return self.exists_local and not os.access(
-            self.file,
-            os.W_OK,
-            follow_symlinks=os.access not in os.supports_follow_symlinks,
-        )
+        return self.exists_local and \
+               (not os.access(self.file, os.W_OK)) and \
+               (not os.path.islink(self.file))
 
     @property
     @iocache


### PR DESCRIPTION
`os.access()` in MacOS has incorrect behavior with `follow_symlinks=False`, so replaces yet another symbolic link judgement.

`os.path.islink()` returns True if the file is symbolic link.
https://docs.python.org/3/library/os.path.html#os.path.islink

`islink()` returns False in the environment which does not support symbolic link (does not raise Exception)
And actually, it can treat files, not only directories.

In detail, please refer the issue #10
