### PR TITLE
Updating copyrights to be until 2019 for Johannes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2016 Johannes Köster <johannes.koester@tu-dortmund.de>
+Copyright (c) 2012-2019 Johannes Köster <johannes.koester@tu-dortmund.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "Johannes Köster"
 __contributors__ = ["Soohyun Lee"]
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/common.py
+++ b/snakemake/common.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2016, Johannes Köster"
+__copyright__ = "Copyright 2016-2019, Johannes Köster"
 __email__ = "johannes.koester@protonmail.com"
 __license__ = "MIT"
 

--- a/snakemake/cwl.py
+++ b/snakemake/cwl.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2018, Johannes Köster"
+__copyright__ = "Copyright 2018-2019, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -1,6 +1,6 @@
 __author__ = "Johannes Köster"
 __contributors__ = ["David Alexander", "Soohyun Lee"]
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/gui.py
+++ b/snakemake/gui.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/output_index.py
+++ b/snakemake/output_index.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2018, Johannes Köster"
+__copyright__ = "Copyright 2018-2019, Johannes Köster"
 __email__ = "johannes.koester@protonmail.com"
 __license__ = "MIT"
 

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/remote/EGA.py
+++ b/snakemake/remote/EGA.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2018, Johannes Köster"
+__copyright__ = "Copyright 2018-2019, Johannes Köster"
 __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2017, Johannes Köster"
+__copyright__ = "Copyright 2017-2019, Johannes Köster"
 __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 

--- a/snakemake/remote/gfal.py
+++ b/snakemake/remote/gfal.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2017, Johannes Köster"
+__copyright__ = "Copyright 2017-2019, Johannes Köster"
 __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 

--- a/snakemake/remote/gridftp.py
+++ b/snakemake/remote/gridftp.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2017, Johannes Köster"
+__copyright__ = "Copyright 2017-2019, Johannes Köster"
 __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -1,6 +1,6 @@
 __author__ = "Johannes Köster"
 __contributors__ = ["Soohyun Lee"]
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/stats.py
+++ b/snakemake/stats.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -1,6 +1,6 @@
 __author__ = "Johannes Köster"
 __contributors__ = ["Per Unneberg"]
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -739,7 +739,9 @@ class Workflow:
                 if cluster or cluster_sync or drmaa:
                     logger.resources_info("Provided cluster nodes: {}".format(nodes))
                 else:
-                    warning = "" if cores > 1 else " (use --cores to define parallelism)"
+                    warning = (
+                        "" if cores > 1 else " (use --cores to define parallelism)"
+                    )
                     logger.resources_info("Provided cores: {}{}".format(cores, warning))
                     logger.resources_info(
                         "Rules claiming more threads " "will be scaled down."

--- a/snakemake/wrapper.py
+++ b/snakemake/wrapper.py
@@ -1,5 +1,5 @@
 __author__ = "Johannes Köster"
-__copyright__ = "Copyright 2016, Johannes Köster"
+__copyright__ = "Copyright 2016-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 __authors__ = ["Tobias Marschall", "Marcel Martin", "Johannes Köster"]
 __contributors__ = ["Soohyun Lee"]
-__copyright__ = "Copyright 2015, Johannes Köster"
+__copyright__ = "Copyright 2015-2019, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 


### PR DESCRIPTION
This will close #61 by updating copyright headers under snakemake and a tests/tests.py to be from their starting date through 2019. I was tempted to do until 2020 to save some work, but it's probably not right to set it to a future date :)

Note that I did not touch copyright headers for other contributors, as the date reflects the last contribution (or if a range) the first and last.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>