### PR TITLE
Checkpoint remote handling

### DIFF
--- a/snakemake/checkpoints.py
+++ b/snakemake/checkpoints.py
@@ -31,6 +31,7 @@ class Checkpoint:
             (not f.exists or f in self.checkpoints.future_output) for f in output
         ):
             raise IncompleteCheckpointException(self.rule, checkpoint_target(output[0]))
+
         return CheckpointJob(self.rule, output)
 
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -151,6 +151,23 @@ class _IOFile(str):
             return func(self, *args, **kwargs)
 
         return wrapper
+    
+    @contextmanager
+    def open(self, mode="r", buffering=-1, encoding=None, errors=None, newline=None):
+        """Open this file. If necessary, download it from remote first. 
+        
+        This can (and should) be used in a `with`-statement.
+        """
+        if not self.exists:
+            raise WorkflowError("File {} cannot be opened, since it does not exist.".format(self))
+        if not self.exists_local and self.is_remote:
+            self.download_from_remote()
+
+        f = open(self)
+        try:
+            yield f
+        finally:
+            f.close()
 
     @property
     def is_remote(self):

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -386,9 +386,7 @@ class Rule:
                 and not is_annotated_callable(value)
                 and self.workflow.default_remote_provider is not None
             ):
-                value = "{}/{}".format(self.workflow.default_remote_prefix, value)
-                value = os.path.normpath(value)
-                return self.workflow.default_remote_provider.remote(value)
+                return self.workflow.apply_default_remote(value)
             else:
                 return value
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -15,6 +15,7 @@ from functools import partial
 from operator import attrgetter
 import copy
 import subprocess
+from pathlib import Path
 
 from snakemake.logging import logger, format_resources, format_resource_names
 from snakemake.rules import Rule, Ruleorder, RuleProxy
@@ -309,6 +310,8 @@ class Workflow:
         will be applied to this file. The file is returned as _IOFile object,
         such that it can e.g. be transparently opened with _IOFile.open().
         """
+        if isinstance(path, Path):
+            path = str(path)
         if self.default_remote_provider is not None:
             path = self.apply_default_remote(path)
         return IOFile(path)


### PR DESCRIPTION
This PR does two things:

*  Add _IOFile.open() function for transparently reading from local or remote input or output files.
* Add Workflow.inputfile(path) method for marking files as input files, which are automatically handled via default remote provider if necessary.