### PR TITLE
Add output redirect flags.

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -402,7 +402,23 @@ The log file has to use the same wildcards as output files, e.g.
     log: "logs/abc.{dataset}.log"
 
 
-For programs that do not have an explicit ``log`` parameter, you may always use ``2> {log}`` to redirect standard output to a file (here, the ``log`` file) in Linux-based systems.
+You can use normal bash I/O redirection syntax, or alternativaly use special log
+names that instruct snakemake to write those streams to your log files:
+``stdout`` for standard output, ``stderr`` for standard error, or ``std``
+writes both streams to the same file.
+
+.. code-block:: python
+   rule X:
+     log: stdout="logs/abc.{dataset}.log", stderr="logs/abc.{dataset}.err"
+     shell: "myprog"
+   # is equivalent to:
+   rule X:
+     log: ["logs/abc.{dataset}.log", "logs/abc.{dataset}.err"]
+     shell: "myprog > log[0] 2> log[1]"
+
+   rule Y:
+     log: std="logs/combined.log"
+
 Note that it is also supported to have multiple (named) log files being specified:
 
 .. code-block:: python

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -392,7 +392,7 @@ class CPUExecutor(RealExecutor):
             job.wildcards,
             job.threads,
             job.resources,
-            job.log._plainstrings(),
+            job.log,
             benchmark,
             benchmark_repeats,
             conda_env,

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1327,8 +1327,27 @@ class Resources(Namedlist):
     pass
 
 
-class Log(Namedlist):
+class LogStreamError(AttributeError):
     pass
+
+
+class Log(Namedlist):
+    def streams(self):
+        _streams = {
+            name: str(value)
+            for name, value in self.items()
+            if name in ("std", "stderr", "stdout")
+        }
+        if "std" in _streams and ("stderr" in _streams or "stdout" in _streams):
+            raise LogStreamError("Can't combine std stream with stdout/stderr.")
+        if any(path for path in _streams.values() if " " in path):
+            raise LogStreamError("Std output stream has more than one entry.")
+
+        for path in _streams.values():
+            dirname = os.path.dirname(path)
+            if any(dirname) and not os.path.exists(dirname):
+                os.makedirs(dirname)
+        return {name: open(value, "w") for name, value in _streams.items()}
 
 
 def _load_configfile(configpath, filetype="Config"):

--- a/tests/test_output_redirection/Snakefile
+++ b/tests/test_output_redirection/Snakefile
@@ -1,0 +1,28 @@
+
+rule redirect_output:
+    output: "output.txt"
+
+    log: stdout="output.log", stderr="output.err"
+    shell: """touch {output}
+      echo stdout log >> /dev/stdout
+      echo stderr log >> /dev/stderr
+      """
+
+
+rule redirect_output_combine:
+    output: "combined.txt"
+
+    log: std="output.log"
+    shell: """touch {output}
+      echo stdout log >> /dev/stdout
+      echo stderr log >> /dev/stderr
+      """
+
+
+rule two_stdouts:
+    output: "two_stdouts.txt"
+    log: std=["output.log", "other.log"]
+    shell: """touch {output}
+      echo stdout log >> /dev/stdout
+      echo stderr log >> /dev/stderr
+      """

--- a/tests/test_output_redirection/Snakefile.compile_error
+++ b/tests/test_output_redirection/Snakefile.compile_error
@@ -1,0 +1,8 @@
+
+rule main_target:
+    output: "combined_err.txt"
+    log: std="output.log", stdout="other.log"
+    shell: """touch {output}
+      echo stdout log >> /dev/stdout
+      echo stderr log >> /dev/stderr
+      """

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,6 @@
+from snakemake.shell import shell
+
+
+def test_collect_stdout():
+    output = shell("echo test output", read=True)
+    assert output == b"test output\n"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -994,3 +994,39 @@ def test_linting():
     snakemake(
         snakefile=os.path.join(dpath("test14"), "Snakefile.nonstandard"), lint=True
     )
+
+
+def test_output_redirection():
+    """ stdout() and stderr() flags on log files lead output from shell rule
+        to be redirected to those paths.
+    """
+    tempdir = run(
+        dpath("test_output_redirection"), targets=["redirect_output"], cleanup=False
+    )
+    with open(tempdir + "/output.log") as stdout_file:
+        assert stdout_file.read() == "stdout log\n"
+    with open(tempdir + "/output.err") as stderr_file:
+        assert stderr_file.read() == "stderr log\n"
+
+    shutil.rmtree(tempdir)
+
+    tempdir = run(
+        dpath("test_output_redirection"),
+        targets=["redirect_output_combine"],
+        cleanup=False,
+    )
+    with open(tempdir + "/output.log") as logfile:
+        assert logfile.read() == "stdout log\nstderr log\n"
+
+    shutil.rmtree(tempdir)
+
+    run(
+        dpath("test_output_redirection"), targets=["two_stdouts"], shouldfail=True,
+    )
+
+    run(
+        dpath("test_output_redirection"),
+        snakefile="Snakefile.compile_error",
+        targets=["invalid_combination"],
+        shouldfail=True,
+    )


### PR DESCRIPTION
Workflows involving many shell scripts can become quite cluttered
with bash redirections if every line in the script has them, especially
if stdout and stderr are redirected to separate files.

This allows the developer to instruct Snakemake to redirect the entirety
of a given script over to files, by flagging log files with stdout and
stderr.

This PR replaces #243, and it's a little closer to the spirit of what I was hoping to
accomplish with that one.

There are a couple of choices I've made here, which I anticipate you might disagree
with.  I hope that you'd be open to the spirit of this change, which would really mean a lot to me,
and work with me to come up with an implementation that matches your design decisions.

thanks! 