### PR TITLE
clarify availability of pythonic names

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -16,7 +16,7 @@ Most importantly, a rule can consist of a name (the name is optional and can be 
 
 Inside the shell command, all local and global variables, especially input and output files can be accessed via their names in the `python format minilanguage <http://docs.python.org/py3k/library/string.html#formatspec>`_. Here input and output (and in general any list or tuple) automatically evaluate to a space-separated list of files (i.e. ``path/to/inputfile path/to/other/inputfile``).
 From Snakemake 3.8.0 on, adding the special formatting instruction ``:q`` (e.g. ``"somecommand {input:q} {output:q}")``) will let Snakemake quote each of the list or tuple elements that contains whitespace.
-Note that ``input`` and ``output`` are available to the shell command only within the python format minilanguage; something like 
+Note that, since ``input`` and ``output`` are not assigned values until the rule is made into a job, they are available to the shell command only within the python format minilanguage; something like
 
 
 .. code-block:: python

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -16,6 +16,17 @@ Most importantly, a rule can consist of a name (the name is optional and can be 
 
 Inside the shell command, all local and global variables, especially input and output files can be accessed via their names in the `python format minilanguage <http://docs.python.org/py3k/library/string.html#formatspec>`_. Here input and output (and in general any list or tuple) automatically evaluate to a space-separated list of files (i.e. ``path/to/inputfile path/to/other/inputfile``).
 From Snakemake 3.8.0 on, adding the special formatting instruction ``:q`` (e.g. ``"somecommand {input:q} {output:q}")``) will let Snakemake quote each of the list or tuple elements that contains whitespace.
+Note that ``input`` and ``output`` are available to the shell command only within the python format minilanguage; something like 
+
+
+.. code-block:: python
+
+    rule NAME:
+        input: "path/to/inputfile", "path/to/other/inputfile"
+        output: "path/to/outputfile", "path/to/another/outputfile"
+        shell: "somecommand {} {}".format(input, output)
+
+would raise a ``NameError``.
 Instead of a shell command, a rule can run some python code to generate the output:
 
 .. code-block:: python


### PR DESCRIPTION
The shell command can only access `input` and `output` in the python format mini language. This updates the docs to make that clear.