### PR TITLE
Add the rule name to finished logging statement

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -393,7 +393,7 @@ class Logger:
                     self.logger.warning(indent(msg["msg"]))
             elif level == "job_finished" and not self.quiet:
                 timestamp()
-                self.logger.info("Finished job {}.".format(msg["jobid"]))
+                self.logger.info("Finished job {}: {}.".format(msg["jobid"], msg["name"]))
                 pass
             elif level == "rule_info":
                 self.logger.info(msg["name"])


### PR DESCRIPTION
I find it difficult to see what jobs finished just based on job id, so I added the name of the rule.  More info could be added, for example when running with `-p`.