### PR TITLE
Fix Tibanna ignoring mem_mb

### DIFF
--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -1853,7 +1853,7 @@ class TibannaExecutor(ClusterExecutor):
             output_target[os.path.join(file_prefix, op_rel)] = "s3://" + op
 
         # mem & cpu
-        mem = job.resources["mem_mb"] / 1024 if "mem_mb" in job.resources else 1
+        mem = job.resources["mem_mb"] / 1024 if "mem_mb" in job.resources.keys() else 1
         cpu = job.threads
 
         # jobid, grouping, run_name


### PR DESCRIPTION
Was wondering why my `mem_mb`values were being ignored. The keys need to be checked.