### PR TITLE
Added info about unparseable argument to parse_key_value_arg

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -759,7 +759,7 @@ def parse_key_value_arg(arg, errmsg):
     try:
         key, val = arg.split("=", 1)
     except ValueError:
-        raise ValueError(errmsg)
+        raise ValueError(errmsg + ' Unparseable value: %r.' % arg)
     return key, val
 
 


### PR DESCRIPTION
This is completely minimal and could be done in other ways, but I just want to see what you think. I haven't run any tests as I'm not sure how one does that.

I suggest adding this because I just did this:

```sh
$ snakemake --config xxx=33 target
```

and got the "Invalid config definition: Config entries have to be defined as name=value pairs." error message. Turned out that because `--config` can accept many key/value pairs, Python's argparse (I guess) was adding `target` to the list of values assigned to `config`. But the error message didn't show me what was going wrong until I went in and changed the code to print the troublesome value.

This doesn't happen if the user uses `snakemake --config xxx=33 -- target` but not everyone will be in the habit of doing (or even know about) this.

I'm happy to write or fix tests, etc., if someone tells me how to run them.