### PR TITLE
added an option to the sftp remote to create output path

### DIFF
--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -178,6 +178,21 @@ Assuming you have SSH keys already set up for the server you are using in the ``
         input:
             SFTP.remote("example.com/path/to/file.bam")
 
+If you need to create the output directories in the remote server, you can specify ``mkdir_remote=True``  in the ``RemoteProvider`` constructor.
+
+.. code-block:: python
+
+   from snakemake.remote.SFTP import RemoteProvider
+   SFTP = RemoteProvider(mkdir_remote=True)
+
+   rule all:
+       input:
+           "/home/foo/bar.txt"
+       output:
+           SFTP.remote('example.com/home/foo/create/dir/bar.txt')
+       shell:
+           "cp {input} {output}"
+
 The remote file addresses used must be specified with the host (domain or IP address) and the absolute path to the file on the remote server. A port may be specified if the SSH daemon on the server is listening on a port other than 22, in either the ``RemoteProvider`` or in each instance of ``remote()``:
 
 .. code-block:: python

--- a/snakemake/remote/SFTP.py
+++ b/snakemake/remote/SFTP.py
@@ -26,7 +26,13 @@ class RemoteProvider(AbstractRemoteProvider):
     allows_directories = True
 
     def __init__(
-        self, *args, keep_local=False, stay_on_remote=False, is_default=False, **kwargs
+        self,
+        *args,
+        keep_local=False,
+        stay_on_remote=False,
+        is_default=False,
+        mkdir_remote=False,
+        **kwargs
     ):
         super(RemoteProvider, self).__init__(
             *args,
@@ -35,6 +41,8 @@ class RemoteProvider(AbstractRemoteProvider):
             is_default=is_default,
             **kwargs
         )
+
+        self.mkdir_remote = mkdir_remote
 
     @property
     def default_protocol(self):
@@ -137,7 +145,29 @@ class RemoteObject(DomainObject):
                     "The file does not seem to exist remotely: %s" % self.local_file()
                 )
 
+    def mkdir_remote_path(self):
+        remote_dir = os.path.dirname(self.remote_path)
+        list_remote_dir = []
+        while True:
+            remote_dir, base = os.path.split(remote_dir)
+            if base == "":
+                if remote_dir != "":
+                    list_remote_dir.insert(0, remote_dir)
+                break
+            list_remote_dir.insert(0, base)
+
+        with self.sftpc() as sftpc:
+            for part in list_remote_dir:
+                try:
+                    sftpc.chdir(part)
+                except IOError:
+                    sftpc.mkdir(part)
+                    sftpc.chdir(part)
+
     def upload(self):
+        if self.provider.mkdir_remote:
+            self.mkdir_remote_path()
+
         with self.sftpc() as sftpc:
             sftpc.put(
                 localpath=self.local_path,


### PR DESCRIPTION
Hello

I added an option to the remote sftp to create the path in the remote
server. This is to be consistent with the standard posix file behavior
of SnakeMake which creates automatically output directories.

The added option is RemoteProvider(mkdir_remote=True)