### PR TITLE
Support alternate signal handling for killing shell processes 

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -529,6 +529,7 @@ class Workflow:
         export_cwl=False,
         batch=None,
         keepincomplete=False,
+        local_timeout=0
     ):
 
         self.check_localrules()
@@ -891,6 +892,7 @@ class Workflow:
             force_use_threads=force_use_threads,
             assume_shared_fs=assume_shared_fs,
             keepincomplete=keepincomplete,
+            local_timeout=local_timeout
         )
 
         if not dryrun:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -45,6 +45,9 @@ def test_issue956():
     run(dpath("test_issue956"))
 
 
+def test_issue448():
+    run(dpath("test_issue448"), shouldfail=True)
+
 @skip_on_windows
 def test01():
     run(dpath("test01"))


### PR DESCRIPTION
See: https://github.com/snakemake/snakemake/issues/448

This also changes the behavior of shutdown for local execution.  Previously, if a running job fails, it may not terminate them even when `-k/--keep-going` is not being used.  This is fixed.

I think a test could be added, something like below, but I couldn't get the trapping to work

<details>

<summary>Snakefile</summary>

```
rule all:
    input:
        ['out1.txt', 'out2.txt']


rule test1:
    output: 'out1.txt'
    shell:
        """
        echo out1 > out1.txt
        sleep 1
        exit 1
        """

rule test2:
    output: 'out2.txt'
    shell:
        """
        _handle_sigterm() {{
            echo "trapped: $1"
            echo "handled" > result.txt
            exit 1
        }}
        trap "_handle_sigterm SIGTERM" SIGTERM
        trap -p
        trap -l
        sleep 1000
        echo "unhandled" > result.txt
        echo out2 > out2.txt
        exit 0
        """
```

</details>