### PR TITLE
Add "preserve" flag to allow authors to skip deleting a log.

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -415,6 +415,16 @@ Note that it is also supported to have multiple (named) log files being specifie
         shell: "somecommand --log {log.log1} METRICS_FILE={log.log2} {input} {output}"
 
 
+If an existing log file should not be removed before the rule executes, wrap the filename in ``preserve()``.
+Use this if your cluster software opens log files for output streams *before* running the jobscript.
+This circumvents certain issues with empty log files or failing cluster jobs, due to the log file having
+been deleted while the cluster is trying to write to it.
+
+
+.. code-block:: python
+
+    log: preserve("logs/cluster-job.stdout")
+
 
 Non-file parameters for rules
 -----------------------------

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -816,6 +816,11 @@ def temporary(value):
     return temp(value)
 
 
+def preserve(value):
+    """ A flag for log files that should not be removed prior to execution. """
+    return flag(value, "preserve")
+
+
 def protected(value):
     """ A flag for a file that shall be write protected after creation. """
     if is_flagged(value, "temp"):

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -642,7 +642,8 @@ class Job(AbstractJob):
                 pass
 
         for f in self.log:
-            f.remove(remove_non_empty_dir=False)
+            if not is_flagged(f, "preserve"):
+                f.remove(remove_non_empty_dir=False)
 
     def download_remote_input(self):
         for f in self.files_to_download:

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -48,6 +48,7 @@ from snakemake.io import (
     unpack,
     local,
     pipe,
+    preserve,
     repeat,
     report,
     multiext,

--- a/tests/test_preserve/Snakefile
+++ b/tests/test_preserve/Snakefile
@@ -1,0 +1,18 @@
+
+
+rule rule2:
+    output: "test.out"
+    input: "rule1.txt"
+    log: preserve("test.log")
+    shell: "touch {output} && echo rule2 >> {log}"
+
+rule rule0:
+    output: "rule0.txt"
+    log: "test.log"
+    shell: "touch {output} && echo rule0 >> {log}"
+
+rule rule1:
+    output: "rule1.txt"
+    input: "rule0.txt"
+    log: "test.log"
+    shell: "touch {output} && echo rule1 >> {log}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -672,7 +672,7 @@ def gcloud_cluster():
                     default_remote_provider="GS",
                     default_remote_prefix=self.bucket_name,
                     no_tmpdir=True,
-                    **kwargs
+                    **kwargs,
                 )
             except Exception as e:
                 shell(
@@ -976,3 +976,12 @@ def test_core_dependent_threads():
 
 def test_env_modules():
     run(dpath("test_env_modules"), use_env_modules=True)
+
+
+def test_preserve():
+    """ Ensure that the preserve flag added to a log file results in its not being
+        deleted. Check that the log file contains results of rule1 and rule2.  """
+    tmpdir = run(dpath("test_preserve"), cleanup=False)
+    with open(f"{tmpdir}/test.log") as logfile:
+        assert logfile.read() == "rule1\nrule2\n"
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
I very simply added a flag called "preserve", and altered
job initialization to skip deleting log files marked with this flag.

I addressed this wish in snakemake/snakemake#204.  Without it
I see no way to use the log files listed on my job definition,
as the paths to which my cluster will save the output streams
for submitted jobs.

Thank you!