### PR TITLE
unlock before building DAG

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -648,6 +648,14 @@ class Workflow:
                     "you don't have the permissions?"
                 )
                 return False
+
+        logger.info("Building DAG of jobs...")
+        dag.init()
+        dag.update_checkpoint_dependencies()
+        # check incomplete has to run BEFORE any call to postprocess
+        dag.check_incomplete()
+        dag.check_dynamic()
+
         try:
             self.persistence.lock()
         except IOError:
@@ -662,13 +670,6 @@ class Workflow:
                 "the --unlock argument.".format(os.getcwd())
             )
             return False
-
-        logger.info("Building DAG of jobs...")
-        dag.init()
-        dag.update_checkpoint_dependencies()
-        # check incomplete has to run BEFORE any call to postprocess
-        dag.check_incomplete()
-        dag.check_dynamic()
 
         if cleanup_shadow:
             self.persistence.cleanup_shadow()

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -637,13 +637,6 @@ class Workflow:
                 self.persistence.cleanup_metadata(f)
             return True
 
-        logger.info("Building DAG of jobs...")
-        dag.init()
-        dag.update_checkpoint_dependencies()
-        # check incomplete has to run BEFORE any call to postprocess
-        dag.check_incomplete()
-        dag.check_dynamic()
-
         if unlock:
             try:
                 self.persistence.cleanup_locks()
@@ -669,6 +662,13 @@ class Workflow:
                 "the --unlock argument.".format(os.getcwd())
             )
             return False
+
+        logger.info("Building DAG of jobs...")
+        dag.init()
+        dag.update_checkpoint_dependencies()
+        # check incomplete has to run BEFORE any call to postprocess
+        dag.check_incomplete()
+        dag.check_dynamic()
 
         if cleanup_shadow:
             self.persistence.cleanup_shadow()


### PR DESCRIPTION
There is no reason to build a DAG if the `--unlock` argument is given.