### PR TITLE
Add caveats for checkpoints to docs

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1349,4 +1349,8 @@ Upon completion of the checkpoint, the input function is re-evaluated, and the c
 Here, we retrieve the values of the wildcard ``i`` based on all files named ``{i}.txt`` in the output directory of the checkpoint.
 These values are then used to expand the pattern ``"post/{sample}/{i}.txt"``, such that the rule ``intermediate`` is executed for each of the determined clusters.
 
+While input file functions using checkpoints can technically return a dictionary for use with ``unpack()``, you will not be able to refer to a specific input file in the ``shell`` directive (*e.g.* ``{input.somefile}``).
+Also, because the ``get`` method throws ``snakemake.exceptions.IncompleteCheckpointException``, rules depending directly on checkpoints via input file functions will never be run in situations where they are ambiguous (provided that ambiguous rules are :ref:`allowed <snakefiles-ambiguous-rules>`).
+This behaviour is due to the fact that Snakemake will defer to alternate rules if an exception is raised during the execution of an input file function.
+
 This mechanism can be used to replace the use of the :ref:`dynamic-flag <snakefiles-dynamic_files>` which will be deprecated in Snakemake 6.0.


### PR DESCRIPTION
I ran into two limitations of checkpoints that took me a while to debug, so I'm submitting this PR to clarify the documentation. 

I'm curious to know if @johanneskoester thinks this is the expected behaviour. Regardless if it is, should these use cases should be supported? If so, let me know and I can open separate issues. 

Thanks for the amazing tool, @johanneskoester! 

