### PR TITLE
Minor grammatical update to rules.rst in documentation

### DIFF
--- a/docs/executing/caching.rst
+++ b/docs/executing/caching.rst
@@ -12,7 +12,7 @@ From version 5.8.0 on, Snakemake offers a way to keep those steps inside the act
 By hashing all steps, parameters, software stacks (in terms of conda environments or containers), and raw input required up to a certain step in a `blockchain <https://en.wikipedia.org/wiki/Blockchain>`_, Snakemake is able to recognize **before** the computation whether a certain result is already available in a central cache on the same system.
 **Note that this is explicitly intended for caching results between workflows! There is no need to use this feature to avoid redundant computations within a workflow. Snakemake does this already out of the box.**
 
-Such caching has to be explitly activated per rule, which can be done via the command line interface.
+Such caching has to be explicitly activated per rule, which can be done via the command line interface.
 For example,
 
 .. code-block:: console

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -40,7 +40,7 @@ Shell commands like above can also be invoked inside a python based rule, via th
 
     shell("somecommand {output.somename}")
 
-Further, this combination of python and shell commands, allows to iterate over the output of the shell command, e.g.:
+Further, this combination of python and shell commands allows us to iterate over the output of the shell command, e.g.:
 
 .. code-block:: python
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -311,8 +311,7 @@ Resources must be ``int`` values.
 
 Note that you are free to choose any names for the given resources.
 There are two **standard resources** for memory and disk usage though: ``mem_mb`` and ``disk_mb``.
-When defining memory constraints, it is advised to use ``mem_mb``, because there are
-Some execution modes make direct use of this information (e.g., when using :ref:`Kubernetes <kubernetes>`).
+When defining memory constraints, it is advised to use ``mem_mb``, because some execution modes make direct use of this information (e.g., when using :ref:`Kubernetes <kubernetes>`).
 Since it would be cumbersome to define them for every rule, you can set default values at the terminal or in a :ref:`profile <profiles>`.
 This works via the command line flag ``--default-resources``, see ``snakemake --help`` for more information.
 If those resource definitions are mandatory for a certain execution mode, Snakemake will fail with a hint if they are missing.

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -135,7 +135,7 @@ Input files can be Python lists, allowing to easily aggregate over parameters or
         shell:
             ...
 
-Above expression can be simplified in two ways.
+The above expression can be simplified in two ways.
 
 The expand function
 ~~~~~~~~~~~~~~~~~~~
@@ -152,7 +152,7 @@ The expand function
 
 
 Note that *dataset* is NOT a wildcard here because it is resolved by Snakemake due to the ``expand`` statement.
-The ``expand`` function thereby allows also to combine different variables, e.g.
+The ``expand`` function also allows us to combine different variables, e.g.
 
 .. code-block:: python
 
@@ -164,9 +164,9 @@ The ``expand`` function thereby allows also to combine different variables, e.g.
         shell:
             ...
 
-If now ``FORMATS=["txt", "csv"]`` contains a list of desired output formats then expand will automatically combine any dataset with any of these extensions.
+If ``FORMATS=["txt", "csv"]`` contains a list of desired output formats then expand will automatically combine any dataset with any of these extensions.
 
-Further, the first argument can also be a list of strings. In that case, the transformation is applied to all elements of the list. E.g.
+Furthermore, the first argument can also be a list of strings. In that case, the transformation is applied to all elements of the list. E.g.
 
 .. code-block:: python
 
@@ -190,7 +190,7 @@ leads to
 
     ["ds1/a.txt", "ds1/b.txt", "ds2/a.csv", "ds2/b.csv"]
 
-You can also mask a wildcard expression in expand such that it will be kept, e.g.
+You can also mask a wildcard expression in ``expand`` such that it will be kept, e.g.
 
 .. code-block:: python
 
@@ -204,7 +204,7 @@ will create strings with all values for ext but starting with the wildcard ``"{d
 The multiext function
 ~~~~~~~~~~~~~~~~~~~~~
 
-``multiext`` provides a simplified variant of ``expand`` that allows to define a set of output or input files that just differ by their extension:
+``multiext`` provides a simplified variant of ``expand`` that allows us to define a set of output or input files that just differ by their extension:
 
 
 .. code-block:: python
@@ -261,7 +261,7 @@ Further, a rule can be given a number of threads to use, i.e.
 Snakemake can alter the number of cores available based on command line options. Therefore it is useful to propagate it via the built in variable ``threads`` rather than hardcoding it into the shell command.
 In particular, it should be noted that the specified threads have to be seen as a maximum. When Snakemake is executed with fewer cores, the number of threads will be adjusted, i.e. ``threads = min(threads, cores)`` with ``cores`` being the number of cores specified at the command line (option ``--cores``). 
 
-Hardcoding a particular maximum number of threads like above is useful when a certain tool has a natural maximum beyond it parallelization won't help to further speed it up.
+Hardcoding a particular maximum number of threads like above is useful when a certain tool has a natural maximum beyond which parallelization won't help to further speed it up.
 This is often the case, and should be evaluated carefully for production workflows.
 If it is certain that no such maximum exists for a tool, one can instead define threads as a function of the number of cores given to Snakemake:
 
@@ -306,7 +306,7 @@ If limits for the resources are given via the command line, e.g.
 the scheduler will ensure that the given resources are not exceeded by running jobs.
 If no limits are given, the resources are ignored in local execution.
 In cluster or cloud execution, resources are always passed to the backend, even if ``--resources`` is not specified.
-Apart from making Snakemake aware of hybrid-computing architectures (e.g. with a limited number of additional devices like GPUs) this allows to control scheduling in various ways, e.g. to limit IO-heavy jobs by assigning an artificial IO-resource to them and limiting it via the ``--resources`` flag.
+Apart from making Snakemake aware of hybrid-computing architectures (e.g. with a limited number of additional devices like GPUs) this allows us to control scheduling in various ways, e.g. to limit IO-heavy jobs by assigning an artificial IO-resource to them and limiting it via the ``--resources`` flag.
 Resources must be ``int`` values.
 
 Note that you are free to choose any names for the given resources.
@@ -321,7 +321,7 @@ Any resource definitions inside a rule override what has been defined with ``--d
 Resources can also be callables that return ``int`` values.
 The signature of the callable has to be ``callable(wildcards [, input] [, threads] [, attempt])`` (``input``, ``threads``, and ``attempt`` are optional parameters).
 
-The parameter ``attempt`` allows to adjust resources based on how often the job has been restarted (see :ref:`all_options`, option ``--restart-times``).
+The parameter ``attempt`` allows us to adjust resources based on how often the job has been restarted (see :ref:`all_options`, option ``--restart-times``).
 This is handy when executing a Snakemake workflow in a cluster environment, where jobs can e.g. fail because of too limited resources.
 When Snakemake is executed with ``--restart-times 3``, it will try to restart a failed job 3 times before it gives up.
 Thereby, the parameter ``attempt`` will contain the current attempt number (starting from ``1``).
@@ -360,7 +360,7 @@ Note that access to wildcards is also possible via the variable ``wildcards`` (e
 Priorities
 ----------
 
-Snakemake allows rules to specify numeric priorities:
+Snakemake allows for rules that specify numeric priorities:
 
 
 .. code-block:: python
@@ -501,7 +501,7 @@ Apart from Python scripts, this mechanism also allows you to integrate R_ and R 
         script:
             "scripts/script.R"
 
-In the R script, an S4 object named ``snakemake`` analog to the Python case above is available and allows access to input and output files and other parameters. Here the syntax follows that of S4 classes with attributes that are R lists, e.g. we can access the first input file with ``snakemake@input[[1]]`` (note that the first file does not have index ``0`` here, because R starts counting from ``1``). Named input and output files can be accessed in the same way, by just providing the name instead of an index, e.g. ``snakemake@input[["myfile"]]``.
+In the R script, an S4 object named ``snakemake`` analogous to the Python case above is available and allows access to input and output files and other parameters. Here the syntax follows that of S4 classes with attributes that are R lists, e.g. we can access the first input file with ``snakemake@input[[1]]`` (note that the first file does not have index ``0`` here, because R starts counting from ``1``). Named input and output files can be accessed in the same way, by just providing the name instead of an index, e.g. ``snakemake@input[["myfile"]]``.
 
 
 Alternatively, it is possible to integrate Julia_ scripts, e.g.
@@ -776,7 +776,7 @@ Dynamic Files
 -------------
 
 Snakemake provides experimental support for dynamic files.
-Dynamic files can be used whenever one has a rule, for which the number of output files is unknown before the rule was executed.
+Dynamic files can be used whenever one has a rule for which the number of output files is unknown before the rule was executed.
 This is useful for example with certain clustering algorithms:
 
 .. code-block:: python
@@ -855,10 +855,10 @@ This can be done by having them return ``dict()`` objects with the names as the 
         output: "someoutput.{token}.txt"
         shell: "..."
 
-Note that ``unpack()`` only necessary for input functions returning ``dict``.
+Note that ``unpack()`` is only necessary for input functions returning ``dict``.
 While it also works for ``list``, remember that lists (and nested lists) of strings are automatically flattened.
 
-Also note that if you do not pass in a *function* into the input list but you directly *call a function* then you don't use ``unpack()`` either.
+Also note that if you do not pass in a *function* into the input list but you directly *call a function* then you shouldn't use ``unpack()``.
 Here, you can simply use Python's double-star (``**``) operator for unpacking the parameters.
 
 Note that as Snakefiles are translated into Python for execution, the same rules as for using the `star and double-star unpacking Python operators <https://docs.python.org/3/tutorial/controlflow.html#unpacking-argument-lists>`_ apply.
@@ -956,9 +956,9 @@ With Snakemake 3.2.1, this is possible via the ``onsuccess`` and ``onerror`` key
         print("An error occurred")
         shell("mail -s "an error occurred" youremail@provider.com < {log}")
 
-The ``onsuccess`` handler is executed if the workflow finished without error. Else, the ``onerror`` handler is executed.
+The ``onsuccess`` handler is executed if the workflow finished without error. Otherwise, the ``onerror`` handler is executed.
 In both handlers, you have access to the variable ``log``, which contains the path to a logfile with the complete Snakemake output.
-Snakemake 3.6.0 adds an ````onstart```` handler, that will be executed before the workflow starts.
+Snakemake 3.6.0 adds an ``onstart`` handler, that will be executed before the workflow starts.
 Note that dry-runs do not trigger any of the handlers.
 
 
@@ -979,8 +979,8 @@ From version 2.4.8 on, rules can also refer to the output of other rules in the 
         output: "path/to/output/of/b"
         shell:  ...
 
-Importantly, be aware that referring to rule a here requires that rule a was defined above rule b in the file, since the object has to be known already.
-This feature also allows to resolve dependencies that are ambiguous when using filenames.
+Importantly, be aware that referring to rule ``a`` here requires that rule ``a`` was defined above rule ``b`` in the file, since the object has to be known already.
+This feature also allows us to resolve dependencies that are ambiguous when using filenames.
 
 Note that when the rule you refer to defines multiple output files but you want to require only a subset of those as input for another rule, you should name the output files and refer to them specifically:
 
@@ -1002,9 +1002,9 @@ Note that when the rule you refer to defines multiple output files but you want 
 Handling Ambiguous Rules
 ------------------------
 
-When two rules can produce the same output file, snakemake cannot decide per default which one to use. Hence an ``AmbiguousRuleException`` is thrown.
+When two rules can produce the same output file, snakemake cannot decide which one to use without additional guidance. Hence an ``AmbiguousRuleException`` is thrown.
 Note: ruleorder is not intended to bring rules in the correct execution order (this is solely guided by the names of input and output files you use), it only helps snakemake to decide which rule to use when multiple ones can create the same output file!
-The proposed strategy to deal with such ambiguity is to provide a ``ruleorder`` for the conflicting rules, e.g.
+To deal with such ambiguity, provide a ``ruleorder`` for the conflicting rules, e.g.
 
 .. code-block:: python
 
@@ -1098,7 +1098,7 @@ Defining groups for execution
 
 From Snakemake 5.0 on, it is possible to assign rules to groups.
 Such groups will be executed together in **cluster** or **cloud mode**, as a so-called **group job**, i.e., all jobs of a particular group will be submitted at once, to the same computing node.
-By this, queueing and execution time can be saved, in particular if one or several short-running rules are involved.
+This way, queueing and execution time can be saved, in particular if one or several short-running rules are involved.
 When executing locally, group definitions are ignored.
 
 Groups can be defined via the ``group`` keyword, e.g.,


### PR DESCRIPTION
Update some rogue uses of 'allows' and a few other minor issues in the `rules.rst` docs.

Happy to change 'us' to 'you', if requested; this would be a bit more in line with the rest of the doc (but 'you' is less friendly than 'us'!)