### PR TITLE
Remove typo in stylesheet

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -108,7 +108,7 @@ def report(
     metadata=None,
     **files
 ):
-    if stylesheeet is None:
+    if stylesheet is None:
         os.path.join(os.path.dirname(__file__), "report.css")
     outmime, _ = mimetypes.guess_type(path)
     if outmime != "text/html":

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -247,7 +247,7 @@ def report(
         metadata (str):     E.g. an optional author name or email address.
 
     """
-    if stylesheeet is None:
+    if stylesheet is None:
         os.path.join(os.path.dirname(__file__), "report.css")
     try:
         import snakemake.report


### PR DESCRIPTION
There was an extra e in `stylesheet` in two locations (read `stylesheeet`) which caused the following error:

```
Traceback (most recent call last):
  File "/home/tereiter/github/dom/.snakemake/scripts/tmpjlh6fs25.assembly_report.py", line 181, i
n <module>
    combined_stats=snakemake.output.combined_contig_stats
  File "/home/tereiter/github/dom/.snakemake/scripts/tmpjlh6fs25.assembly_report.py", line 167, $
n main
    report(report_str, report_out, Table_1=combined_stats, stylesheet=os.path.join(atlas_dir,'re$
ort', "report.css"))
  File "/home/tereiter/github/killi/databases/conda_envs/df922afa/lib/python3.6/site-packages/sn$
kemake/utils.py", line 265, in report
    **files
  File "/home/tereiter/github/killi/databases/conda_envs/df922afa/lib/python3.6/site-packages/sn$
kemake/report/__init__.py", line 111, in report
    if stylesheeet is None:
NameError: name 'stylesheeet' is not defined
```

This pull request removes both extra `e`s.