### PR TITLE
Smart input function exception handling

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -721,6 +721,8 @@ class DAG:
                 MissingInputException,
                 CyclicGraphException,
                 PeriodicWildcardError,
+                InputFunctionException,
+                WorkflowError,
             ) as ex:
                 exceptions.append(ex)
             except RecursionError as e:
@@ -742,7 +744,7 @@ class DAG:
                 job = cycles[0]
                 raise CyclicGraphException(job.rule, file, rule=job.rule)
             if exceptions:
-                raise exceptions[0]
+                raise WorkflowError(*exceptions)
         else:
             logger.dag_debug(dict(status="selected", job=producer))
 
@@ -797,6 +799,8 @@ class DAG:
                 MissingInputException,
                 CyclicGraphException,
                 PeriodicWildcardError,
+                InputFunctionException,
+                WorkflowError,
             ) as ex:
                 if not file.exists:
                     self.delete_job(job, recursive=False)  # delete job from tree

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -747,6 +747,13 @@ class DAG:
                 raise WorkflowError(*exceptions)
         else:
             logger.dag_debug(dict(status="selected", job=producer))
+            logger.dag_debug(
+                dict(
+                    file=file,
+                    msg="Producer found, hence exceptions are ignored.",
+                    exception=WorkflowError(*exceptions),
+                )
+            )
 
         n = len(self.dependencies)
         if progress and n % 1000 == 0 and n and self._progress != n:
@@ -805,6 +812,14 @@ class DAG:
                 if not file.exists:
                     self.delete_job(job, recursive=False)  # delete job from tree
                     raise ex
+                else:
+                    logger.dag_debug(
+                        dict(
+                            file=file,
+                            msg="No producers found, but file is present on disk.",
+                            exception=ex,
+                        )
+                    )
 
         for file, job_ in producer.items():
             dependencies[job_].add(file)

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -743,8 +743,10 @@ class DAG:
             if cycles:
                 job = cycles[0]
                 raise CyclicGraphException(job.rule, file, rule=job.rule)
-            if exceptions:
+            if len(exceptions) > 1:
                 raise WorkflowError(*exceptions)
+            elif len(exceptions) == 1:
+                raise exceptions[0]
         else:
             logger.dag_debug(dict(status="selected", job=producer))
             logger.dag_debug(

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -721,7 +721,6 @@ class DAG:
                 MissingInputException,
                 CyclicGraphException,
                 PeriodicWildcardError,
-                InputFunctionException,
                 WorkflowError,
             ) as ex:
                 exceptions.append(ex)
@@ -808,7 +807,6 @@ class DAG:
                 MissingInputException,
                 CyclicGraphException,
                 PeriodicWildcardError,
-                InputFunctionException,
                 WorkflowError,
             ) as ex:
                 if not file.exists:

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -274,7 +274,13 @@ class Env:
 
                     # install packages manually from env archive
                     cmd = " ".join(
-                        ["conda", "create", "--copy", "--prefix '{}'".format(env_path)]
+                        [
+                            "conda",
+                            "create",
+                            "--quiet",
+                            "--copy",
+                            "--prefix '{}'".format(env_path),
+                        ]
                         + packages
                     )
                     if self._container_img:
@@ -301,6 +307,7 @@ class Env:
                             self.frontend,
                             "env",
                             "create",
+                            "--quiet",
                             "--file '{}'".format(target_env_file),
                             "--prefix '{}'".format(env_path),
                         ]

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -210,7 +210,7 @@ class InputFunctionException(WorkflowError):
             )
             + "\nTraceback:\n"
             + "\n".join(
-                format_traceback(cut_traceback(msg, rule.workflow.linemaps))
+                format_traceback(cut_traceback(msg), rule.workflow.linemaps)
             )
         )
         super().__init__(msg, lineno=lineno, snakefile=snakefile, rule=rule)

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -207,10 +207,10 @@ class InputFunctionException(WorkflowError):
             + "\n".join(
                 "{}={}".format(name, value)
                 for name, value in wildcards.items()
-                + "\nTraceback:\n"
-                + "\n".join(
-                    format_traceback(cut_traceback(msg, rule.workflow.linemaps))
-                )
+            )
+            + "\nTraceback:\n"
+            + "\n".join(
+                format_traceback(cut_traceback(msg, rule.workflow.linemaps))
             )
         )
         super().__init__(msg, lineno=lineno, snakefile=snakefile, rule=rule)

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -203,9 +203,14 @@ class InputFunctionException(WorkflowError):
     def __init__(self, msg, wildcards=None, lineno=None, snakefile=None, rule=None):
         msg = (
             self.format_arg(msg)
-            + "\n    Wildcards:\n"
+            + "\nWildcards:\n"
             + "\n".join(
-                "    {}={}".format(name, value) for name, value in wildcards.items()
+                "{}={}".format(name, value)
+                for name, value in wildcards.items()
+                + "\nTraceback:\n"
+                + "\n".join(
+                    format_traceback(cut_traceback(msg, rule.workflow.linemaps))
+                )
             )
         )
         super().__init__(msg, lineno=lineno, snakefile=snakefile, rule=rule)

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -131,6 +131,11 @@ class WorkflowError(Exception):
     def format_arg(arg):
         if isinstance(arg, str):
             return arg
+        elif isinstance(arg, WorkflowError):
+            rule = "rule {}".format(arg.rule) if arg.rule is not None else ""
+            location = "line {}, {}".format(arg.lineno, arg.snakefile) if arg.snakefile else ""
+            spec = ", ".join([rule, location])
+            return "{} ({}): {}".format(arg.__class__.__name__, spec, str(arg))
         else:
             return "{}: {}".format(arg.__class__.__name__, str(arg))
 

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -5,6 +5,7 @@ __license__ = "MIT"
 
 import os
 import traceback
+import textwrap
 from tokenize import TokenError
 from snakemake.logging import logger
 
@@ -137,7 +138,9 @@ class WorkflowError(Exception):
                 "line {}, {}".format(arg.lineno, arg.snakefile) if arg.snakefile else ""
             )
             spec = ", ".join([rule, location])
-            return "{} ({}): {}".format(arg.__class__.__name__, spec, str(arg))
+            return "{} ({}):\n{}".format(
+                arg.__class__.__name__, spec, textwrap.indent(str(arg), "    ")
+            )
         else:
             return "{}: {}".format(arg.__class__.__name__, str(arg))
 
@@ -200,9 +203,9 @@ class InputFunctionException(WorkflowError):
     def __init__(self, msg, wildcards=None, lineno=None, snakefile=None, rule=None):
         msg = (
             self.format_arg(msg)
-            + "\nWildcards:\n"
+            + "\n    Wildcards:\n"
             + "\n".join(
-                "{}={}".format(name, value) for name, value in wildcards.items()
+                "    {}={}".format(name, value) for name, value in wildcards.items()
             )
         )
         super().__init__(msg, lineno=lineno, snakefile=snakefile, rule=rule)

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -133,12 +133,18 @@ class WorkflowError(Exception):
         if isinstance(arg, str):
             return arg
         elif isinstance(arg, WorkflowError):
-            rule = "rule {}".format(arg.rule) if arg.rule is not None else ""
-            location = (
-                "line {}, {}".format(arg.lineno, arg.snakefile) if arg.snakefile else ""
-            )
-            spec = ", ".join([rule, location])
-            return "{} ({}):\n{}".format(
+            spec = ""
+            if arg.rule is not None:
+                spec += "rule {}".format(arg.rule)
+            if arg.snakefile is not None:
+                if spec:
+                    spec += ", "
+                spec += "line {}, {}".format(arg.lineno, arg.snakefile)
+
+            if spec:
+                spec = " ({})".format(spec)
+
+            return "{}{}:\n{}".format(
                 arg.__class__.__name__, spec, textwrap.indent(str(arg), "    ")
             )
         else:

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -202,16 +202,14 @@ class RuleException(Exception):
 class InputFunctionException(WorkflowError):
     def __init__(self, msg, wildcards=None, lineno=None, snakefile=None, rule=None):
         msg = (
-            self.format_arg(msg)
+            "Message:\n    "
+            + self.format_arg(msg)
             + "\nWildcards:\n"
             + "\n".join(
-                "{}={}".format(name, value)
-                for name, value in wildcards.items()
+                "  {}={}".format(name, value) for name, value in wildcards.items()
             )
             + "\nTraceback:\n"
-            + "\n".join(
-                format_traceback(cut_traceback(msg), rule.workflow.linemaps)
-            )
+            + "\n".join(format_traceback(cut_traceback(msg), rule.workflow.linemaps))
         )
         super().__init__(msg, lineno=lineno, snakefile=snakefile, rule=rule)
 

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -202,7 +202,7 @@ class RuleException(Exception):
 class InputFunctionException(WorkflowError):
     def __init__(self, msg, wildcards=None, lineno=None, snakefile=None, rule=None):
         msg = (
-            "Message:\n    "
+            "Error:\n  "
             + self.format_arg(msg)
             + "\nWildcards:\n"
             + "\n".join(

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -133,7 +133,9 @@ class WorkflowError(Exception):
             return arg
         elif isinstance(arg, WorkflowError):
             rule = "rule {}".format(arg.rule) if arg.rule is not None else ""
-            location = "line {}, {}".format(arg.lineno, arg.snakefile) if arg.snakefile else ""
+            location = (
+                "line {}, {}".format(arg.lineno, arg.snakefile) if arg.snakefile else ""
+            )
             spec = ", ".join([rule, location])
             return "{} ({}): {}".format(arg.__class__.__name__, spec, str(arg))
         else:

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -14,6 +14,7 @@ import threading
 import tempfile
 from functools import partial
 import inspect
+import textwrap
 
 from snakemake.common import DYNAMIC_FILL
 from snakemake.common import Mode
@@ -403,14 +404,25 @@ class Logger:
                 print(json.dumps({"nodes": msg["nodes"], "links": msg["edges"]}))
             elif level == "dag_debug":
                 if self.debug_dag:
-                    job = msg["job"]
-                    self.logger.warning(
-                        "{status} job {name}\n\twildcards: {wc}".format(
-                            status=msg["status"],
-                            name=job.rule.name,
-                            wc=format_wildcards(job.wildcards),
+                    if "file" in msg:
+                        self.logger.warning(
+                            "file {file}:\n    {msg}\n{exception}".format(
+                                file=msg["file"],
+                                msg=msg["msg"],
+                                exception=textwrap.indent(
+                                    str(msg["exception"]), "    "
+                                ),
+                            )
                         )
-                    )
+                    else:
+                        job = msg["job"]
+                        self.logger.warning(
+                            "{status} job {name}\n    wildcards: {wc}".format(
+                                status=msg["status"],
+                                name=job.rule.name,
+                                wc=format_wildcards(job.wildcards),
+                            )
+                        )
 
             self.last_msg_was_job_info = False
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -289,7 +289,7 @@ def test_empty_include():
 
 @skip_on_windows
 def test_script():
-    run(dpath("test_script"), use_conda=True)
+    run(dpath("test_script"), use_conda=True, check_md5=False)
 
 
 def test_script_python():


### PR DESCRIPTION
This PR enables to consider alternative paths in the DAG if an input function fails. To make this change more accesible, the --debug-dag output has been extended to include all ignored exceptions that occur during DAG evaluation.