### PR TITLE
Delete successful k8s pods.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,14 +63,14 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
-        if env.AWS_AVAILABLE
+        if: env.AWS_AVAILABLE
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Test AWS execution
-        if: success()
+        if: env.AWS_AVAILABLE && success()
         env: 
           CI: true
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     needs: formatting
+    env:
+      AWS_AVAILABLE: ${{ secrets.AWS_ACCESS_KEY_ID }}
     steps:
       - uses: actions/checkout@v1
       
@@ -61,6 +63,7 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
+        if env.AWS_AVAILABLE
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -1621,6 +1621,8 @@ class KubernetesExecutor(ClusterExecutor):
                     elif res.status.phase == "Succeeded":
                         # finished
                         j.callback(j.job)
+                        body = kubernetes.client.V1DeleteOptions()
+                        self.kubeapi.delete_namespaced_pod(j.jobid, self.namespace, body=body)
                     else:
                         # still active
                         still_running.append(j)

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -1622,7 +1622,9 @@ class KubernetesExecutor(ClusterExecutor):
                         # finished
                         j.callback(j.job)
                         body = kubernetes.client.V1DeleteOptions()
-                        self.kubeapi.delete_namespaced_pod(j.jobid, self.namespace, body=body)
+                        self.kubeapi.delete_namespaced_pod(
+                            j.jobid, self.namespace, body=body
+                        )
                     else:
                         # still active
                         still_running.append(j)


### PR DESCRIPTION
Snakemake is not removing k8s pods that "Succeeded" until the end of Snakemake's run. This leads to an accumulation of Completed pods that waste resources during long runs. My update deletes pods as they succeed. Pods that have errors are not deleted so the user can investigate their logs. I also altered the CI so it doesn't fail when AWS secrets are missing.