### PR TITLE
set up conda channel order as bioconda docs recommend

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -27,14 +27,14 @@ Then, you can install Snakemake with
 
 .. code-block:: console
 
-    $ conda install -c bioconda -c conda-forge snakemake
+    $ conda install -c conda-forge -c bioconda snakemake
 
 from the `Bioconda <https://bioconda.github.io>`_ channel.
 Alternatively, Snakemake can be installed into an isolated software environment with
 
 .. code-block:: console
 
-    $ conda create -c bioconda -c conda-forge -n snakemake snakemake
+    $ conda create -c conda-forge -c bioconda -n snakemake snakemake
 
 The software environment has to be activated before using Snakemake:
 


### PR DESCRIPTION
Just reversing the order, as Bioconda docs state `conda-forge` should take precedence over `bioconda`

https://bioconda.github.io/user/install.html#set-up-channels