### PR TITLE
updating sys.maxsize to os.cpu_count() for number cores

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -335,7 +335,7 @@ def snakemake(
         updated_files = list()
 
     if cluster or cluster_sync or drmaa or tibanna:
-        cores = sys.maxsize
+        cores = os.cpu_count()
     else:
         nodes = sys.maxsize
 


### PR DESCRIPTION
this commit will fix issue #213, namely that we should use os.cpu_count() to get the max number of cores and not sys.maxsize. The reason, as stated in the issue, is that sys.maxsize reflects the maximum pointer size and not the maximum number of cores. Locally on my machine I can verify this:

```python
import os
import sys

os.cpu_count()                                                                                                                                                           
# 8
sys.maxsize                                                                                                                                                              
# 9223372036854775807
```

Signed-off-by: vsoch <vsochat@stanford.edu>