### PR TITLE
Added support for Azure storage authentication via SAS

### DIFF
--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -144,7 +144,8 @@ Microsoft Azure Storage
 
 Usage of the Azure Storage provider is similar to the S3 provider.
 For authentication, one needs to provide an account name and a key
-or SAS token, which can for example be read from environment variables.
+or SAS token (without leading question mark), which can for example
+be read from environment variables.
 
 .. code-block:: python
 

--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -143,15 +143,17 @@ Microsoft Azure Storage
 =======================
 
 Usage of the Azure Storage provider is similar to the S3 provider.
-For authentication, one needs to provide an account name and a key, which can e.g. be taken
-from environment variables.
+For authentication, one needs to provide an account name and a key
+or SAS token, which can for example be read from environment variables.
 
 .. code-block:: python
 
     from snakemake.remote.AzureStorage import RemoteProvider as AzureRemoteProvider
-    account_key=os.environ['AZURE_KEY']
     account_name=os.environ['AZURE_ACCOUNT']
-    AS = AzureRemoteProvider(account_name=account_name, account_key=account_key)
+    account_key=os.environ.get('AZURE_KEY')
+    sas_token=os.environ.get('SAS_TOKEN')
+    assert account_key or sas_token
+    AS = AzureRemoteProvider(account_name=account_name, account_key=account_key, sas_token=sas_token)
 
     rule a:
         input:

--- a/tests/test_remote_azure/.gitignore
+++ b/tests/test_remote_azure/.gitignore
@@ -1,2 +1,0 @@
-test.txt.gz
-globbing.done

--- a/tests/test_remote_azure/README.md
+++ b/tests/test_remote_azure/README.md
@@ -1,8 +1,15 @@
 # Instruction for testing of Azure Storage integration
-* in order to perform this test, an Azure Storage Account is required
-* Both the storage account and associated key need to be passed to snakemake at runtime
-* currently this is solved by setting and exporting environment variables called
-** $AZURE_ACCOUNT
-** $AZURE_KEY
-* furthermore, in the storage account, a container "snakemake-test" needs to be created prio to running the test
+
+In order to perform this test, you need an Azure Storage account
+with read/write access.
+Both the storage account and associated key or SAS token (without
+leading questionmark) need to be
+passed to snakemake at runtime, by exporting
+environment variables `AZURE_ACCOUNT` and either `AZURE_KEY` or
+`SAS_TOKEN`.
+
+Furthermore, in the storage account, a container "snakemake-test"
+needs to be created prior to running the test.
+
+And lastly, a local file called `test.txt.gz` needs to be created.
 

--- a/tests/test_remote_azure/Snakefile
+++ b/tests/test_remote_azure/Snakefile
@@ -6,14 +6,17 @@ from snakemake.remote.AzureStorage import RemoteProvider as AzureRemoteProvider
 
 # setup Azure Storage for remote access
 # for testing these variable can be added to CircleCI
-account_key=os.environ['AZURE_KEY']
 account_name=os.environ['AZURE_ACCOUNT']
-AS = AzureRemoteProvider(account_name=account_name, account_key=account_key)
+account_key=os.environ.get('AZURE_KEY')
+sas_token=os.environ.get('SAS_TOKEN')
+assert sas_token or account_key, ("Either SAS_TOKEN or AZURE_KEY have to be set")
+AS = AzureRemoteProvider(account_name=account_name,
+    account_key=account_key, sas_token=sas_token)
 
 
 rule upload_to_azure_storage:
     input:
-        "data/test.txt.gz"
+        "test.txt.gz"
     output:
         AS.remote("snakemake-test/data_upload/test.txt.gz")
     run:


### PR DESCRIPTION
This is a safer and more flexible alternative to using an account key (which is still supported). See official [SAS documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview) and [Sebastian's original PR](https://bitbucket.org/snakemake/snakemake/pull-requests/378/azure-integration/diff). Also refer to email exchange with Sebastian from Thu, Oct 10, 2019.

Happy to provide temporary read/write authentication tokens for testing (the one in the email won't work anymore) and refer to tests/test_remote_azure/README.md