### PR TITLE
Fix issue 480: cleanup_workdir should remove input dirs if they are from remotes

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -230,7 +230,7 @@ class DAG:
         for io_dir in set(
             os.path.dirname(io_file)
             for job in self.jobs
-            for io_file in chain(job.output, job.input)
+            for io_file in chain(job.output, job.remote_input)
             if not os.path.exists(io_file)
         ):
             if os.path.exists(io_dir) and not len(os.listdir(io_dir)):

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1239,6 +1239,11 @@ class GroupJob(AbstractJob):
         return self._input
 
     @property
+    def remote_input(self):
+        return [f for f in self.input 
+                if f.is_remote and not f.should_stay_on_remote]
+
+    @property
     def output(self):
         all_input = set(f for job in self.jobs for f in job.input)
         if self._output is None:

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1240,8 +1240,7 @@ class GroupJob(AbstractJob):
 
     @property
     def remote_input(self):
-        return [f for f in self.input 
-                if f.is_remote and not f.should_stay_on_remote]
+        return [f for f in self.input if f.is_remote and not f.should_stay_on_remote]
 
     @property
     def output(self):


### PR DESCRIPTION
### Potential fix for issue:
#### #480: Snakemake deletes input directory in dry run.

This changes DAG.cleanup_workdir from deleting all empty input dirs to only those from remote inputs.

