### PR TITLE
changed --edit-notebook to use default_url instead

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -61,11 +61,14 @@ class JupyterNotebook(ScriptBase):
             fname_out = os.path.join(os.getcwd(), fname_out)
             output_parameter = "--output {fname_out:q}"
 
+        #get url relative to cwd
+        notebook_url = os.path.join(os.sep,'tree',os.path.relpath(fname))
+
         if edit is not None:
             logger.info("Opening notebook for editing.")
             cmd = (
                 "jupyter notebook --no-browser --log-level ERROR --ip {edit.ip} --port {edit.port} "
-                "--NotebookApp.quit_button=True {{fname:q}}".format(edit=edit)
+                "--NotebookApp.quit_button=True --NotebookApp.default_url={notebook_url}".format(edit=edit,notebook_url=notebook_url)
             )
         else:
             cmd = (

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -68,7 +68,8 @@ class JupyterNotebook(ScriptBase):
             logger.info("Opening notebook for editing.")
             cmd = (
                 "jupyter notebook --no-browser --log-level ERROR --ip {edit.ip} --port {edit.port} "
-                "--NotebookApp.quit_button=True --NotebookApp.default_url={notebook_url}".format(edit=edit,notebook_url=notebook_url)
+                "--NotebookApp.default_url={notebook_url} "
+                "--NotebookApp.quit_button=True".format(edit=edit,notebook_url=notebook_url)
             )
         else:
             cmd = (


### PR DESCRIPTION
Passing the ipynb notebook as a positional argument forces the browser to open, even if `--no-browser` is used. By using` --NotebookApp.default_url` this does not happen. However, there does not seem to be a way to quit the notebook from the browser if this alternative is used. Any other suggestions? 