### PR TITLE
option 2 is to pin versions for storage and python client until there…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,8 @@ setup(
         "google-cloud": [
             "crc32c",
             "oauth2client",
-            "google-api-python-client",
-            "google-cloud-storage",
+            "google-api-python-client==1.9.1",
+            "google-cloud-storage==1.28.1",
         ],
     },
     classifiers=[


### PR DESCRIPTION
This is an option 2 to #540, instead of removing the open source crc32c library (which I like better because it installs a compiled crc32c library) we pin the versions for the google-cloud-storage and google api client libraries until they can internally do a fix to rename the library and not infringe on the namespace. I grabbed these versions from the last working container for snakemake, v5.20.1.

Signed-off-by: vsoch <vsochat@stanford.edu>