### PR TITLE
Update executors.py

### DIFF
--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -1719,8 +1719,8 @@ class TibannaExecutor(ClusterExecutor):
             if src_fname != snakefile_fname:  # redundant
                 snakemake_child_fnames.append(src_fname)
         # change path for config files
-        self.workflow.overwrite_configfile, _ = self.split_filename(
-            self.workflow.overwrite_configfile, snakemake_dir
+        self.workflow.overwrite_configfiles, _ = self.split_filename(
+            self.workflow.overwrite_configfiles, snakemake_dir
         )
         tibanna_args.snakemake_directory_local = snakemake_dir
         tibanna_args.snakemake_main_filename = snakefile_fname


### PR DESCRIPTION
@johanneskoester Apparently, the variable `overwrite_configfile` has been renamed to `overwrite_configfiles` since my PR but not in every place - there was an issue for tibanna on this - https://github.com/4dn-dcic/tibanna/issues/251#issue-506964982. Could we merge this one asap? It should be a simple fix.