### PR TITLE
generalization of multiext output

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -970,13 +970,13 @@ def expand(*args, **wildcards):
 
 
 def multiext(prefix, *extensions):
-    """Expand a given prefix with multiple extensions (e.g. .txt, .csv, ...)."""
+    """Expand a given prefix with multiple extensions (e.g. .txt, .csv, _peaks.bed, ...)."""
     if any(
-        (r"/" in ext or r"\\" in ext or not ext.startswith(".")) for ext in extensions
+        (r"/" in ext or r"\\" in ext) for ext in extensions
     ):
         raise WorkflowError(
             r"Extensions for multiext may not contain path delimiters "
-            r"(/,\) and must start with '.' (e.g. .txt)."
+            r"(/,\)."
         )
     return [flag(prefix + ext, "multiext", flag_value=prefix) for ext in extensions]
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -971,12 +971,9 @@ def expand(*args, **wildcards):
 
 def multiext(prefix, *extensions):
     """Expand a given prefix with multiple extensions (e.g. .txt, .csv, _peaks.bed, ...)."""
-    if any(
-        (r"/" in ext or r"\\" in ext) for ext in extensions
-    ):
+    if any((r"/" in ext or r"\\" in ext) for ext in extensions):
         raise WorkflowError(
-            r"Extensions for multiext may not contain path delimiters "
-            r"(/,\)."
+            r"Extensions for multiext may not contain path delimiters " r"(/,\)."
         )
     return [flag(prefix + ext, "multiext", flag_value=prefix) for ext in extensions]
 

--- a/tests/test_multiext/Snakefile
+++ b/tests/test_multiext/Snakefile
@@ -1,5 +1,5 @@
 rule a:
     output:
-        multiext("ref/genome", ".ann", ".bwt", ".sa")
+        multiext("ref/genome", ".ann", ".bwt", ".sa", "_test.fai")
     shell:
         "touch {output}"


### PR DESCRIPTION
Generalization of the `multiext()` command. Allow extensions to start with different characters, not only with `.` .

Example (to catch multiple output files from `macs2 callpeak`):
`output:
    multiext("peaks/{sample}", "_peaks.xls", "_narrowPeaks.peak", "_model.R")`