### PR TITLE
disable double-/ warning for remote files

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -240,7 +240,7 @@ class _IOFile(str):
                 "File path '{}' contains line break. "
                 "This is likely unintended. {}".format(self._file, hint)
             )
-        if _double_slash_regex.search(self._file) is not None:
+        if _double_slash_regex.search(self._file) is not None and not self.is_remote:
             logger.warning(
                 "File path {} contains double '{}'. "
                 "This is likely unintended. {}".format(self._file, os.path.sep, hint)


### PR DESCRIPTION
Minimal fix for #147 

Something more sophisticated might be to specifically allow `://`, but this does not solve the problem with XRootD