### PR TITLE
Fix GS inventory cache by removing blob prefix

### DIFF
--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -138,9 +138,7 @@ class RemoteObject(AbstractRemoteObject):
             - cache_mtime
             - cache.size
         """
-        for blob in self.client.list_blobs(
-            self.bucket_name, prefix=os.path.dirname(self.blob.name)
-        ):
+        for blob in self.client.list_blobs(self.bucket_name):
             # By way of being listed, it exists. mtime is a datetime object
             name = "{}/{}".format(blob.bucket.name, blob.name)
             cache.exists_remote[name] = True


### PR DESCRIPTION
I think caching remote files is an excellent addition to snakemake, so first of all thank you @johanneskoester and @vsoch . However, 01cf67fd54f8c86e61a26da1d9b44518414ef20a in v5.19.3 broke kubernetes on GCP for me. This PR fixes the `MissingInputException` errors I'm seeing in nested buckets containing wildcards by removing `prefix=` from the `client.list_blobs()` function.

## Example 

Snakefile:
```python
rule all:
    input:
        expand("project1/results/{sample}/output.txt", sample=["sample1"])

rule do_something:
    input:
        "project1/reads/{sample}/empty-input.txt"
    output:
        "project1/results/{sample}/output.txt"
```

Demonstration:
```bash
# empty-input.txt exists in the sm-test-gs bucket with a nested structure
$ gsutil ls gs://sm-test-gs/project1/reads/sample1/empty-input.txt
gs://sm-test-gs/project1/reads/sample1/empty-input.txt

# v5.19.3 failes (and v5.20.1 as well, not shown)
$ snakemake --version && snakemake --kubernetes --default-remote-provider GS --default-remote-prefix sm-test-gs -n -r
5.19.3
Building DAG of jobs...
MissingInputException in line 6 of /home/derek/gs-sm-test/Snakefile:
Missing input files for rule do_something:
sm-test-gs/project1/reads/sample1/empty-input.txt

# now with v5.19.2
# (also works with this PR branch)
$ snakemake --version && snakemake --kubernetes --default-remote-provider GS --default-remote-prefix sm-test-gs -n -r
5.19.2
Building DAG of jobs...
Job counts:
        count   jobs
        1       all
        1       do_something
        2

[Wed Jul 22 21:32:38 2020]
localrule do_something:
    input: sm-test-gs/project1/reads/sample1/empty-input.txt
    output: sm-test-gs/project1/results/sample1/output.txt
    jobid: 1
    reason: Missing output files: sm-test-gs/project1/results/sample1/output.txt
    wildcards: sample=sample1

[Wed Jul 22 21:32:38 2020]
localrule all:
    input: sm-test-gs/project1/results/sample1/output.txt
    jobid: 0
    reason: Input files updated by another job: sm-test-gs/project1/results/sample1/output.txt

Job counts:
        count   jobs
        1       all
        1       do_something
        2
This was a dry-run (flag -n). The order of jobs does not reflect the order of execution.
```
