### PR TITLE
Rearrange conditional statement in debug check

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -444,7 +444,7 @@ def snakemake(
     if cluster_mode > 1:
         logger.error("Error: cluster and drmaa args are mutually exclusive")
         return False
-    if debug and (cores > 1 or cluster_mode):
+    if debug and (cluster_mode or cores > 1):
         logger.error(
             "Error: debug mode cannot be used with more than one core or cluster execution."
         )


### PR DESCRIPTION
If cluster mode is enabled then cores is set to `None` on line 363, which results in a `TypeError` in the following comparison statement.