### PR TITLE
Specifying number of cores to fix #266

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,7 +16,7 @@ def test_list_untracked():
 
 
 def test_delete_all_output():
-    run(dpath("test_delete_all_output"))
+    run(dpath("test_delete_all_output"), cores=1)
 
 
 def test_github_issue_14():


### PR DESCRIPTION
This is a quick fix to address an error that is in master and causing a lot of current builds to fail, we need to specify the number of cores for this delete_all_output test to work. Hopefully this won't further propagate to other tests that aren't specifying cores... we will see!

 - This will close #266 

Signed-off-by: vsoch <vsochat@stanford.edu>