### PR TITLE
Fix security hole in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV PATH /opt/conda/bin:${PATH}
 ENV LANG C.UTF-8
 ENV SHELL /bin/bash
 RUN /bin/bash -c "install_packages wget bzip2 ca-certificates gnupg2 squashfs-tools git && \
-    wget -O- http://neuro.debian.net/lists/xenial.us-ca.full > /etc/apt/sources.list.d/neurodebian.sources.list && \
-    wget -O- http://neuro.debian.net/_static/neuro.debian.net.asc | apt-key add - && \
+    wget -O- https://neuro.debian.net/lists/xenial.us-ca.full > /etc/apt/sources.list.d/neurodebian.sources.list && \
+    wget -O- https://neuro.debian.net/_static/neuro.debian.net.asc | apt-key add - && \
     install_packages singularity-container && \
     wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \

--- a/examples/c/README.txt
+++ b/examples/c/README.txt
@@ -1,1 +1,1 @@
-http://www.cs.colby.edu/maxwell/courses/tutorials/maketutor/
+https://www.cs.colby.edu/maxwell/courses/tutorials/maketutor/


### PR DESCRIPTION
(I attempted to report this privately, to no response.  Maybe a spam filter blocked it??)

snakemake's Dockerfile uses `wget -O- http://neuro.debian.net/...` to obtain the Neurodebian repository key and address, then uses them to install the singularity-container package.  As http:// is insecure against malicious modification, this is a remote code execution (inside the container) security hole.

The first commit fixes this by using https instead; the second changes an (unrelated and not such a problem, but might as well while we're thinking about it) link to https.

Not addressed here but maybe something to think about: you seem to be using Neurodebian xenial on top of base stretch, which is both mismatched (Ubuntu vs Debian) and old (2016-7).