### PR TITLE
Make previous output files available as prevoutput

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -669,6 +669,9 @@ class Job(AbstractJob):
                 )
             )
 
+        # TODO: instead of removing existing output, move it into a temp dir
+        # and make the files available to shell/run/script as prevoutput.
+        # Then delete after job completion.
         self.remove_existing_output()
 
         for f, f_ in zip(self.output, self.rule.output):


### PR DESCRIPTION
This way, it becomes possible for jobs to perform smart updates of existing files, saving computation time.