### PR TITLE
🐛 Fix bug to work with git submodules

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -277,7 +277,7 @@ class Workflow:
         # TODO allow a manifest file as alternative
         try:
             out = subprocess.check_output(
-                ["git", "ls-files", "."], stderr=subprocess.PIPE
+                ["git", "ls-files", "--recurse-submodules", "."], stderr=subprocess.PIPE
             )
             for f in out.decode().split("\n"):
                 if f:


### PR DESCRIPTION
When working with Kubernetes, files returned by "git ls-files" will be deemed as source files and then uploaded to Kubernetes pods as secrets.

However, if the working directory is a git repository with submodules(https://git-scm.com/book/en/v2/Git-Tools-Submodules), the submodule directory will be returned by "git ls-files" as well, but it's a directory rather than a regular file, so previously snakemake may fail. It has something to do with the this line of code: https://github.com/snakemake/snakemake/blob/v5.15.0/snakemake/workflow.py#L274

The bug can be fixed simply by adding `--recurse-submodules` to the git command (https://git-scm.com/docs/git-ls-files#Documentation/git-ls-files.txt---recurse-submodules).

--------

### Bug description

Version: snakemake v5.15.0

Scenario: call snakemake from a git directory which contains a submodule named `src`, as the following `.git/config` shows:

```
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
        ignorecase = true
        precomposeunicode = true
[user]
        name = Haizi Zheng
        email = haizi.zheng@cchmc.org
        signingkey = 47CD602B2A8FBF9BBCBDEE9CC615658DA91285E4
[commit]
        gpgsign = true
[remote "origin"]
        url = git@bitbucket.org:haizi-zh/cofrag.git
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
        remote = origin
        merge = refs/heads/master
[submodule "src"]
        url = git@bitbucket.org:epifluidlab/cfhic.git
        active = true
```

If invoke snakemake as the following: 

```
snakemake --kubernetes snakemake --container-image zephyre/comp-bio:v0.3.4 -j 480 --default-remote-provider S3 --default-remote-prefix cofrag.epifluidlab.cchmc.org -s distance_matrix.smk -p
```

The following error will occur:

```
Traceback (most recent call last):
  File "/Users/haizi/miniconda3/envs/comp-bio/lib/python3.7/site-packages/snakemake/__init__.py", line 654, in snakemake
    keepincomplete=keep_incomplete,
  File "/Users/haizi/miniconda3/envs/comp-bio/lib/python3.7/site-packages/snakemake/workflow.py", line 842, in execute
    keepincomplete=keepincomplete,
  File "/Users/haizi/miniconda3/envs/comp-bio/lib/python3.7/site-packages/snakemake/scheduler.py", line 229, in __init__
    keepincomplete=keepincomplete,
  File "/Users/haizi/miniconda3/envs/comp-bio/lib/python3.7/site-packages/snakemake/executors.py", line 1395, in __init__
    self.register_secret()
  File "/Users/haizi/miniconda3/envs/comp-bio/lib/python3.7/site-packages/snakemake/executors.py", line 1414, in register_secret
    with open(f, "br") as content:
IsADirectoryError: [Errno 21] Is a directory: 'src'
```