### PR TITLE
Speed up job hash and equality checks

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -17,7 +17,7 @@ import uuid
 import math
 
 from snakemake.io import PeriodicityDetector, wait_for_files, is_flagged
-from snakemake.jobs import Job, Reason, GroupJob
+from snakemake.jobs import Reason, JobFactory, GroupJobFactory
 from snakemake.exceptions import MissingInputException
 from snakemake.exceptions import MissingRuleException, AmbiguousRuleException
 from snakemake.exceptions import CyclicGraphException, MissingOutputException
@@ -123,6 +123,9 @@ class DAG:
         self.container_imgs = dict()
         self._progress = 0
         self._group = dict()
+
+        self.job_factory = JobFactory()
+        self.group_job_factory = GroupJobFactory()
 
         self.forcerules = set()
         self.forcefiles = set()
@@ -995,7 +998,7 @@ class DAG:
             # BFS into depending needrun jobs if in same group
             # Note: never go up here (into depending), because it may contain
             # jobs that have been sorted out due to e.g. ruleorder.
-            group = GroupJob(
+            group = self.group_job_factory.new(
                 job.group,
                 (
                     job
@@ -1245,7 +1248,7 @@ class DAG:
             assert targetfile is not None
             return self.job_cache[key]
         wildcards_dict = rule.get_wildcards(targetfile)
-        job = Job(
+        job = self.job_factory.new(
             rule,
             self,
             wildcards_dict=wildcards_dict,

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -80,11 +80,22 @@ class JobFactory:
         self.cache = dict()
 
     def new(
-        self, rule, dag, wildcards_dict=None, format_wildcards=None, targetfile=None, update=False
+        self,
+        rule,
+        dag,
+        wildcards_dict=None,
+        format_wildcards=None,
+        targetfile=None,
+        update=False,
     ):
         if rule.is_branched:
             # for distinguishing branched rules, we need input and output in addition
-            key = (rule.name, *rule.output, *rule.input, *sorted(wildcards_dict.items()))
+            key = (
+                rule.name,
+                *rule.output,
+                *rule.input,
+                *sorted(wildcards_dict.items()),
+            )
         else:
             key = (rule.name, *sorted(wildcards_dict.items()))
         if update:
@@ -215,7 +226,7 @@ class Job(AbstractJob):
             self.dag,
             wildcards_dict=self.wildcards_dict,
             targetfile=self.targetfile,
-            update=True
+            update=True,
         )
         job.is_updated = True
         return job

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1068,7 +1068,8 @@ class GroupJobFactory:
         self.cache = dict()
 
     def new(self, id, jobs):
-        key = (id, frozenset(jobs))
+        jobs = frozenset(jobs)
+        key = (id, jobs)
         try:
             obj = self.cache[key]
         except KeyError:
@@ -1096,7 +1097,7 @@ class GroupJob(AbstractJob):
 
     def __init__(self, id, jobs):
         self.groupid = id
-        self.jobs = frozenset(jobs)
+        self.jobs = jobs
         self.toposorted = None
         self._resources = None
         self._input = None

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -75,8 +75,36 @@ class AbstractJob:
         raise NotImplementedError()
 
 
+class JobFactory:
+    def __init__(self):
+        self.cache = dict()
+
+    def new(
+        self, rule, dag, wildcards_dict=None, format_wildcards=None, targetfile=None, update=False
+    ):
+        if rule.is_branched:
+            # for distinguishing branched rules, we need input and output in addition
+            key = (rule.name, *rule.output, *rule.input, *sorted(wildcards_dict.items()))
+        else:
+            key = (rule.name, *sorted(wildcards_dict.items()))
+        if update:
+            # cache entry has to be replaced because job shall be constructed from scratch
+            obj = Job(rule, dag, wildcards_dict, format_wildcards, targetfile)
+            self.cache[key] = obj
+        else:
+            try:
+                # try to get job from cache
+                obj = self.cache[key]
+            except KeyError:
+                obj = Job(rule, dag, wildcards_dict, format_wildcards, targetfile)
+                self.cache[key] = obj
+        return obj
+
+
 class Job(AbstractJob):
     HIGHEST_PRIORITY = sys.maxsize
+
+    obj_cache = dict()
 
     __slots__ = [
         "rule",
@@ -180,16 +208,14 @@ class Job(AbstractJob):
                             rule=self.rule,
                         )
                 self.subworkflow_input[f] = sub
-        self._hash = self.rule.__hash__()
-        for wildcard_value in self.wildcards_dict.values():
-            self._hash ^= wildcard_value.__hash__()
 
     def updated(self):
-        job = Job(
+        job = self.dag.job_factory.new(
             self.rule,
             self.dag,
             wildcards_dict=self.wildcards_dict,
             targetfile=self.targetfile,
+            update=True
         )
         job.is_updated = True
         return job
@@ -860,21 +886,11 @@ class Job(AbstractJob):
     def __repr__(self):
         return self.rule.name
 
-    def __eq__(self, other):
-        if other is None:
-            return False
-        return self.rule.name == other.rule.name and (
-            self.wildcards_dict == other.wildcards_dict
-        )
-
     def __lt__(self, other):
         return self.rule.__lt__(other.rule)
 
     def __gt__(self, other):
         return self.rule.__gt__(other.rule)
-
-    def __hash__(self):
-        return self._hash
 
     def expand_dynamic(self, pattern):
         """ Expand dynamic files. """
@@ -1036,7 +1052,23 @@ class Job(AbstractJob):
         return 1
 
 
+class GroupJobFactory:
+    def __init__(self):
+        self.cache = dict()
+
+    def new(self, id, jobs):
+        key = (id, frozenset(jobs))
+        try:
+            obj = self.cache[key]
+        except KeyError:
+            obj = GroupJob(id, jobs)
+            self.cache[key] = obj
+        return obj
+
+
 class GroupJob(AbstractJob):
+
+    obj_cache = dict()
 
     __slots__ = [
         "groupid",


### PR DESCRIPTION
ensure job uniqueness via a factory, and use the fast default object hash and eq for job objects.