### PR TITLE
Pass latency_wait to kubernetes jobs

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1363,7 +1363,7 @@ class KubernetesExecutor(ClusterExecutor):
             "cp -rf /source/. . && "
             "snakemake {target} --snakefile {snakefile} "
             "--force -j{cores} --keep-target-files  --keep-remote "
-            "--latency-wait 0 "
+            "--latency-wait {latency_wait} "
             " --attempt {attempt} {use_threads} "
             "--wrapper-prefix {workflow.wrapper_prefix} "
             "{overwrite_config} {printshellcmds} {rules} --nocolor "


### PR DESCRIPTION
The hardcoded `--latency-wait 0` was causing some jobs to fail for me. Passing `{latency_wait}` instead mimics other `executor` classes e.g. `ClusterExecutor`:
https://github.com/snakemake/snakemake/blob/f62792d69c28e937243ca8b4f7cac3cec868adcc/snakemake/executors/__init__.py#L622