### PR TITLE
feat(tes): towards supporting FTP files

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -2273,11 +2273,20 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
 
         task = {}
         task["name"] = job.format_wildcards(self.jobname)
-        task["description"] = "Here is description."  # TODO: check if corresponding value in Snakemake, else omit
+        task["description"] = ""
         task["inputs"] = []
         task["outputs"] = []
         task["executors"] = []
         task["resources"] = tes.models.Resources()
+
+        # populate description with rule messages
+        if job.is_group():
+            msgs = [i.message for i in job.jobs if i.message]
+            if msgs:
+                task["description"] = ' & '.join(msgs)
+        else:
+            if job.message:
+                task["description"] = job.message
 
         # add workflow sources to inputs
         for src in self.workflow.get_sources():
@@ -2345,7 +2354,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
         task["executors"].append(
             tes.models.Executor(
                 image=self.container_image,
-                command=[
+                command=[  # TODO: info about what is executed is opaque
                     "/bin/bash",
                     os.path.join(self.container_workdir, "run_snakemake.sh"),
                 ],

--- a/tests/test_tes/Snakefile
+++ b/tests/test_tes/Snakefile
@@ -6,6 +6,7 @@ rule all:
 rule step1a:
     input: "testfiles/input.txt"
     output: pipe("out_1a.txt")
+    message: "Step 1a"
     shell:
         """
         cat {input} > {output}
@@ -18,6 +19,7 @@ rule step1b:
         mem_mb=1000,
         disk_mb=1000,
         _cores=2,
+    message: "Step 1b"
     shell:
         """
         cat {input} > {output}
@@ -31,12 +33,14 @@ rule step1c:
         mem_mb=2000,
         disk_mb=2000,
         _cores=4,
+    message: "Step 1c"
     script: "scripts/test_script.py"
 
 rule step1d:
     output: temp("out_1d.txt")
     params:
         message="hello world"
+    message: "Step 1d"
     run:
         with open(output[0], "w") as f:
             f.write(params.message)

--- a/tests/test_tes_ftp.py
+++ b/tests/test_tes_ftp.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import subprocess
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from common import *
+
+def test_tes_ftp():
+    subprocess.call(["rm", "-rf", "tests/test_tes_ftp/.snakemake"])
+    subprocess.call(["rm", "-rf", "tests/test_tes_ftp/output.txt"])
+    subprocess.call(["rm", "-rf", "tests/test_tes_ftp/output.txt.bz2"])
+    subprocess.call(["rm", "-rf", "tests/test_tes_ftp/stats.txt"])
+    subprocess.call(["rm", "-rf", "tests/test_tes_ftp/test.log"])
+    workdir = dpath("test_tes_ftp")
+    run(
+        workdir,
+        snakefile="Snakefile",
+        tes=True,
+        tes_url="http://localhost:8000",
+        use_conda=True,
+        conda_prefix="/tmp/conda",
+        conda_frontend="conda",
+        envvars=["HTTP_PROXY", "HTTPS_PROXY", "CONDA_PKGS_DIRS", "CONDA_ENVS_PATH"],
+        no_tmpdir=True,
+        cleanup=False
+    )

--- a/tests/test_tes_ftp/Snakefile
+++ b/tests/test_tes_ftp/Snakefile
@@ -1,0 +1,66 @@
+from snakemake.remote.FTP import RemoteProvider as FTPRemoteProvider
+
+FTP = FTPRemoteProvider(username="user", password="pass")
+
+rule all:
+    input:
+        "output.txt",
+        "output.txt.bz2"
+
+rule step1a:
+    input: FTP.remote("ftp-private.ebi.ac.uk/upload/snakemake/input.txt")
+    output: pipe("out_1a.txt")
+    shell:
+        """
+        cat {input} > {output}
+        """
+
+rule step1b:
+    input: "out_1a.txt"
+    output: temp("out_1b.txt")
+    resources:
+        mem_mb=1000,
+        disk_mb=1000,
+        _cores=2,
+    shell:
+        """
+        cat {input} > {output}
+        """
+
+rule step1c:
+    output: temp("out_1c.txt")
+    params:
+        message="hello world"
+    resources:
+        mem_mb=2000,
+        disk_mb=2000,
+        _cores=4,
+    script: "scripts/test_script.py"
+
+rule step1d:
+    output: temp("out_1d.txt")
+    params:
+        message="hello world"
+    run:
+        with open(output[0], "w") as f:
+            f.write(params.message)
+
+rule step2:
+    input:
+        "out_1b.txt",
+        "out_1c.txt",
+        "out_1d.txt"
+    output:
+        "output.txt",
+        "output.txt.bz2"
+    conda:
+        "envs/gzip.yaml"
+    log: "test.log"
+    shell:
+        """
+        cat {input[0]} >> {output[0]}
+        cat {input[1]} >> {output[0]}
+        cat {input[2]} >> {output[0]}
+        bzip2 -c {output[0]} > {output[1]}
+        echo "fine" > {log} 
+        """

--- a/tests/test_tes_ftp/envs/gzip.yaml
+++ b/tests/test_tes_ftp/envs/gzip.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - bzip2

--- a/tests/test_tes_ftp/scripts/test_script.py
+++ b/tests/test_tes_ftp/scripts/test_script.py
@@ -1,0 +1,2 @@
+with open(snakemake.output[0], "w") as f:
+  f.write(snakemake.params.message)


### PR DESCRIPTION
FTP support successfully tested with Funnel TES for FTP input but not output files (553 error when trying to upload files).
Code changes are not finalized (some leftover/debug code around).

Apart from FTP support, these issues were addressed via different commits (could be easily cherry-picked for a separate PR if desired):
* improve logging (more log messages, more consistent)
* enforce rate at which TES status is polled (did not seem to have worked previously)
* allow passing input/output files by content (good for Snakemake file and related input files that are not really part of the task)
* get task description from rule message, if present
