### PR TITLE
Replace Docker build badge with GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Sonarcloud Status](https://sonarcloud.io/api/project_badges/measure?project=snakemake_snakemake&metric=alert_status)](https://sonarcloud.io/dashboard?id=snakemake_snakemake)
 [![Bioconda](https://img.shields.io/conda/dn/bioconda/snakemake.svg?label=Bioconda)](https://bioconda.github.io/recipes/snakemake/README.html)
 [![Pypi](https://img.shields.io/pypi/pyversions/snakemake.svg)](https://pypi.org/project/snakemake)
-[![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/snakemake/snakemake)](https://hub.docker.com/r/snakemake/snakemake)
+[![Publish to Docker Hub](https://github.com/snakemake/snakemake/workflows/Publish%20to%20Docker%20Hub/badge.svg?branch=master)](https://hub.docker.com/r/snakemake/snakemake)
 [![Stack Overflow](https://img.shields.io/badge/stack-overflow-orange.svg)](https://stackoverflow.com/questions/tagged/snakemake)
 [![Twitter](https://img.shields.io/twitter/follow/johanneskoester.svg?style=social&label=Follow)](https://twitter.com/search?l=&q=%23snakemake%20from%3Ajohanneskoester)
 [![Github stars](https://img.shields.io/github/stars/snakemake/snakemake?style=social)](https://github.com/snakemake/snakemake/stargazers)


### PR DESCRIPTION
This PR updates the Docker build README status badge to the "Publish to Docker Hub" GitHub Action. The badge link still points to Docker Hub itself.