### PR TITLE
Adding check for keep remotes to job

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1208,6 +1208,7 @@ class DAG:
             wildcards_dict=wildcards_dict,
             format_wildcards=format_wildcards,
             targetfile=targetfile,
+            keep_remote_local=self.keep_remote_local,
         )
         self.cache_job(job)
         return job

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -108,10 +108,17 @@ class Job(AbstractJob):
     ]
 
     def __init__(
-        self, rule, dag, wildcards_dict=None, format_wildcards=None, targetfile=None
+        self,
+        rule,
+        dag,
+        wildcards_dict=None,
+        format_wildcards=None,
+        targetfile=None,
+        keep_remote_local=False,
     ):
         self.rule = rule
         self.dag = dag
+        self.keep_remote_local = keep_remote_local
 
         # the targetfile that led to the job
         # it is important to record this, since we need it to submit the
@@ -758,7 +765,9 @@ class Job(AbstractJob):
         """ Cleanup output files. """
         to_remove = [f for f in self.expanded_output if f.exists]
 
-        to_remove.extend([f for f in self.remote_input if f.exists_local])
+        if not self.keep_remote_local:
+            to_remove.extend([f for f in self.remote_input if f.exists_local])
+
         to_remove.extend(
             [
                 f


### PR DESCRIPTION
This is a suggested fix (we can call WIP) to address #244. Basically, the variable gets passed from the client to the DAG object, and then when the dag creates a new job, it hands off the variable (and then it's available in cleanup).

Note that for testing I just commented out the line (the one that will be triggered by the variable) and the files are no longer removed! There they are! :clinking_glasses: 

```
$ ls snakemake-testing/kim-wxs-varlociraptor/
igv-report  merged-calls  recal  refs
```

Signed-off-by: vsoch <vsochat@stanford.edu>