### PR TITLE
Use 1 core by default

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -882,6 +882,7 @@ def get_argument_parser(profile=None):
         "-j",
         action="store",
         const=available_cpu_count(),
+        default=1,
         nargs="?",
         metavar="N",
         help=(


### PR DESCRIPTION
Provided default=1 value for cores option in order to solve this issue: https://github.com/snakemake/snakemake/issues/312