### PR TITLE
Allow include directive to take a pathlib.Path object

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -991,6 +991,9 @@ class Workflow:
         """
         Include a snakefile.
         """
+        if isinstance(snakefile, Path):
+            snakefile = str(snakefile)
+
         # check if snakefile is a path to the filesystem
         if not urllib.parse.urlparse(snakefile).scheme:
             if not os.path.isabs(snakefile) and self.included_stack:

--- a/tests/test_multiple_includes/Snakefile
+++ b/tests/test_multiple_includes/Snakefile
@@ -1,5 +1,9 @@
+from pathlib import Path
+
+
 include: 'test_rule.smk'
 include: 'test_second_rule.smk'
+include: Path('test_third_rule.smk')
 
 rule all:
-    input: rules.test_second_rule.output
+    input: rules.test_third_rule.output

--- a/tests/test_multiple_includes/test_third_rule.smk
+++ b/tests/test_multiple_includes/test_third_rule.smk
@@ -1,0 +1,4 @@
+rule test_third_rule:
+    input: rules.test_second_rule.output
+    output: 'test3.txt'
+    shell: 'touch {output}'


### PR DESCRIPTION
This addresses #220 .

I have implemented the "easiest" solution to the problem. I tried following the issue upstream, but allowing `snakefile` to be "PathLike" would not be a simple fix I think. However, if you think there is a nicer way of implementing the ability to use `pathlib.Path` objects in `include` directives point me at the relevant code and I can make the changes.

On a side note, I noticed quite a lot of unused `import` statements. Would you like me to clean those up? (Will take one second - thank god for JetBrains/PyCharm)