### PR TITLE
print statements and --dag, rulegraph and filegraph

### DIFF
--- a/docs/executing/cluster-cloud.rst
+++ b/docs/executing/cluster-cloud.rst
@@ -301,3 +301,5 @@ To visualize the whole DAG regardless of the eventual presence of files, the ``f
     $ snakemake --forceall --dag | dot -Tpdf > dag.pdf
 
 Of course the visual appearance can be modified by providing further command line arguments to ``dot``.
+
+**Note:** The DAG is printed in DOT format straight to the standard output, along with other ``print`` statements you may have in your Snakefile. Make sure to comment these other ``print`` statements so that ``dot`` can build a visual representation of your DAG.

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1142,7 +1142,9 @@ def get_argument_parser(profile=None):
         action="store_true",
         help="Do not execute anything and print the directed "
         "acyclic graph of jobs in the dot language. Recommended "
-        "use on Unix systems: snakemake --dag | dot | display",
+        "use on Unix systems: snakemake --dag | dot | display"
+        "Note print statements in your Snakefile may interfere "
+        "with visualization.",
     )
     group_utils.add_argument(
         "--rulegraph",
@@ -1153,7 +1155,9 @@ def get_argument_parser(profile=None):
         "Note that each rule is displayed once, hence the displayed graph will be "
         "cyclic if a rule appears in several steps of the workflow. "
         "Use this if above option leads to a DAG that is too large. "
-        "Recommended use on Unix systems: snakemake --rulegraph | dot | display",
+        "Recommended use on Unix systems: snakemake --rulegraph | dot | display"
+        "Note print statements in your Snakefile may interfere "
+        "with visualization.",
     )
     group_utils.add_argument(
         "--filegraph",
@@ -1164,7 +1168,9 @@ def get_argument_parser(profile=None):
         "Note that each rule is displayed once, hence the displayed graph will be "
         "cyclic if a rule appears in several steps of the workflow. "
         "Use this if above option leads to a DAG that is too large. "
-        "Recommended use on Unix systems: snakemake --filegraph | dot | display",
+        "Recommended use on Unix systems: snakemake --filegraph | dot | display"
+        "Note print statements in your Snakefile may interfere "
+        "with visualization.",
     )
     group_utils.add_argument(
         "--d3dag",


### PR DESCRIPTION
In issue #316 I reported that the --dag (and other dot representations) option may not work properly because of other print statements in your Snakefile.

The way these three options work is that a DOT representation of a DAG is printed to the standard output. The documentation recommends you pipe that into `dot` to get a visualization of the graph.

Because Snakefiles are python scripts, it is used by many as such, and people might put `print` statements within the Snakefile. These statements, if redirected to the standard output, may interefere with `dot`.

In this PR, I changed the documentation about visualization and the argparse descriptions of these options to caution people about the use of `print` statements within the Snakefile when trying to get dot representations.