### PR TITLE
Add env vars

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1764,6 +1764,9 @@ def main(argv=None):
         args = parser.parse_args(argv)
 
         def adjust_path(f):
+            # add environment variables to the path string, if one has been present
+            # in the yaml file:
+            f = os.path.expandvars(f)
             if os.path.exists(f) or os.path.isabs(f):
                 return f
             else:

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1325,9 +1325,8 @@ def _load_configfile(configpath, filetype="Config"):
                 import yaml
             except ImportError:
                 raise WorkflowError(
-                    "{} file is not valid JSON and PyYAML "
-                    "has not been installed. Please install "
-                    "PyYAML to use YAML config files.".format(filetype)
+                        "Unable to import module 'yaml'."
+                        "Please check that your installation supports PyYAML"
                 )
             try:
                 # From http://stackoverflow.com/a/21912744/84349

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1325,8 +1325,8 @@ def _load_configfile(configpath, filetype="Config"):
                 import yaml
             except ImportError:
                 raise WorkflowError(
-                        "Unable to import module 'yaml'."
-                        "Please check that your installation supports PyYAML"
+                    "Unable to import module 'yaml'."
+                    "Please check that your installation supports PyYAML"
                 )
             try:
                 # From http://stackoverflow.com/a/21912744/84349


### PR DESCRIPTION
Hoi,

in order to support wrapped versions of snakemake in [easybuild](https://www.google.com/search?client=firefox-b-e&q=easybuild) or spack together with curated HPC conforming workflows, preventing the per-user install of snakemake, it would be necessary to allow environment variables in 'config.yaml' files (e.g. such that a submit_xxx.py file can have an arbitrary placement).

This single line modification would do the trick. However, I am not sure of side effects this might have.

Best,
Christian
