### PR TITLE
Fix race condition.

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -664,8 +664,6 @@ class DAG:
                     logger.info("Removing local output file: {}".format(f))
                     f.remove()
 
-            job.rmdir_empty_remote_dirs()
-
     def jobid(self, job):
         """Return job id of given job."""
         if job.is_group():

--- a/snakemake/remote/S3.py
+++ b/snakemake/remote/S3.py
@@ -289,7 +289,7 @@ class S3Helper(object):
                     )
             return destination_path
         except:
-            return None
+            raise S3FileException("Error downloading file '%s' from bucket '%s'." % (key, bucket_name))
 
     def delete_from_bucket(self, bucket_name, key):
         """ Delete a file from s3

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -936,6 +936,9 @@ class Workflow:
 
         success = scheduler.schedule()
 
+        for job in dag.jobs:
+            job.rmdir_empty_remote_dirs()
+
         if success:
             if dryrun:
                 if len(dag):


### PR DESCRIPTION
Solves the issue where a directory would be removed prematurely
if multiple files are downloaded from the same key hierarchy on S3,
in multiple concurrent jobs.  This commit also fixes
https://github.com/snakemake/snakemake/issues/404 where S3 exceptions
were silently ignored.