### PR TITLE
fix conda version checker

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -444,7 +444,7 @@ class Conda:
                 stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )
-            version = version.split()[1]
+            version = re.findall('\d+.\d+.\d+', version)[0]
             if StrictVersion(version) < StrictVersion("4.2"):
                 raise CreateCondaEnvironmentException(
                     "Conda must be version 4.2 or later, found version {}.".format(


### PR DESCRIPTION
In case of singularity using, conda checker gives me the error:

```
Full Traceback (most recent call last):
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/site-packages/snakemake/executors/__init__.py", line 2168, in run_wrapper
    run(
  File "/mnt/tank/scratch/mfiruleva/other_stuff/sin_guide/smk_sing_guide/rules/script_2.smk", line 16, in __rule_geom_point
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/site-packages/snakemake/shell.py", line 134, in __new__
    cmd = Conda(container_img).shellcmd(conda_env, cmd)
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/site-packages/snakemake/deployment/conda.py", line 381, in __new__
    inst.__init__(container_img=container_img)
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/site-packages/snakemake/deployment/conda.py", line 394, in __init__
    self._check()
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/site-packages/snakemake/deployment/conda.py", line 451, in _check
    if StrictVersion(version) < StrictVersion("4.2"):
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/nfs/home/mfiruleva/anaconda3/envs/guide/lib/python3.8/distutils/version.py", line 138, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number 'Convert'

```

It happens because `version` string contains not only the conda version, but also the `INFO:    Convert SIF file to sandbox...` message. So, I use regexp to catch the conda version.

**Snakemake version**: 5.20.1
**singularity version**: singularity version 47b018f-dirty (installed via conda)

**Minimal example**

1. Snakefile:

```
container: "docker://continuumio/miniconda3:latest"

rule scatter:
    output: "scatter.pdf"
    conda: "scn.yaml"
    shell: "python scatter.py"
```

2. scn.yaml:

```
channels:
  - anaconda
  - defaults
dependencies:
  - seaborn=0.10.0
```

3. scatter.py:

```
import seaborn as sns

df = sns.load_dataset('iris')
sns.scatterplot(x="sepal_length", y="petal_length", data=df).get_figure().savefig("scatter.pdf")
```

run:
`snakemake -j 1 --use-singularity --use-conda`