### PR TITLE
io.py: ImportError for yaml module raises same error as a parsing error

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -18,6 +18,9 @@ import subprocess as sp
 from itertools import product, chain
 from contextlib import contextmanager
 import collections
+
+import yaml
+
 from snakemake.exceptions import (
     MissingOutputException,
     WorkflowError,
@@ -1321,13 +1324,6 @@ def _load_configfile(configpath, filetype="Config"):
                 return json.load(f, object_pairs_hook=collections.OrderedDict)
             except ValueError:
                 f.seek(0)  # try again
-            try:
-                import yaml
-            except ImportError:
-                raise WorkflowError(
-                    "Unable to import module 'yaml'."
-                    "Please check that your installation supports PyYAML"
-                )
             try:
                 # From http://stackoverflow.com/a/21912744/84349
                 class OrderedLoader(yaml.Loader):

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1325,9 +1325,8 @@ def _load_configfile(configpath, filetype="Config"):
                 import yaml
             except ImportError:
                 raise WorkflowError(
-                    "{} file is not valid JSON and PyYAML "
-                    "has not been installed. Please install "
-                    "PyYAML to use YAML config files.".format(filetype)
+                        "Unable to import module 'yaml'."
+                        "Please check that your installation supports PyYAML"
                 )
             try:
                 # From http://stackoverflow.com/a/21912744/84349

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1325,8 +1325,8 @@ def _load_configfile(configpath, filetype="Config"):
                 import yaml
             except ImportError:
                 raise WorkflowError(
-                        "Unable to import module 'yaml'."
-                        "Please check that your installation supports PyYAML"
+                    "Unable to import module 'yaml'."
+                    "Please check that your installation supports PyYAML"
                 )
             try:
                 # From http://stackoverflow.com/a/21912744/84349


### PR DESCRIPTION
Hi,

Importing yaml usually should be a non-issue with snakemake installations. However, when tinkering with the parser, I stumbled accross

``try:
      import yaml
except ImportError:
     raise WorkflowError("{} file is not valid JSON and PyYAML "
                                    "has not been installed. Please install "
                                    "PyYAML to use YAML config files.".format(
                                    filetype))
``

which does not fit the encountered error. 