### PR TITLE
Changing crc32c library to use google-crc32c instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         "reports": ["jinja2", "networkx", "pygments", "pygraphviz"],
         "messaging": ["slacker"],
         "google-cloud": [
-            "crc32c",
             "oauth2client",
             "google-api-python-client",
             "google-cloud-storage",


### PR DESCRIPTION
Just so we have it in case this is the direction we want to take, this pull request will replace the current dependency on the crc32c (non Google) library with the Google one. The changes are trivial, it seems that the Google library lets us import a Checksum, and it acts akin to how a hashlib object would add. The main change is that we don't need to use struct on the checksum.digest(), but instead just base64 decode it. I didn't have a quick way to test this, but the output of the update() and then final hexdigest() looked correct, so anyway, we can discuss this too :)

Signed-off-by: vsoch <vsochat@stanford.edu>