### PR TITLE
Enhancement: Allowing to write rule decorator

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -804,7 +804,7 @@ class Snakefile:
 def format_tokens(tokens):
     t_ = None
     for t in tokens:
-        if t_ and not t.isspace() and not t_.isspace():
+        if t_ and (not t.isspace() and not t_.isspace()) and (not t_ == '@'):
             yield " "
         yield t
         t_ = t

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -804,7 +804,7 @@ class Snakefile:
 def format_tokens(tokens):
     t_ = None
     for t in tokens:
-        if t_ and (not t.isspace() and not t_.isspace()) and (not t_ == '@'):
+        if t_ and (not t.isspace() and not t_.isspace()) and (not t_ == "@"):
             yield " "
         yield t
         t_ = t

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -918,7 +918,7 @@ class Workflow:
                 continue
             # find @workflow.rule decorator, and pull it to the first decorator
             try:
-                rule_decorator_t = next(filter(lambda x: getattr(x[1].func, 'attr', '') == 'rule', enumerate(ast_elm.decorator_list)))
+                rule_decorator_t = next(filter(lambda x: getattr(getattr(x[1], 'func', ''), 'attr', '') == 'rule', enumerate(ast_elm.decorator_list)))
             except Exception as e:
                 logger.error(str(e))
                 continue

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -921,7 +921,7 @@ class Workflow:
             try:
                 rule_decorator_t = next(filter(lambda x: getattr(x[1].func, 'attr', '') == 'rule', enumerate(ast_elm.decorator_list)))
             except Exception as e:
-                print(e)  # TODO replace right stack trace output!
+                logger.error(str(e))
                 continue
             rd_i, rd = rule_decorator_t
             ast_elm.decorator_list[1:rd_i+1] = ast_elm.decorator_list[:rd_i]

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -912,7 +912,6 @@ class Workflow:
 
         # put user decorator under @workflow.rule
         ast_tree = ast.parse(code)
-        print(ast.dump(ast_tree))
         for ast_elm in ast.iter_child_nodes(ast_tree):
             # if "rule:" section definition...
             if not getattr(ast_elm, 'name', '').startswith('__rule_'):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -914,16 +914,22 @@ class Workflow:
         ast_tree = ast.parse(code)
         for ast_elm in ast.iter_child_nodes(ast_tree):
             # if "rule:" section definition...
-            if not getattr(ast_elm, 'name', '').startswith('__rule_'):
+            if not getattr(ast_elm, "name", "").startswith("__rule_"):
                 continue
             # find @workflow.rule decorator, and pull it to the first decorator
             try:
-                rule_decorator_t = next(filter(lambda x: getattr(getattr(x[1], 'func', ''), 'attr', '') == 'rule', enumerate(ast_elm.decorator_list)))
+                rule_decorator_t = next(
+                    filter(
+                        lambda x: getattr(getattr(x[1], "func", ""), "attr", "")
+                        == "rule",
+                        enumerate(ast_elm.decorator_list),
+                    )
+                )
             except Exception as e:
                 logger.error(str(e))
                 continue
             rd_i, rd = rule_decorator_t
-            ast_elm.decorator_list[1:rd_i+1] = ast_elm.decorator_list[:rd_i]
+            ast_elm.decorator_list[1 : rd_i + 1] = ast_elm.decorator_list[:rd_i]
             ast_elm.decorator_list[0] = rd
 
         if print_compilation:


### PR DESCRIPTION
# What's this PR?

This PR allows to write **decorator wrapping a rule** in Snakefile.

This is example of decorator in Snakefile. We can enable remote file access just putting `@s3_remote_wrapper` decorator.
```
@s3_remote_wrapper
rule rule1:
    input: 'some-bucket-name/input.txt'
    output: 'some-bucket-name/output.txt'
    shell: 'grep foo {input} > {output}'
```

Decorator implementation is like this.

```
from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
S3 = S3RemoteProvider()

def s3_remote_wrapper(ruleinfo):
    # wrap S3.remote() with all args and kwargs of input/output
    ruleinfo.input = (tuple(map(S3.remote, ruleinfo.input[0])), {k: S3.remote(v) for k, v in ruleinfo.input[1]})
    ruleinfo.output = (tuple(map(S3.remote, ruleinfo.output[0])), {k: S3.remote(v) for k, v in ruleinfo.output[1]})
    return ruleinfo
```

# What's the benefit?

- **Keep rule description simple.** Just putting one decorator is simpler than writing `S3.remote()` call for all inputs and outputs.
- **Control wrap functions easily.** The decorator can be easily disabled with just uncomment it. In the example above, we can easily change using remote file or not.
- **Enables to write ruleinfo based behavior.** For example, we can write output filename based on rule name using the ruleinfo argument. This might solve the Issue #156, "Access the rule name within a rule". 

# (Current) Limitation

1. `shellcmd`, `wrapper` and `script` cannot be overwritten. `ruleinfo.shellcmd` is just information, not actual executed command. Assigning `ruleinfo.shellcmd` with new value does not change actual executed command.
2. Getting rulename from ruleinfo is not straight forward. `ruleinfo.func.__name__[7:]`will return rule name.
3. Have to know ruleinfo structure details when writing wrapper.

About limitation 1. and 2., I'm planning to write PR for them if this decorator PR is accepted.