### PR TITLE
Assign nodes resources to groups.

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1173,6 +1173,7 @@ class GroupJob(AbstractJob):
     def resources(self):
         if self._resources is None:
             self._resources = defaultdict(int)
+            self._resources["_nodes"] = 1
             pipe_group = any([job.is_pipe for job in self.jobs])
             # iterate over siblings that can be executed in parallel
             for siblings in self.toposorted:


### PR DESCRIPTION
We are running a large DAG with a lot of groups on SLURM, and I noticed with some additional output that the scheduler only subtracts the core/thread count from the `_cores` resource. Thus if we attempt to throttle our submissions of 100 parallel, "ready" groups to the queue with e.g. `--jobs 20`, Snakemake will submit all 100 groups, even though there is a global `_nodes = 20` resource maximum.

This is our hotfix that assigns a resource of 1 node to each group. In non-cluster mode, I don't think this should have an effect, as I see that the global `_nodes` resource is set to max int.