### PR TITLE
Fix UnboundLocalError in resources expansion

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -956,7 +956,7 @@ class Rule:
                             res = TBDInt(0)
                         else:
                             raise e
-                except e:
+                except FileNotFoundError as e:
                     raise InputFunctionException(e, rule=self, wildcards=wildcards)
 
                 if not isinstance(res, int):


### PR DESCRIPTION
Fixes #224 by explicitly catching `FileNotFoundError`, allowing the original exception to propagate properly.