### PR TITLE
Allow resources to be strings

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -307,7 +307,7 @@ the scheduler will ensure that the given resources are not exceeded by running j
 If no limits are given, the resources are ignored in local execution.
 In cluster or cloud execution, resources are always passed to the backend, even if ``--resources`` is not specified.
 Apart from making Snakemake aware of hybrid-computing architectures (e.g. with a limited number of additional devices like GPUs) this allows us to control scheduling in various ways, e.g. to limit IO-heavy jobs by assigning an artificial IO-resource to them and limiting it via the ``--resources`` flag.
-Resources must be ``int`` values.
+Resources must be ``int`` or ``str`` values.
 
 Note that you are free to choose any names for the given resources.
 There are two **standard resources** for memory and disk usage though: ``mem_mb`` and ``disk_mb``.

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -914,10 +914,10 @@ def get_argument_parser(profile=None):
         help=(
             "Define additional resources that shall constrain the scheduling "
             "analogously to threads (see above). A resource is defined as "
-            "a name and an integer value. E.g. --resources gpu=1. Rules can "
+            "a name and an integer value. E.g. --resources mem_mb=1000. Rules can "
             "use resources by defining the resource keyword, e.g. "
-            "resources: gpu=1. If now two rules require 1 of the resource "
-            "'gpu' they won't be run in parallel by the scheduler."
+            "resources: mem_mb=600. If now two rules require 600 of the resource "
+            "'mem_mb' they won't be run in parallel by the scheduler."
         ),
     )
     group_exec.add_argument(

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -85,10 +85,12 @@ class AbstractExecutor:
 
     def get_default_resources_args(self):
         if self.workflow.default_resources.args is not None:
+
             def fmt(res):
                 if isinstance(res, str):
-                    res = res.replace('"', r'\"')
+                    res = res.replace('"', r"\"")
                 return '"{}"'.format(res)
+
             args = " --default-resources {} ".format(
                 " ".join(map(fmt, self.workflow.default_resources.args))
             )

--- a/snakemake/executors.py
+++ b/snakemake/executors.py
@@ -85,8 +85,12 @@ class AbstractExecutor:
 
     def get_default_resources_args(self):
         if self.workflow.default_resources.args is not None:
+            def fmt(res):
+                if isinstance(res, str):
+                    res = res.replace('"', r'\"')
+                return '"{}"'.format(res)
             args = " --default-resources {} ".format(
-                " ".join(map('"{}"'.format, self.workflow.default_resources.args))
+                " ".join(map(fmt, self.workflow.default_resources.args))
             )
             return args
         return ""

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -959,11 +959,12 @@ class Rule:
                 except e:
                     raise InputFunctionException(e, rule=self, wildcards=wildcards)
 
-                if not isinstance(res, int):
+                if not isinstance(res, int) and not isinstance(res, str):
                     raise WorkflowError(
-                        "Resources function did not return int.", rule=self
+                        "Resources function did not return int or str.", rule=self
                     )
-            res = min(self.workflow.global_resources.get(name, res), res)
+            if isinstance(res, int):
+                res = min(self.workflow.global_resources.get(name, res), res)
             return res
 
         threads = apply("_cores", self.resources["_cores"])

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -956,7 +956,7 @@ class Rule:
                             res = TBDInt(0)
                         else:
                             raise e
-                except e:
+                except (Exception, BaseException) as e:
                     raise InputFunctionException(e, rule=self, wildcards=wildcards)
 
                 if not isinstance(res, int) and not isinstance(res, str):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1104,10 +1104,16 @@ class Workflow:
                 if args:
                     raise RuleException("Resources have to be named.")
                 if not all(
-                    map(lambda r: isinstance(r, int) or isinstance(r, str) or callable(r), resources.values())
+                    map(
+                        lambda r: isinstance(r, int)
+                        or isinstance(r, str)
+                        or callable(r),
+                        resources.values(),
+                    )
                 ):
                     raise RuleException(
-                        "Resources values have to be integers, strings, or callables (functions)", rule=rule
+                        "Resources values have to be integers, strings, or callables (functions)",
+                        rule=rule,
                     )
                 rule.resources.update(resources)
             if ruleinfo.priority:

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1104,10 +1104,10 @@ class Workflow:
                 if args:
                     raise RuleException("Resources have to be named.")
                 if not all(
-                    map(lambda r: isinstance(r, int) or callable(r), resources.values())
+                    map(lambda r: isinstance(r, int) or isinstance(r, str) or callable(r), resources.values())
                 ):
                     raise RuleException(
-                        "Resources values have to be integers or callables", rule=rule
+                        "Resources values have to be integers, strings, or callables (functions)", rule=rule
                     )
                 rule.resources.update(resources)
             if ruleinfo.priority:

--- a/tests/test_string_resources/Snakefile
+++ b/tests/test_string_resources/Snakefile
@@ -1,0 +1,7 @@
+rule a:
+    output:
+        "test.txt"
+    resources:
+        gpu_model="nvidia-tesla-p100"
+    shell:
+        "echo {resources.gpu_model} > {output}"

--- a/tests/test_string_resources/Snakefile
+++ b/tests/test_string_resources/Snakefile
@@ -1,3 +1,11 @@
+rule b:
+    input:
+        "test.txt"
+    output:
+        "test2.txt"
+    shell:
+        "echo {resources.gpu_model} > {output}"
+
 rule a:
     output:
         "test.txt"

--- a/tests/test_string_resources/expected-results/test.txt
+++ b/tests/test_string_resources/expected-results/test.txt
@@ -1,0 +1,1 @@
+nvidia-tesla-p100

--- a/tests/test_string_resources/expected-results/test2.txt
+++ b/tests/test_string_resources/expected-results/test2.txt
@@ -1,0 +1,1 @@
+nvidia-tesla-1000

--- a/tests/test_string_resources/qsub.py
+++ b/tests/test_string_resources/qsub.py
@@ -7,7 +7,11 @@ from snakemake.utils import read_job_properties
 
 jobscript = sys.argv[1]
 job_properties = read_job_properties(jobscript)
-assert job_properties["resources"]["gpu_model"] == "nvidia-tesla-p100"
+
+expected_model = "nvidia-tesla-p100" if job_properties["rule"] == "a" else "nvidia-tesla-1000"
+print(job_properties)
+
+assert job_properties["resources"]["gpu_model"] == expected_model
 with open("qsub.log", "a") as log:
     print(job_properties, file=log)
 

--- a/tests/test_string_resources/qsub.py
+++ b/tests/test_string_resources/qsub.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import sys
+import os
+import random
+
+from snakemake.utils import read_job_properties
+
+jobscript = sys.argv[1]
+job_properties = read_job_properties(jobscript)
+assert job_properties["resources"]["gpu_model"] == "nvidia-tesla-p100"
+with open("qsub.log", "a") as log:
+    print(job_properties, file=log)
+
+print(random.randint(1, 100))
+os.system("sh {}".format(jobscript))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1003,3 +1003,12 @@ def test_linting():
     snakemake(
         snakefile=os.path.join(dpath("test14"), "Snakefile.nonstandard"), lint=True
     )
+
+
+def test_string_resources():
+    from snakemake.resources import DefaultResources
+    run(
+        dpath("test_string_resources"),
+        default_resources=DefaultResources(["gpu_model='nvidia-tesla-1000'"]),
+        cluster="./qsub.py",
+    )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1007,6 +1007,7 @@ def test_linting():
 
 def test_string_resources():
     from snakemake.resources import DefaultResources
+
     run(
         dpath("test_string_resources"),
         default_resources=DefaultResources(["gpu_model='nvidia-tesla-1000'"]),


### PR DESCRIPTION
This PR introduces string resources, e.g.

```
rule do_something:
    output:
        "test.txt"
    resources:
        gpu_model="nvidia-tesla-p100"
    shell:
        "some-cuda-tool {output}"
```