### PR TITLE
executors.py - Quoting correction

### DIFF
--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -824,7 +824,7 @@ class GenericClusterExecutor(ClusterExecutor):
             # TODO wrap with watch and touch {jobrunning}
             # check modification date of {jobrunning} in the wait_for_job method
             self.exec_job += (
-                ' && touch "{jobfinished}" || (touch "{jobfailed}"; exit 1)'
+                ' && touch {jobfinished} || (touch {jobfailed}; exit 1)'
             )
         else:
             raise WorkflowError(


### PR DESCRIPTION
Hello Snakemake team,

First thank you for developing and maintaining this great tool. Below the details and solution about a bug I found yesterday.

### Bug explanation and solution

**Context**: Job submission to SGE cluster using `qsub` from a folder with a path containing special character or white space.

**Problem**: First batch of jobs is successfully submitted but snakemake then hangs forever. This is due to an error generated by the `executors.py` script which prevent job status to be checked. The error is:
```bash
touch: cannot touch `\'XXX/tmp/t&st/.snakemake/tmp.gekxw62y/0.jobfinished\'': No such file or directory
touch: cannot touch `\'XXX/tmp/t&st/.snakemake/tmp.gekxw62y/0.jobfailed\'': No such file or directory
```
The `executors.py` generates a bash script for submission which generates (`touch`) status file after the job is done. If current path contains space or special character, the path given to `touch` has single quotes surrounded by double quotes which prevent `touch` to create the status file because the double quotes induced the escape of the single quotes which is then part of the path (and obviously the path does not exist under this form).

**Solution**: Remove quoting around `jobfinished` and `jobfailed` variables in the `executors.py` script avoid this unexpected behavior in bash and remove submission hanging. Single quotes are still added as need by python (see below).

### Comments

The solution has been tested in several cases with no white space, with white space, and with special character (&). This is the bit of the shell script generated by the current version of the `executors.py`:
``` bash
# With no white space
...
--mode 2  && touch "XXX/tmp/test/.snakemake/tmp.zl6n_m1l/0.jobfinished" || (touch "XXX/tmp/test/.snakemake/tmp.zl6n_m1l/0.jobfailed"; exit 1)

# With white space
...
--mode 2  && touch "'XXX/tmp/test test/.snakemake/tmp.ctp9fjxn/0.jobfinished'" || (touch "'XXX/tmp/test test/.snakemake/tmp.ctp9fjxn/0.jobfailed'"; exit 1)

# With special character
--mode 2  && touch "'XXX/tmp/t&st/.snakemake/tmp.gekxw62y/0.jobfinished'" || (touch "'XXX/tmp/t&st/.snakemake/tmp.gekxw62y/0.jobfailed'"; exit 1)
```
This is the same bit of the shell script after the current patch:
``` bash
# With no white space
...
--mode 2  && touch XXX/tmp/test/.snakemake/tmp.l_dr2r3q/0.jobfinished || (touch XXX/tmp/test/.snakemake/tmp.l_dr2r3q/0.jobfailed; exit 1)

# With white space
...
--mode 2  && touch 'XXX/tmp/test test/.snakemake/tmp.watwc2qe/0.jobfinished' || (touch 'XXX/tmp/test test/.snakemake/tmp.watwc2qe/0.jobfailed'; exit 1)

# With special character
--mode 2  && touch 'XXX/tmp/t&st/.snakemake/tmp.3rpc4nm7/0.jobfinished' || (touch 'XXX/tmp/t&st/.snakemake/tmp.3rpc4nm7/0.jobfailed'; exit 1)
```

### Minimal reproducible example

In case this needs to be reproduced.
```bash
# Create working directory
mkdir "test test"
cd "test test"

# Create status directory for qsub and output directory
mkdir status
mkdir output

# Create snakefile
cat  << EOF > snakefile
rule complex_conversion:
    input:
        "test"
    output:
        "output/a.txt"
    shell:
        'sleep 10 && echo h=$(hostname) "{input}" > "{output}"'
EOF

# Submit job
snakemake --cluster "qsub -V -cwd -o status -j y" --jobs 20 -w 10

# Print status
cat status/*
```
``` bash
python -V
# Python 3.6.10
```

Thank you for considering this patch.

Hope everything goes well and stay safe!

Fred