### PR TITLE
Make the documentation build reproducibly

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -102,12 +102,14 @@ def data_uri_from_file(file, defaultenc="utf8"):
 def report(
     text,
     path,
-    stylesheet=os.path.join(os.path.dirname(__file__), "report.css"),
+    stylesheet=None,
     defaultenc="utf8",
     template=None,
     metadata=None,
     **files
 ):
+    if stylesheeet is None:
+        os.path.join(os.path.dirname(__file__), "report.css")
     outmime, _ = mimetypes.guess_type(path)
     if outmime != "text/html":
         raise ValueError("Path to report output has to be an HTML file.")

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -201,7 +201,7 @@ def makedirs(dirnames):
 def report(
     text,
     path,
-    stylesheet=os.path.join(os.path.dirname(__file__), "report.css"),
+    stylesheet=None,
     defaultenc="utf8",
     template=None,
     metadata=None,
@@ -247,6 +247,8 @@ def report(
         metadata (str):     E.g. an optional author name or email address.
 
     """
+    if stylesheeet is None:
+        os.path.join(os.path.dirname(__file__), "report.css")
     try:
         import snakemake.report
     except ImportError:


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that snakemake could not be built reproducibly.

This is due to the default keyword arguments embedding an absolute build path which gets placed literally into any generated documentation:

![image](https://user-images.githubusercontent.com/133209/68047693-3a04c680-fc9c-11e9-91c3-71f957dc3818.png)

This was originally filed in Debian as [#932116](https://bugs.debian.org/932116) and [#943956](https://bugs.debian.org/943956)