### PR TITLE
Overwrite threads

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -47,6 +47,16 @@ By specifying the number of available cores, i.e.
 one can tell Snakemake to use up to 4 cores and solve a binary knapsack problem to optimize the scheduling of jobs.
 If the number is omitted (i.e., only ``--cores`` is given), the number of used cores is determined as the number of available CPU cores in the machine.
 
+Snakemake workflows usually define the number of used threads of certain rules. Sometimes, it makes sense to overwrite the defaults given in the workflow definition.
+This can be done by using the ``--set-threads`` argument, e.g.,
+
+.. code-block:: console
+
+    $ snakemake --cores 4 --set-threads myrule=2
+
+would overwrite whatever number of threads has been defined for the rule ``myrule`` and use ``2`` instead.
+This can be particularly handy when used in combination with :ref:`cluster execution <cluster>`.
+
 Dealing with very large workflows
 ---------------------------------
 

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -903,7 +903,7 @@ def get_argument_parser(profile=None):
         help="Overwrite thread usage of rules. This allows to fine-tune workflow "
         "parallelization. In particular, this is helpful to target certain cluster nodes "
         "by e.g. shifting a rule to use more, or less threads than defined in the workflow. "
-        "Thereby, THREADS has to be a positive integer, and RULE has to be the name of the rule."
+        "Thereby, THREADS has to be a positive integer, and RULE has to be the name of the rule.",
     )
     group_exec.add_argument(
         "--default-resources",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -650,7 +650,7 @@ def snakemake(
 
 
 def parse_set_threads(args):
-    errmsg = "Invalid threads definition: entries have to be defined as RULE=THREADS pairs."
+    errmsg = "Invalid threads definition: entries have to be defined as RULE=THREADS pairs (with THREADS being a positive integer)."
     overwrite_threads = dict()
     if args.set_threads is not None:
         for entry in args.set_threads:

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -898,11 +898,12 @@ def get_argument_parser(profile=None):
     )
     group_exec.add_argument(
         "--set-threads",
-        metavar="NAME=INT",
+        metavar="RULE=THREADS",
         nargs="*",
         help="Overwrite thread usage of rules. This allows to fine-tune workflow "
         "parallelization. In particular, this is helpful to target certain cluster nodes "
-        "by e.g. shifting a rule to use more, or less threads than defined in the workflow."
+        "by e.g. shifting a rule to use more, or less threads than defined in the workflow. "
+        "Thereby, THREADS has to be a positive integer, and RULE has to be the name of the rule."
     )
     group_exec.add_argument(
         "--default-resources",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -48,6 +48,7 @@ def snakemake(
     nodes=1,
     local_cores=1,
     resources=dict(),
+    overwrite_threads=dict(),
     default_resources=None,
     config=dict(),
     configfiles=None,
@@ -445,6 +446,7 @@ def snakemake(
             overwrite_workdir=workdir,
             overwrite_configfiles=configfiles,
             overwrite_clusterconfig=cluster_config_content,
+            overwrite_threads=overwrite_threads,
             config_args=config_args,
             debug=debug,
             verbose=verbose,
@@ -645,6 +647,22 @@ def snakemake(
     if not keep_logger:
         logger.cleanup()
     return success
+
+
+def parse_set_threads(args):
+    errmsg = "Invalid threads definition: entries have to be defined as RULE=THREADS pairs."
+    overwrite_threads = dict()
+    if args.set_threads is not None:
+        for entry in args.set_threads:
+            rule, threads = parse_key_value_arg(entry, errmsg=errmsg)
+            try:
+                threads = int(threads)
+            except ValueError:
+                raise ValueError(errmsg)
+            if threads < 0:
+                raise ValueError(errmsg)
+            overwrite_threads[rule] = threads
+    return overwrite_threads
 
 
 def parse_batch(args):
@@ -877,6 +895,14 @@ def get_argument_parser(profile=None):
             "resources: gpu=1. If now two rules require 1 of the resource "
             "'gpu' they won't be run in parallel by the scheduler."
         ),
+    )
+    group_exec.add_argument(
+        "--set-threads",
+        metavar="NAME=INT",
+        nargs="*",
+        help="Overwrite thread usage of rules. This allows to fine-tune workflow "
+        "parallelization. In particular, this is helpful to target certain cluster nodes "
+        "by e.g. shifting a rule to use more, or less threads than defined in the workflow."
     )
     group_exec.add_argument(
         "--default-resources",
@@ -1775,6 +1801,7 @@ def main(argv=None):
             ]
         default_resources = DefaultResources(args.default_resources)
         batch = parse_batch(args)
+        overwrite_threads = parse_set_threads(args)
     except ValueError as e:
         print(e, file=sys.stderr)
         print("", file=sys.stderr)
@@ -1971,6 +1998,7 @@ def main(argv=None):
             local_cores=args.local_cores,
             nodes=args.cores,
             resources=resources,
+            overwrite_threads=overwrite_threads,
             default_resources=default_resources,
             config=config,
             configfiles=args.configfile,

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -76,6 +76,7 @@ class Workflow:
         overwrite_workdir=None,
         overwrite_configfiles=None,
         overwrite_clusterconfig=dict(),
+        overwrite_threads=dict(),
         config_args=None,
         debug=False,
         verbose=False,
@@ -129,6 +130,7 @@ class Workflow:
         self.overwrite_config = overwrite_config
         self.overwrite_configfiles = overwrite_configfiles
         self.overwrite_clusterconfig = overwrite_clusterconfig
+        self.overwrite_threads = overwrite_threads
         self.config_args = config_args
         self.immediate_submit = None
         self._onsuccess = lambda log: None
@@ -1010,7 +1012,10 @@ class Workflow:
                         "Threads value has to be an integer, float, or a callable.",
                         rule=rule,
                     )
-                rule.resources["_cores"] = int(ruleinfo.threads)
+                if name in self.overwrite_threads:
+                    rule.resources["_cores"] = self.overwrite_threads[name]
+                else:
+                    rule.resources["_cores"] = int(ruleinfo.threads)
             if ruleinfo.shadow_depth:
                 if ruleinfo.shadow_depth not in (True, "shallow", "full", "minimal"):
                     raise RuleException(


### PR DESCRIPTION
Allow overwriting threads definitions at the command line with `--set-threads RULE=THREADS ...`.