### PR TITLE
Use HTTPS for links where available

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://www.sphinx-doc.org/)
 endif
 
 # Internal variables.

--- a/docs/executing/cluster-cloud.rst
+++ b/docs/executing/cluster-cloud.rst
@@ -236,7 +236,7 @@ and forward it to the cluster scheduler:
 
     $ snakemake --cluster "qsub --runtime {params.runtime}"
 
-If your cluster system supports `DRMAA <http://www.drmaa.org/>`_, Snakemake can make use of that to increase the control over jobs.
+If your cluster system supports `DRMAA <https://www.drmaa.org/>`_, Snakemake can make use of that to increase the control over jobs.
 E.g. jobs can be cancelled upon pressing ``Ctrl+C``, which is not possible with the generic ``--cluster`` support.
 With DRMAA, no ``qsub`` command needs to be provided, but system specific arguments can still be given as a string, e.g.
 

--- a/docs/executing/interoperability.rst
+++ b/docs/executing/interoperability.rst
@@ -9,7 +9,7 @@ Interoperability
 CWL export
 ----------
 
-Snakemake workflows can be exported to `CWL <http://www.commonwl.org/>`_, such that they can be executed in any `CWL-enabled workflow engine <https://www.commonwl.org/#Implementations>`_.
+Snakemake workflows can be exported to `CWL <https://www.commonwl.org/>`_, such that they can be executed in any `CWL-enabled workflow engine <https://www.commonwl.org/#Implementations>`_.
 Since, CWL is less powerful for expressing workflows than Snakemake (most importantly Snakemake offers more flexible scatter-gather patterns, since full Python can be used), export works such that every Snakemake job is encoded into a single step in the CWL workflow.
 Moreover, every step of that workflow calls Snakemake again to execute the job. The latter enables advanced Snakemake features like scripts, benchmarks and remote files to work inside CWL.
 So, when exporting keep in mind that the resulting CWL file can become huge, depending on the number of jobs in your workflow.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -175,7 +175,7 @@ Please consider to add your own.
 * Park et al. 2015. `Ebola Virus Epidemiology, Transmission, and Evolution during Seven Months in Sierra Leone <http://doi.org/10.1016/j.cell.2015.06.007>`_. Cell.
 * Břinda et al. 2015. `RNF: a general framework to evaluate NGS read mappers <http://bioinformatics.oxfordjournals.org/content/early/2015/09/30/bioinformatics.btv524>`_. Bioinformatics.
 * Břinda et al. 2015. `Spaced seeds improve k-mer-based metagenomic classification <http://bioinformatics.oxfordjournals.org/content/early/2015/08/10/bioinformatics.btv419>`_. Bioinformatics.
-* Spjuth et al. 2015. `Experiences with workflows for automating data-intensive bioinformatics <http://www.biologydirect.com/content/10/1/43>`_. Biology Direct.
+* Spjuth et al. 2015. `Experiences with workflows for automating data-intensive bioinformatics <https://biologydirect.biomedcentral.com/articles/10.1186/s13062-015-0071-8>`_. Biology Direct.
 * Schramm et al. 2015. `Mutational dynamics between primary and relapse neuroblastomas <http://www.nature.com/ng/journal/v47/n8/full/ng.3349.html>`_. Nature Genetics.
 * Berulava et al. 2015. `N6-Adenosine Methylation in MiRNAs <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0118438>`_. PLOS ONE.
 * The Genome of the Netherlands Consortium 2014. `Whole-genome sequence variation, population structure and demographic history of the Dutch population <http://www.nature.com/ng/journal/v46/n8/full/ng.3021.html>`_. Nature Genetics.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -113,7 +113,7 @@ Support
 Citation
 --------
 
-`Köster, Johannes and Rahmann, Sven. "Snakemake - A scalable bioinformatics workflow engine". Bioinformatics 2012. <http://bioinformatics.oxfordjournals.org/content/28/19/2520>`_
+`Köster, Johannes and Rahmann, Sven. "Snakemake - A scalable bioinformatics workflow engine". Bioinformatics 2012. <https://bioinformatics.oxfordjournals.org/content/28/19/2520>`_
 
 See :doc:`Citations <project_info/citations>` for more information.
 
@@ -154,41 +154,41 @@ Please consider to add your own.
 * Goormaghtigh et al. 2018. `Reassessing the Role of Type II Toxin-Antitoxin Systems in Formation of Escherichia coli Type II Persister Cells <https://mbio.asm.org/content/mbio/9/3/e00640-18.full.pdf>`_. mBio.
 * Ramirez et al. 2018. `Detecting macroecological patterns in bacterial communities across independent studies of global soils <https://www.nature.com/articles/s41564-017-0062-x>`_. Nature microbiology.
 * Amato et al. 2018. `Evolutionary trends in host physiology outweigh dietary niche in structuring primate gut microbiomes <https://www.nature.com/articles/s41396-018-0175-0>`_. The ISME journal.
-* Uhlitz et al. 2017. `An immediate–late gene expression module decodes ERK signal duration <http://msb.embopress.org/content/13/5/928>`_. Molecular Systems Biology.
-* Akkouche et al. 2017. `Piwi Is Required during Drosophila Embryogenesis to License Dual-Strand piRNA Clusters for Transposon Repression in Adult Ovaries <http://www.sciencedirect.com/science/article/pii/S1097276517302071>`_. Molecular Cell.
+* Uhlitz et al. 2017. `An immediate–late gene expression module decodes ERK signal duration <https://msb.embopress.org/content/13/5/928>`_. Molecular Systems Biology.
+* Akkouche et al. 2017. `Piwi Is Required during Drosophila Embryogenesis to License Dual-Strand piRNA Clusters for Transposon Repression in Adult Ovaries <https://www.sciencedirect.com/science/article/pii/S1097276517302071>`_. Molecular Cell.
 * Beatty et al. 2017. `Giardia duodenalis induces pathogenic dysbiosis of human intestinal microbiota biofilms <https://www.ncbi.nlm.nih.gov/pubmed/28237889>`_. International Journal for Parasitology.
 * Meyer et al. 2017. `Differential Gene Expression in the Human Brain Is Associated with Conserved, but Not Accelerated, Noncoding Sequences <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5400397/>`_. Molecular Biology and Evolution.
-* Lonardo et al. 2017. `Priming of soil organic matter: Chemical structure of added compounds is more important than the energy content <http://www.sciencedirect.com/science/article/pii/S0038071716304539>`_. Soil Biology and Biochemistry.
+* Lonardo et al. 2017. `Priming of soil organic matter: Chemical structure of added compounds is more important than the energy content <https://www.sciencedirect.com/science/article/pii/S0038071716304539>`_. Soil Biology and Biochemistry.
 * Beisser et al. 2017. `Comprehensive transcriptome analysis provides new insights into nutritional strategies and phylogenetic relationships of chrysophytes <https://peerj.com/articles/2832/>`_. PeerJ.
 * Piro et al 2017. `MetaMeta: integrating metagenome analysis tools to improve taxonomic profiling <https://microbiomejournal.biomedcentral.com/articles/10.1186/s40168-017-0318-y>`_. Microbiome.
 * Dimitrov et al 2017. `Successive DNA extractions improve characterization of soil microbial communities <https://peerj.com/articles/2915/>`_. PeerJ.
-* de Bourcy et al. 2016. `Phylogenetic analysis of the human antibody repertoire reveals quantitative signatures of immune senescence and aging <http://www.pnas.org/content/114/5/1105.short>`_. PNAS.
-* Bray et al. 2016. `Near-optimal probabilistic RNA-seq quantification <http://www.nature.com/nbt/journal/v34/n5/abs/nbt.3519.html>`_. Nature Biotechnology.
+* de Bourcy et al. 2016. `Phylogenetic analysis of the human antibody repertoire reveals quantitative signatures of immune senescence and aging <https://www.pnas.org/content/114/5/1105.short>`_. PNAS.
+* Bray et al. 2016. `Near-optimal probabilistic RNA-seq quantification <https://www.nature.com/nbt/journal/v34/n5/abs/nbt.3519.html>`_. Nature Biotechnology.
 * Etournay et al. 2016. `TissueMiner: a multiscale analysis toolkit to quantify how cellular processes create tissue dynamics <https://elifesciences.org/content/5/e14334>`_. eLife Sciences.
-* Townsend et al. 2016. `The Public Repository of Xenografts Enables Discovery and Randomized Phase II-like Trials in Mice <http://www.cell.com/cancer-cell/abstract/S1535-6108%2816%2930090-3>`_. Cancer Cell.
-* Burrows et al. 2016. `Genetic Variation, Not Cell Type of Origin, Underlies the Majority of Identifiable Regulatory Differences in iPSCs <http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005793>`_. PLOS Genetics.
-* Ziller et al. 2015. `Coverage recommendations for methylation analysis by whole-genome bisulfite sequencing <http://www.nature.com/nmeth/journal/v12/n3/full/nmeth.3152.html>`_. Nature Methods.
+* Townsend et al. 2016. `The Public Repository of Xenografts Enables Discovery and Randomized Phase II-like Trials in Mice <https://www.cell.com/cancer-cell/abstract/S1535-6108%2816%2930090-3>`_. Cancer Cell.
+* Burrows et al. 2016. `Genetic Variation, Not Cell Type of Origin, Underlies the Majority of Identifiable Regulatory Differences in iPSCs <https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005793>`_. PLOS Genetics.
+* Ziller et al. 2015. `Coverage recommendations for methylation analysis by whole-genome bisulfite sequencing <https://www.nature.com/nmeth/journal/v12/n3/full/nmeth.3152.html>`_. Nature Methods.
 * Li et al. 2015. `Quality control, modeling, and visualization of CRISPR screens with MAGeCK-VISPR <https://genomebiology.biomedcentral.com/articles/10.1186/s13059-015-0843-6>`_. Genome Biology.
-* Schmied et al. 2015. `An automated workflow for parallel processing of large multiview SPIM recordings <http://bioinformatics.oxfordjournals.org/content/32/7/1112>`_. Bioinformatics.
-* Chung et al. 2015. `Whole-Genome Sequencing and Integrative Genomic Analysis Approach on Two 22q11.2 Deletion Syndrome Family Trios for Genotype to Phenotype Correlations <http://onlinelibrary.wiley.com/doi/10.1002/humu.22814/full>`_. Human Mutation.
-* Kim et al. 2015. `TUT7 controls the fate of precursor microRNAs by using three different uridylation mechanisms <http://emboj.embopress.org/content/34/13/1801.long>`_. The EMBO Journal.
-* Park et al. 2015. `Ebola Virus Epidemiology, Transmission, and Evolution during Seven Months in Sierra Leone <http://doi.org/10.1016/j.cell.2015.06.007>`_. Cell.
-* Břinda et al. 2015. `RNF: a general framework to evaluate NGS read mappers <http://bioinformatics.oxfordjournals.org/content/early/2015/09/30/bioinformatics.btv524>`_. Bioinformatics.
-* Břinda et al. 2015. `Spaced seeds improve k-mer-based metagenomic classification <http://bioinformatics.oxfordjournals.org/content/early/2015/08/10/bioinformatics.btv419>`_. Bioinformatics.
+* Schmied et al. 2015. `An automated workflow for parallel processing of large multiview SPIM recordings <https://bioinformatics.oxfordjournals.org/content/32/7/1112>`_. Bioinformatics.
+* Chung et al. 2015. `Whole-Genome Sequencing and Integrative Genomic Analysis Approach on Two 22q11.2 Deletion Syndrome Family Trios for Genotype to Phenotype Correlations <https://onlinelibrary.wiley.com/doi/10.1002/humu.22814/full>`_. Human Mutation.
+* Kim et al. 2015. `TUT7 controls the fate of precursor microRNAs by using three different uridylation mechanisms <https://emboj.embopress.org/content/34/13/1801.long>`_. The EMBO Journal.
+* Park et al. 2015. `Ebola Virus Epidemiology, Transmission, and Evolution during Seven Months in Sierra Leone <https://doi.org/10.1016/j.cell.2015.06.007>`_. Cell.
+* Břinda et al. 2015. `RNF: a general framework to evaluate NGS read mappers <https://bioinformatics.oxfordjournals.org/content/early/2015/09/30/bioinformatics.btv524>`_. Bioinformatics.
+* Břinda et al. 2015. `Spaced seeds improve k-mer-based metagenomic classification <https://bioinformatics.oxfordjournals.org/content/early/2015/08/10/bioinformatics.btv419>`_. Bioinformatics.
 * Spjuth et al. 2015. `Experiences with workflows for automating data-intensive bioinformatics <https://biologydirect.biomedcentral.com/articles/10.1186/s13062-015-0071-8>`_. Biology Direct.
-* Schramm et al. 2015. `Mutational dynamics between primary and relapse neuroblastomas <http://www.nature.com/ng/journal/v47/n8/full/ng.3349.html>`_. Nature Genetics.
-* Berulava et al. 2015. `N6-Adenosine Methylation in MiRNAs <http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0118438>`_. PLOS ONE.
-* The Genome of the Netherlands Consortium 2014. `Whole-genome sequence variation, population structure and demographic history of the Dutch population <http://www.nature.com/ng/journal/v46/n8/full/ng.3021.html>`_. Nature Genetics.
-*  Patterson et al. 2014. `WhatsHap: Haplotype Assembly for Future-Generation Sequencing Reads <http://online.liebertpub.com/doi/10.1089/cmb.2014.0157>`_. Journal of Computational Biology.
-* Fernández et al. 2014. `H3K4me1 marks DNA regions hypomethylated during aging in human stem and differentiated cells <http://genome.cshlp.org/content/25/1/27.long>`_. Genome Research.
+* Schramm et al. 2015. `Mutational dynamics between primary and relapse neuroblastomas <https://www.nature.com/ng/journal/v47/n8/full/ng.3349.html>`_. Nature Genetics.
+* Berulava et al. 2015. `N6-Adenosine Methylation in MiRNAs <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0118438>`_. PLOS ONE.
+* The Genome of the Netherlands Consortium 2014. `Whole-genome sequence variation, population structure and demographic history of the Dutch population <https://www.nature.com/ng/journal/v46/n8/full/ng.3021.html>`_. Nature Genetics.
+*  Patterson et al. 2014. `WhatsHap: Haplotype Assembly for Future-Generation Sequencing Reads <https://online.liebertpub.com/doi/10.1089/cmb.2014.0157>`_. Journal of Computational Biology.
+* Fernández et al. 2014. `H3K4me1 marks DNA regions hypomethylated during aging in human stem and differentiated cells <https://genome.cshlp.org/content/25/1/27.long>`_. Genome Research.
 * Köster et al. 2014. `Massively parallel read mapping on GPUs with the q-group index and PEANUT <https://peerj.com/articles/606/>`_. PeerJ.
-* Chang et al. 2014. `TAIL-seq: Genome-wide Determination of Poly(A) Tail Length and 3′ End Modifications <http://www.cell.com/molecular-cell/abstract/S1097-2765(14)00121-X>`_. Molecular Cell.
-* Althoff et al. 2013. `MiR-137 functions as a tumor suppressor in neuroblastoma by downregulating KDM1A <http://onlinelibrary.wiley.com/doi/10.1002/ijc.28091/abstract;jsessionid=33613A834E2A2FDCCA49246C23DF777E.f04t02>`_. International Journal of Cancer.
-* Marschall et al. 2013. `MATE-CLEVER: Mendelian-Inheritance-Aware Discovery and Genotyping of Midsize and Long Indels <http://bioinformatics.oxfordjournals.org/content/29/24/3143.long>`_. Bioinformatics.
-* Rahmann et al. 2013. `Identifying transcriptional miRNA biomarkers by integrating high-throughput sequencing and real-time PCR data <http://www.sciencedirect.com/science/article/pii/S1046202312002605>`_. Methods.
-* Martin et al. 2013. `Exome sequencing identifies recurrent somatic mutations in EIF1AX and SF3B1 in uveal melanoma with disomy 3 <http://www.nature.com/ng/journal/v45/n8/full/ng.2674.html>`_. Nature Genetics.
-* Czeschik et al. 2013. `Clinical and mutation data in 12 patients with the clinical diagnosis of Nager syndrome <http://link.springer.com/article/10.1007%2Fs00439-013-1295-2>`_. Human Genetics.
-* Marschall et al. 2012. `CLEVER: Clique-Enumerating Variant Finder <http://bioinformatics.oxfordjournals.org/content/28/22/2875.long>`_. Bioinformatics.
+* Chang et al. 2014. `TAIL-seq: Genome-wide Determination of Poly(A) Tail Length and 3′ End Modifications <https://www.cell.com/molecular-cell/abstract/S1097-2765(14)00121-X>`_. Molecular Cell.
+* Althoff et al. 2013. `MiR-137 functions as a tumor suppressor in neuroblastoma by downregulating KDM1A <https://onlinelibrary.wiley.com/doi/10.1002/ijc.28091/abstract;jsessionid=33613A834E2A2FDCCA49246C23DF777E.f04t02>`_. International Journal of Cancer.
+* Marschall et al. 2013. `MATE-CLEVER: Mendelian-Inheritance-Aware Discovery and Genotyping of Midsize and Long Indels <https://bioinformatics.oxfordjournals.org/content/29/24/3143.long>`_. Bioinformatics.
+* Rahmann et al. 2013. `Identifying transcriptional miRNA biomarkers by integrating high-throughput sequencing and real-time PCR data <https://www.sciencedirect.com/science/article/pii/S1046202312002605>`_. Methods.
+* Martin et al. 2013. `Exome sequencing identifies recurrent somatic mutations in EIF1AX and SF3B1 in uveal melanoma with disomy 3 <https://www.nature.com/ng/journal/v45/n8/full/ng.2674.html>`_. Nature Genetics.
+* Czeschik et al. 2013. `Clinical and mutation data in 12 patients with the clinical diagnosis of Nager syndrome <https://link.springer.com/article/10.1007%2Fs00439-013-1295-2>`_. Human Genetics.
+* Marschall et al. 2012. `CLEVER: Clique-Enumerating Variant Finder <https://bioinformatics.oxfordjournals.org/content/28/22/2875.long>`_. Bioinformatics.
 
 
 .. toctree::

--- a/docs/project_info/citations.rst
+++ b/docs/project_info/citations.rst
@@ -18,7 +18,7 @@ When using Snakemake for a publication, **please cite the following article** in
 Cite This
 =========
 
-`Köster, Johannes and Rahmann, Sven. "Snakemake - A scalable bioinformatics workflow engine". Bioinformatics 2012. <http://bioinformatics.oxfordjournals.org/content/28/19/2520>`_
+`Köster, Johannes and Rahmann, Sven. "Snakemake - A scalable bioinformatics workflow engine". Bioinformatics 2012. <https://bioinformatics.oxfordjournals.org/content/28/19/2520>`_
 
 
 More References
@@ -26,11 +26,11 @@ More References
 
 Another publication describing more of Snakemake internals:
 
-`Köster, Johannes and Rahmann, Sven. "Building and Documenting Bioinformatics Workflows with Python-based Snakemake". Proceedings of the GCB 2012. <http://drops.dagstuhl.de/opus/volltexte/oasics-complete/oasics-vol26-gcb2012-complete.pdf>`_
+`Köster, Johannes and Rahmann, Sven. "Building and Documenting Bioinformatics Workflows with Python-based Snakemake". Proceedings of the GCB 2012. <https://drops.dagstuhl.de/opus/volltexte/oasics-complete/oasics-vol26-gcb2012-complete.pdf>`_
 
 And my PhD thesis which describes all algorithmic details:
 
-`Johannes Köster, "Parallelization, Scalability, and Reproducibility in Next-Generation Sequencing Analysis", TU Dortmund 2014 <http://hdl.handle.net/2003/33940>`_
+`Johannes Köster, "Parallelization, Scalability, and Reproducibility in Next-Generation Sequencing Analysis", TU Dortmund 2014 <https://hdl.handle.net/2003/33940>`_
 
 
 Project Pages
@@ -48,4 +48,4 @@ The markdown syntax is
     [![Snakemake](https://img.shields.io/badge/snakemake-≥5.6.0-brightgreen.svg?style=flat)](https://snakemake.readthedocs.io)
 
 Replace the ``3.5.2`` with the minimum required Snakemake version.
-You can also `change the style <http://shields.io/#styles>`_.
+You can also `change the style <https://shields.io/#styles>`_.

--- a/docs/project_info/faq.rst
+++ b/docs/project_info/faq.rst
@@ -188,7 +188,7 @@ and have in the Snakefile some Python code that reads this environment variable,
 I get a NameError with my shell command. Are braces unsupported?
 ----------------------------------------------------------------
 
-You can use the entire Python `format minilanguage <http://docs.python.org/3/library/string.html#formatspec>`_ in shell commands. Braces in shell commands that are not intended to insert variable values thus have to be escaped by doubling them:
+You can use the entire Python `format minilanguage <https://docs.python.org/3/library/string.html#formatspec>`_ in shell commands. Braces in shell commands that are not intended to insert variable values thus have to be escaped by doubling them:
 
 This:
 
@@ -315,7 +315,7 @@ On unix, you can make use of the commonly pre-installed `mail` command:
     snakemake 2> snakemake.log
     mail -s "snakemake finished" youremail@provider.com < snakemake.log
 
-In case your administrator does not provide you with a proper configuration of the sendmail framework, you can configure `mail` to work e.g. via Gmail (see `here <http://www.cyberciti.biz/tips/linux-use-gmail-as-a-smarthost.html>`_).
+In case your administrator does not provide you with a proper configuration of the sendmail framework, you can configure `mail` to work e.g. via Gmail (see `here <https://www.cyberciti.biz/tips/linux-use-gmail-as-a-smarthost.html>`_).
 
 I want to pass variables between rules. Is that possible?
 ---------------------------------------------------------

--- a/docs/project_info/more_resources.rst
+++ b/docs/project_info/more_resources.rst
@@ -14,8 +14,8 @@ Talks and Posters
 * `Invited talk by Johannes Köster at the Broad Institute, Boston 2015. <https://slides.com/johanneskoester/snakemake-broad-2015>`_
 * `Introduction to Snakemake. Tutorial Slides presented by Johannes Köster at the GCB 2015, Dortmund, Germany. <https://slides.com/johanneskoester/deck-1>`_
 * `Invited talk by Johannes Köster at the DTL Focus Meeting: "NGS Production Pipelines", Dutch Techcentre for Life Sciences, Utrecht 2014. <https://speakerdeck.com/johanneskoester/workflow-management-with-snakemake>`_
-* `Taming Snakemake by Jeremy Leipzig, Bioinformatics software developer at Children's Hospital of Philadelphia, 2014. <http://de.slideshare.net/jermdemo/taming-snakemake>`_
-* `"Snakemake makes ... snakes?" - An Introduction by Marcel Martin from SciLifeLab, Stockholm 2015 <http://marcelm.net/talks/2015/snakemake>`_
+* `Taming Snakemake by Jeremy Leipzig, Bioinformatics software developer at Children's Hospital of Philadelphia, 2014. <https://de.slideshare.net/jermdemo/taming-snakemake>`_
+* `"Snakemake makes ... snakes?" - An Introduction by Marcel Martin from SciLifeLab, Stockholm 2015 <https://marcelm.net/talks/2015/snakemake>`_
 * `"Workflow Management with Snakemake" by Johannes Köster, 2015. Held at the Department of Biostatistics and Computational Biology, Dana-Farber Cancer Institute <https://speakerdeck.com/johanneskoester/workflow-management-with-snakemake-1>`_
 
 
@@ -27,14 +27,14 @@ External Resources
 
 These resources are not part of the official documentation.
 
-* `A number of tutorials on the subject "Tools for reproducible research" <http://nbis-reproducible-research.readthedocs.io>`_
+* `A number of tutorials on the subject "Tools for reproducible research" <https://nbis-reproducible-research.readthedocs.io>`_
 * `Snakemake workflow used for the Kallisto paper <https://github.com/pachterlab/kallisto_paper_analysis>`_
-* `An alternative tutorial for Snakemake <http://slowkow.com/notes/snakemake-tutorial/>`_
+* `An alternative tutorial for Snakemake <https://slowkow.com/notes/snakemake-tutorial/>`_
 * `An Emacs mode for Snakemake <http://melpa.milkbox.net/#/snakemake-mode>`_
 * `Flexible bioinformatics pipelines with Snakemake <http://watson.nci.nih.gov/~sdavis/blog/flexible_bioinformatics_pipelines_with_snakemake/>`_
 * `Sandwiches with Snakemake <https://github.com/leipzig/SandwichesWithSnakemake>`_
-* `A visualization of the past years of Snakemake development <http://youtu.be/bq3vXrWw1yk>`_
+* `A visualization of the past years of Snakemake development <https://youtu.be/bq3vXrWw1yk>`_
 * `Japanese version of the Snakemake tutorial <https://github.com/joemphilips/Translate_Snakemake_Tutorial>`_
-* `Basic <http://bioinfo-fr.net/snakemake-pour-les-nuls>`_ and `advanced <http://bioinfo-fr.net/snakemake-aller-plus-loin-avec-la-parallelisation>`_ french Snakemake tutorial.
+* `Basic <https://bioinfo-fr.net/snakemake-pour-les-nuls>`_ and `advanced <https://bioinfo-fr.net/snakemake-aller-plus-loin-avec-la-parallelisation>`_ french Snakemake tutorial.
 * `Mini tutorial on Snakemake and Bioconda <https://github.com/dlaehnemann/TutMinicondaSnakemake>`_
 * `Snakeparse: a utility to expose Snakemake workflow configuation via a command line interface <https://github.com/nh13/snakeparse>`_

--- a/docs/snakefiles/configuration.rst
+++ b/docs/snakefiles/configuration.rst
@@ -64,7 +64,7 @@ With the `Pandas library <https://pandas.pydata.org/>`_ such data can be read an
     samples = pd.read_table("samples.tsv").set_index("samples", drop=False)
 
 reads in a table ``samples.tsv`` in TSV format and makes every record accessible by the sample name.
-For details, see the `Pandas documentation <http://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_table.html?highlight=read_table#pandas-read-table>`_.
+For details, see the `Pandas documentation <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_table.html?highlight=read_table#pandas-read-table>`_.
 A fully working real-world example containing both types of configuration can be found `here <https://github.com/snakemake-workflows/rna-seq-star-deseq2>`_.
 
 ---------------------
@@ -104,7 +104,7 @@ Instead, for data provenance and reproducibility reasons, you are required to pa
 Validation
 ----------
 
-With Snakemake 5.1, it is possible to validate both types of configuration via `JSON schemas <http://json-schema.org>`_.
+With Snakemake 5.1, it is possible to validate both types of configuration via `JSON schemas <https://json-schema.org>`_.
 The function ``snakemake.utils.validate`` takes a loaded configuration (a config dictionary or a Pandas data frame) and validates it with a given JSON schema.
 Thereby, the schema can be provided in JSON or YAML format. Also, by using the defaults property it is possible to populate entries with default values. See `jsonschema FAQ on setting default values <https://python-jsonschema.readthedocs.io/en/latest/faq/>`_ for details.
 In case of the data frame, the schema should model the record that is expected in each row of the data frame.
@@ -137,7 +137,7 @@ the schema for validating the samples data frame looks like this:
 
 .. code-block:: yaml
 
-  $schema: "http://json-schema.org/draft-06/schema#"
+  $schema: "https://json-schema.org/draft-06/schema#"
   description: an entry in the sample sheet
   properties:
     sample:

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -61,8 +61,8 @@ Integrated Package Management
 -----------------------------
 
 With Snakemake 3.9.0 it is possible to define isolated software environments per rule.
-Upon execution of a workflow, the `Conda package manager <http://conda.pydata.org>`_ is used to obtain and deploy the defined software packages in the specified versions. Packages will be installed into your working directory, without requiring any admin/root priviledges.
-Given that conda is available on your system (see `Miniconda <http://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--use-conda`` flag to your workflow execution command, e.g. ``snakemake --cores 8 --use-conda``.
+Upon execution of a workflow, the `Conda package manager <https://conda.pydata.org>`_ is used to obtain and deploy the defined software packages in the specified versions. Packages will be installed into your working directory, without requiring any admin/root priviledges.
+Given that conda is available on your system (see `Miniconda <https://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--use-conda`` flag to your workflow execution command, e.g. ``snakemake --cores 8 --use-conda``.
 When ``--use-conda`` is activated, Snakemake will automatically create software environments for any used wrapper (see :ref:`snakefiles-wrappers`).
 Further, you can manually define environments via the ``conda`` directive, e.g.:
 

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -78,7 +78,7 @@ Further, you can manually define environments via the ``conda`` directive, e.g.:
         script:
             "scripts/plot-stuff.R"
 
-with the following `environment definition <http://conda.pydata.org/docs/using/envs.html#create-environment-file-by-hand>`_:
+with the following `environment definition <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#create-env-file-manually>`_:
 
 
 .. code-block:: yaml

--- a/docs/snakefiles/modularization.rst
+++ b/docs/snakefiles/modularization.rst
@@ -52,7 +52,7 @@ The `Snakemake Wrapper Repository`_ is meant as a collaborative project and pull
 Common-Workflow-Language (CWL) support
 --------------------------------------
 
-With Snakemake 4.8.0, it is possible to refer to `CWL <http://www.commonwl.org/>`_ tool definitions in rules instead of specifying a wrapper or a plain shell command.
+With Snakemake 4.8.0, it is possible to refer to `CWL <https://www.commonwl.org/>`_ tool definitions in rules instead of specifying a wrapper or a plain shell command.
 A CWL tool definition can be used as follows.
 
 .. code-block:: python
@@ -75,7 +75,7 @@ Snakemake will execute the rule by invoking `cwltool`, which has to be available
 When using in combination with :ref:`--use-singularity <singularity>`, Snakemake will instruct `cwltool` to execute the command via Singularity in user space.
 Otherwise, `cwltool` will in most cases use a Docker container, which requires Docker to be set up properly.
 
-The advantage is that predefined tools available via any `repository of CWL tool definitions <http://www.commonwl.org/#Repositories_of_CWL_Tools_and_Workflows>`_ can be used in any supporting workflow management system.
+The advantage is that predefined tools available via any `repository of CWL tool definitions <https://www.commonwl.org/#Repositories_of_CWL_Tools_and_Workflows>`_ can be used in any supporting workflow management system.
 In contrast to a :ref:`Snakemake wrapper <snakefiles-wrappers>`, CWL tool definitions are in general not suited to alter the behavior of a tool, e.g., by normalizing output names or special input handling.
 As you can see in comparison to the analog :ref:`wrapper declaration <snakefiles-wrappers>` above, the rule becomes slightly more verbose, because input, output, and params have to be dispatched to the specific expectations of the CWL tool definition.
 

--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -322,7 +322,7 @@ If the URI used includes characters not permitted in a local file path, you may 
             HTTP.remote("example.com/query.php", additional_request_string="?range=2;3")
 
 If the file requires authentication, you can specify a username and password for HTTP Basic Auth with the Remote Provider, or with each instance of `remote()`.
-For different types of authentication, you can pass in a Python ```requests.auth`` object (see `here <http://docs.python-requests.org/en/latest/api/#authentication>`_) the `auth` ``kwarg``.
+For different types of authentication, you can pass in a Python ```requests.auth`` object (see `here <https://requests.readthedocs.io/en/master/api/#authentication>`_) the `auth` ``kwarg``.
 
 .. code-block:: python
 
@@ -470,7 +470,7 @@ Note that Dropbox paths are case-insensitive.
 XRootD
 =======
 
-Snakemake can be used with `XRootD <http://xrootd.org/>`_ backed storage provided the python bindings are installed.
+Snakemake can be used with `XRootD <https://xrootd.slac.stanford.edu/>`_ backed storage provided the python bindings are installed.
 This is typically most useful when combined with the ``stay_on_remote`` flag to minimise local storage requirements.
 This flag can be overridden on a file by file basis as described in the S3 remote. Additionally ``glob_wildcards()`` is supported:
 

--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -32,7 +32,7 @@ Amazon Simple Storage Service (S3)
 
 This section describes usage of the S3 RemoteProvider, and also provides an intro to remote files and their usage.
 
-It is important to note that you must have credentials (``access_key_id`` and ``secret_access_key``) which permit read/write access. If a file only serves as input to a Snakemake rule, read access is sufficient. You may specify credentials as environment variables or in the file ``=/.aws/credentials``, prefixed with ``AWS_*``, as with a standard `boto config <http://boto.readthedocs.org/en/latest/boto_config_tut.html>`_. Credentials may also be explicitly listed in the ``Snakefile``, as shown below:
+It is important to note that you must have credentials (``access_key_id`` and ``secret_access_key``) which permit read/write access. If a file only serves as input to a Snakemake rule, read access is sufficient. You may specify credentials as environment variables or in the file ``=/.aws/credentials``, prefixed with ``AWS_*``, as with a standard `boto config <https://boto.readthedocs.org/en/latest/boto_config_tut.html>`_. Credentials may also be explicitly listed in the ``Snakefile``, as shown below:
 
 For the Amazon S3 and Google Cloud Storage providers, the sub-directory used must be the bucket name.
 
@@ -264,7 +264,7 @@ Web addresses must be specified without protocol, so if your URI looks like this
 
 .. code-block:: text
 
-    http://server3.example.com/path/to/myfile.tar.gz
+    https://server3.example.com/path/to/myfile.tar.gz
 
 The URI used in the ``Snakefile`` must look like this:
 

--- a/docs/snakefiles/reporting.rst
+++ b/docs/snakefiles/reporting.rst
@@ -8,7 +8,7 @@ From Snakemake 5.1 on, it is possible to automatically generate detailed self-co
 **A realistic example report from a real workflow can be found** `here <https://koesterlab.github.io/resources/report.html>`_.
 
 For including results into the report, the Snakefile has to be annotated with additional information.
-Each output file that shall be part of the report has to be marked with the ``report`` flag, which optionally points to a caption in `restructured text format <http://docutils.sourceforge.net/rst.html>`_ and allows to define a ``category`` for grouping purposes.
+Each output file that shall be part of the report has to be marked with the ``report`` flag, which optionally points to a caption in `restructured text format <https://docutils.sourceforge.io/docs/user/rst/quickstart.html>`_ and allows to define a ``category`` for grouping purposes.
 Moreover, a global workflow description can be defined via the ``report`` directive.
 Consider the following example:
 
@@ -60,7 +60,7 @@ As can be seen, we define a global description which is contained in the file ``
 In addition, we mark ``fig1.svg`` and ``fig2.png`` for inclusion into the report, while in both cases specifying a caption text via again referring to a restructured text file.
 Note the paths to the ``.rst``-files are interpreted relative to the current Snakefile.
 
-Inside the ``.rst``-files you can use `Jinja2 <http://jinja.pocoo.org>`_ templating to access context information.
+Inside the ``.rst``-files you can use `Jinja2 <https://jinja.palletsprojects.com>`_ templating to access context information.
 In case of the global description, you can access the config dictionary via ``{{ snakemake.config }}``, (e.g., use ``{{ snakemake.config["mykey"] }}`` to access the key ``mykey``).
 In case of output files, you can access the same values as available with the :ref:`script directive <snakefiles-external_scripts>` (e.g., ``snakemake.wildcards``).
 
@@ -79,7 +79,7 @@ Moreover, in every ``.rst`` document, you can link to
 * any **category** panel (with ``Mycategory_``, while ``Mycategory`` is the name given for the category argument of the report flag). E.g., with above example, you could write ``see `Step 2`_`` in order to link to the section with the results that have been assigned to the category ``Step 2``.
 * any **file** marked with the report flag (with ``myfile.txt_``, while ``myfile.txt`` is the basename of the file, without any leading directories). E.g., with above example, you could write ``see fig2.png_`` in order to link to the result in the report document.
 
-For details about the hyperlink mechanism of restructured text see `here <http://docutils.sourceforge.net/docs/user/rst/quickref.html#hyperlink-targets>`_.
+For details about the hyperlink mechanism of restructured text see `here <https://docutils.sourceforge.io/docs/user/rst/quickref.html#hyperlink-targets>`_.
 
 To create the report simply run
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -14,7 +14,7 @@ Most importantly, a rule can consist of a name (the name is optional and can be 
         output: "path/to/outputfile", "path/to/another/outputfile"
         shell: "somecommand {input} {output}"
 
-Inside the shell command, all local and global variables, especially input and output files can be accessed via their names in the `python format minilanguage <http://docs.python.org/py3k/library/string.html#formatspec>`_. Here input and output (and in general any list or tuple) automatically evaluate to a space-separated list of files (i.e. ``path/to/inputfile path/to/other/inputfile``).
+Inside the shell command, all local and global variables, especially input and output files can be accessed via their names in the `python format minilanguage <https://docs.python.org/py3k/library/string.html#formatspec>`_. Here input and output (and in general any list or tuple) automatically evaluate to a space-separated list of files (i.e. ``path/to/inputfile path/to/other/inputfile``).
 From Snakemake 3.8.0 on, adding the special formatting instruction ``:q`` (e.g. ``"somecommand {input:q} {output:q}")``) will let Snakemake quote each of the list or tuple elements that contains whitespace.
 Instead of a shell command, a rule can run some python code to generate the output:
 
@@ -117,7 +117,7 @@ Finally, you can also define global wildcard constraints that apply for all rule
     rule b:
         ...
 
-See the `Python documentation on regular expressions <http://docs.python.org/py3k/library/re.html>`_ for detailed information on regular expression syntax.
+See the `Python documentation on regular expressions <https://docs.python.org/py3k/library/re.html>`_ for detailed information on regular expression syntax.
 
 
 Aggregation
@@ -486,7 +486,7 @@ Inside the script, you have access to an object ``snakemake`` that provides acce
 Apart from Python scripts, this mechanism also allows you to integrate R_ and R Markdown_ scripts with Snakemake, e.g.
 
 .. _R: https://www.r-project.org
-.. _Markdown: http://rmarkdown.rstudio.com
+.. _Markdown: https://rmarkdown.rstudio.com
 
 .. code-block:: python
 

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -17,16 +17,16 @@ Additional features
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
 .. _Graphviz: http://www.graphviz.org
-.. _RestructuredText: http://docutils.sourceforge.net/rst.html
+.. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
 .. _JSON: http://json.org
 .. _YAML: http://yaml.org
 .. _DRMAA: http://www.drmaa.org
-.. _rpy2: http://rpy.sourceforge.net
+.. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
 .. _PyYAML: http://pyyaml.org
-.. _Docutils: http://docutils.sourceforge.net
+.. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -6,32 +6,32 @@ Additional features
 .. _Snakemake: https://snakemake.readthedocs.io
 .. _Snakemake homepage: https://snakemake.readthedocs.io
 .. _GNU Make: https://www.gnu.org/software/make
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org
 .. _BWA: http://bio-bwa.sourceforge.net
-.. _SAMtools: http://www.htslib.org
-.. _BCFtools: http://www.htslib.org
-.. _Pandas: http://pandas.pydata.org
-.. _Miniconda: http://conda.pydata.org/miniconda.html
-.. _Conda: http://conda.pydata.org
-.. _Bash: http://www.tldp.org/LDP/Bash-Beginners-Guide/html
+.. _SAMtools: https://www.htslib.org
+.. _BCFtools: https://www.htslib.org
+.. _Pandas: https://pandas.pydata.org
+.. _Miniconda: https://conda.pydata.org/miniconda.html
+.. _Conda: https://conda.pydata.org
+.. _Bash: https://www.tldp.org/LDP/Bash-Beginners-Guide/html
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
-.. _Graphviz: http://www.graphviz.org
+.. _Graphviz: https://www.graphviz.org
 .. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
-.. _JSON: http://json.org
-.. _YAML: http://yaml.org
-.. _DRMAA: http://www.drmaa.org
+.. _JSON: https://json.org
+.. _YAML: https://yaml.org
+.. _DRMAA: https://www.drmaa.org
 .. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
-.. _PyYAML: http://pyyaml.org
+.. _PyYAML: https://pyyaml.org
 .. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com
-.. _Blogpost: http://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
-.. _slides: http://slides.com/johanneskoester/deck-1
+.. _Blogpost: https://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
+.. _slides: https://slides.com/johanneskoester/deck-1
 
 In the following, we introduce some features that are beyond the scope of above example workflow.
 For details and even more features, see :ref:`user_manual-writing_snakefiles`, :ref:`project_info-faq` and the command line help (``snakemake --help``).
@@ -144,7 +144,7 @@ When Snakemake is executed with
 
 it will automatically create required environments and
 activate them before a job is executed.
-It is best practice to specify at least the `major and minor version <http://semver.org/>`_ of any packages
+It is best practice to specify at least the `major and minor version <https://semver.org/>`_ of any packages
 in the environment definition. Specifying environments per rule in this way has two
 advantages.
 First, the workflow definition also documents all used software versions.

--- a/docs/tutorial/advanced.rst
+++ b/docs/tutorial/advanced.rst
@@ -6,32 +6,32 @@ Advanced: Decorating the example workflow
 .. _Snakemake: https://snakemake.readthedocs.io
 .. _Snakemake homepage: https://snakemake.readthedocs.io
 .. _GNU Make: https://www.gnu.org/software/make
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org
 .. _BWA: http://bio-bwa.sourceforge.net
-.. _SAMtools: http://www.htslib.org
-.. _BCFtools: http://www.htslib.org
-.. _Pandas: http://pandas.pydata.org
-.. _Miniconda: http://conda.pydata.org/miniconda.html
-.. _Conda: http://conda.pydata.org
-.. _Bash: http://www.tldp.org/LDP/Bash-Beginners-Guide/html
+.. _SAMtools: https://www.htslib.org
+.. _BCFtools: https://www.htslib.org
+.. _Pandas: https://pandas.pydata.org
+.. _Miniconda: https://conda.pydata.org/miniconda.html
+.. _Conda: https://conda.pydata.org
+.. _Bash: https://www.tldp.org/LDP/Bash-Beginners-Guide/html
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
-.. _Graphviz: http://www.graphviz.org
+.. _Graphviz: https://www.graphviz.org
 .. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
-.. _JSON: http://json.org
-.. _YAML: http://yaml.org
-.. _DRMAA: http://www.drmaa.org
+.. _JSON: https://json.org
+.. _YAML: https://yaml.org
+.. _DRMAA: https://www.drmaa.org
 .. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
-.. _PyYAML: http://pyyaml.org
+.. _PyYAML: https://pyyaml.org
 .. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com
-.. _Blogpost: http://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
-.. _slides: http://slides.com/johanneskoester/deck-1
+.. _Blogpost: https://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
+.. _slides: https://slides.com/johanneskoester/deck-1
 
 Now that the basic concepts of Snakemake have been illustrated, we can introduce advanced topics.
 

--- a/docs/tutorial/advanced.rst
+++ b/docs/tutorial/advanced.rst
@@ -17,16 +17,16 @@ Advanced: Decorating the example workflow
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
 .. _Graphviz: http://www.graphviz.org
-.. _RestructuredText: http://docutils.sourceforge.net/rst.html
+.. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
 .. _JSON: http://json.org
 .. _YAML: http://yaml.org
 .. _DRMAA: http://www.drmaa.org
-.. _rpy2: http://rpy.sourceforge.net
+.. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
 .. _PyYAML: http://pyyaml.org
-.. _Docutils: http://docutils.sourceforge.net
+.. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com

--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -6,32 +6,32 @@ Basics: An example workflow
 .. _Snakemake: https://snakemake.readthedocs.io
 .. _Snakemake homepage: https://snakemake.readthedocs.io
 .. _GNU Make: https://www.gnu.org/software/make
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org
 .. _BWA: http://bio-bwa.sourceforge.net
-.. _SAMtools: http://www.htslib.org
-.. _BCFtools: http://www.htslib.org
-.. _Pandas: http://pandas.pydata.org
-.. _Miniconda: http://conda.pydata.org/miniconda.html
-.. _Conda: http://conda.pydata.org
-.. _Bash: http://www.tldp.org/LDP/Bash-Beginners-Guide/html
+.. _SAMtools: https://www.htslib.org
+.. _BCFtools: https://www.htslib.org
+.. _Pandas: https://pandas.pydata.org
+.. _Miniconda: https://conda.pydata.org/miniconda.html
+.. _Conda: https://conda.pydata.org
+.. _Bash: https://www.tldp.org/LDP/Bash-Beginners-Guide/html
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
-.. _Graphviz: http://www.graphviz.org
+.. _Graphviz: https://www.graphviz.org
 .. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
-.. _JSON: http://json.org
-.. _YAML: http://yaml.org
-.. _DRMAA: http://www.drmaa.org
+.. _JSON: https://json.org
+.. _YAML: https://yaml.org
+.. _DRMAA: https://www.drmaa.org
 .. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
-.. _PyYAML: http://pyyaml.org
+.. _PyYAML: https://pyyaml.org
 .. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com
-.. _Blogpost: http://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
-.. _slides: http://slides.com/johanneskoester/deck-1
+.. _Blogpost: https://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
+.. _slides: https://slides.com/johanneskoester/deck-1
 
 Please make sure that you have **activated** the environment we created before, and that you have an open terminal in the working directory you have created.
 

--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -17,16 +17,16 @@ Basics: An example workflow
 .. _Atom: https://atom.io
 .. _Anaconda: https://anaconda.org
 .. _Graphviz: http://www.graphviz.org
-.. _RestructuredText: http://docutils.sourceforge.net/rst.html
+.. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 .. _data URI: https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
 .. _JSON: http://json.org
 .. _YAML: http://yaml.org
 .. _DRMAA: http://www.drmaa.org
-.. _rpy2: http://rpy.sourceforge.net
+.. _rpy2: https://rpy2.github.io
 .. _R: https://www.r-project.org
 .. _Rscript: https://stat.ethz.ch/R-manual/R-devel/library/utils/html/Rscript.html
 .. _PyYAML: http://pyyaml.org
-.. _Docutils: http://docutils.sourceforge.net
+.. _Docutils: https://docutils.sourceforge.io
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com

--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -4,20 +4,20 @@
 Setup
 -----
 
-.. _Snakemake: http://snakemake.readthedocs.io
-.. _Snakemake homepage: http://snakemake.readthedocs.io
+.. _Snakemake: https://snakemake.readthedocs.io
+.. _Snakemake homepage: https://snakemake.readthedocs.io
 .. _GNU Make: https://www.gnu.org/software/make
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org
 .. _BWA: http://bio-bwa.sourceforge.net
-.. _SAMtools: http://www.htslib.org
-.. _BCFtools: http://www.htslib.org
-.. _Pandas: http://pandas.pydata.org
-.. _Miniconda: http://conda.pydata.org/miniconda.html
-.. _Conda: http://conda.pydata.org
-.. _Bash: http://www.tldp.org/LDP/Bash-Beginners-Guide/html
+.. _SAMtools: https://www.htslib.org
+.. _BCFtools: https://www.htslib.org
+.. _Pandas: https://pandas.pydata.org
+.. _Miniconda: https://conda.pydata.org/miniconda.html
+.. _Conda: https://conda.pydata.org
+.. _Bash: https://www.tldp.org/LDP/Bash-Beginners-Guide/html
 .. _Atom: https://atom.io
-.. _Graphviz: http://www.graphviz.org
-.. _PyYAML: http://pyyaml.org
+.. _Graphviz: https://www.graphviz.org
+.. _PyYAML: https://pyyaml.org
 .. _Docutils: https://docutils.sourceforge.io
 .. _Jinja2: https://jinja.palletsprojects.com
 .. _NetworkX: https://networkx.github.io
@@ -26,7 +26,7 @@ Setup
 .. _Bioconda: https://bioconda.github.io
 .. _Vagrant: https://www.vagrantup.com
 .. _Vagrant Documentation: https://docs.vagrantup.com
-.. _Blogpost: http://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
+.. _Blogpost: https://blog.osteel.me/posts/2015/01/25/how-to-use-vagrant-on-windows.html
 
 Requirements
 ::::::::::::

--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -18,8 +18,8 @@ Setup
 .. _Atom: https://atom.io
 .. _Graphviz: http://www.graphviz.org
 .. _PyYAML: http://pyyaml.org
-.. _Docutils: http://docutils.sourceforge.net
-.. _Jinja2: http://jinja.pocoo.org
+.. _Docutils: https://docutils.sourceforge.io
+.. _Jinja2: https://jinja.palletsprojects.com
 .. _NetworkX: https://networkx.github.io
 .. _Matplotlib: https://matplotlib.org
 .. _Pysam: https://pysam.readthedocs.io

--- a/docs/tutorial/short.rst
+++ b/docs/tutorial/short.rst
@@ -184,12 +184,12 @@ variants. First, we define a variable
 at the top of the ``Snakefile``. This serves as a definition of the
 samples over which we would want to aggregate. In real life, you would
 want to use an external sample sheet or a `config
-file <http://snakemake.readthedocs.io/en/stable/tutorial/advanced.html#step-2-config-files>`__
+file <https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html#step-2-config-files>`__
 for things like this.
 
 For aggregation over many files, Snakemake provides the helper function
 ``expand`` (see `the
-docs <http://snakemake.readthedocs.io/en/stable/tutorial/basics.html#step-5-calling-genomic-variants>`__).
+docs <https://snakemake.readthedocs.io/en/stable/tutorial/basics.html#step-5-calling-genomic-variants>`__).
 Create a rule ``call`` with input files
 
 -  ``fa="data/genome.fa"``

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -4,10 +4,10 @@
 Snakemake Tutorial
 ==================
 
-.. _Snakemake: http://snakemake.readthedocs.io
+.. _Snakemake: https://snakemake.readthedocs.io
 .. _GNU Make: https://www.gnu.org/software/make
-.. _Python: http://www.python.org
-.. _slides: http://slides.com/johanneskoester/snakemake-tutorial
+.. _Python: https://www.python.org
+.. _slides: https://slides.com/johanneskoester/snakemake-tutorial
 .. _Conda: https://conda.io
 .. _Singularity: https://www.sylabs.io
 

--- a/snakemake/gui.html
+++ b/snakemake/gui.html
@@ -2,13 +2,13 @@
 <html lang="en">
     <head>
         <title>Snakemake</title>
-        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.6/d3.min.js"></script>
-        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
-        <script type="text/javascript" src="http://cpettitt.github.io/project/dagre-d3/v0.1.5/dagre-d3.js"></script>
-        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.5.4/bootstrap-select.min.js"></script>
-        <link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css"/>
-        <link rel="stylesheet" type="text/css" href="http://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.5.4/bootstrap-select.min.css"/>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.6/d3.min.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/js/bootstrap.min.js"></script>
+        <script type="text/javascript" src="https://cpettitt.github.io/project/dagre-d3/v0.1.5/dagre-d3.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.5.4/bootstrap-select.min.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.1.1/css/bootstrap.min.css"/>
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.5.4/bootstrap-select.min.css"/>
         <style>
         body {
           font-family: sans-serif;

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1355,7 +1355,7 @@ def _load_configfile(configpath, filetype="Config"):
             except ValueError:
                 f.seek(0)  # try again
             try:
-                # From http://stackoverflow.com/a/21912744/84349
+                # From https://stackoverflow.com/a/21912744/84349
                 class OrderedLoader(yaml.Loader):
                     pass
 

--- a/snakemake/remote/NCBI.py
+++ b/snakemake/remote/NCBI.py
@@ -443,7 +443,7 @@ class NCBIHelper(object):
     def parse_accession_str(self, id_str):
         """
             This tries to match an NCBI accession as defined here:
-                http://www.ncbi.nlm.nih.gov/Sequin/acc.html
+                https://www.ncbi.nlm.nih.gov/Sequin/acc.html
         """
         m = re.search(
             r"(?P<accession>(?:[a-zA-Z]{1,6}|NW_|NC_|NM_|NR_)\d{1,10})(?:\.(?P<version>\d+))?(?:\.(?P<file_ext>\S+))?.*",
@@ -467,7 +467,7 @@ class NCBIHelper(object):
 
     @staticmethod
     def _seq_chunks(seq, n):
-        # http://stackoverflow.com/a/312464/190597 (Ned Batchelder)
+        # https://stackoverflow.com/a/312464/190597 (Ned Batchelder)
         """ Yield successive n-sized chunks from seq."""
         for i in range(0, len(seq), n):
             yield seq[i : i + n]

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -31,10 +31,10 @@ def validate(data, schema, set_default=True):
         schema (str): Path to JSON schema used for validation. The schema can also be
             in YAML format. If validating a pandas data frame, the schema has to
             describe a row record (i.e., a dict with column names as keys pointing
-            to row values). See http://json-schema.org. The path is interpreted
+            to row values). See https://json-schema.org. The path is interpreted
             relative to the Snakefile when this function is called.
         set_default (bool): set default values defined in schema. See
-            http://python-jsonschema.readthedocs.io/en/latest/faq/ for more
+            https://python-jsonschema.readthedocs.io/en/latest/faq/ for more
             information
     """
     try:
@@ -61,7 +61,7 @@ def validate(data, schema, set_default=True):
         handlers={"file": lambda uri: _load_configfile(re.sub("^file://", "", uri))},
     )
 
-    # Taken from http://python-jsonschema.readthedocs.io/en/latest/faq/
+    # Taken from https://python-jsonschema.readthedocs.io/en/latest/faq/
     def extend_with_default(validator_class):
         validate_properties = validator_class.VALIDATORS["properties"]
 
@@ -450,7 +450,7 @@ def update_config(config, overwrite_config):
     """Recursively update dictionary config with overwrite_config.
 
     See
-    http://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
+    https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth
     for details.
 
     Args:
@@ -477,7 +477,7 @@ def available_cpu_count():
     when the cpuset(7) mechanism is in use, as is the case on some cluster
     systems.
 
-    Adapted from http://stackoverflow.com/a/1006301/715090
+    Adapted from https://stackoverflow.com/a/1006301/715090
     """
     try:
         with open("/proc/self/status") as f:

--- a/versioneer.py
+++ b/versioneer.py
@@ -1752,7 +1752,7 @@ def do_setup():
     except EnvironmentError:
         pass
     # That doesn't cover everything MANIFEST.in can do
-    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # (https://docs.python.org/2/distutils/sourcedist.html#commands), so
     # it might give some false negatives. Appending redundant 'include'
     # lines is safe, though.
     if "versioneer.py" not in simple_includes:


### PR DESCRIPTION
and fix at least one broken link found while checking.

bio-bwa.sourceforge.net, melpa.milkbox.net and redsymbol.net were excluded because they do not work in HTTPS.

The following links were found to be broken (in both http and https) and currently lack replacements:
http://toolkit.globus.org/toolkit/docs/latest-stable/gridftp/user/#globus-url-copy
http://watson.nci.nih.gov/~sdavis/blog/flexible_bioinformatics_pipelines_with_snakemake/