### PR TITLE
Update io.py: special treatment of symlinks

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -223,12 +223,10 @@ class _IOFile(str):
                 cache.exists_local[path] = True
                 with os.scandir(path) as scan:
                     for entry in scan:
-                        if entry.is_dir():
-                            # check if entry is a symlink
-                            if entry.is_symlink():
-                                pass
-                            else:
-                                queue.append(entry.path)
+                        if entry.is_dir() and not entry.is_symlink():
+                            queue.append(entry.path)
+                        elif entry.is_symlink():
+                            pass
                         else:
                             # path is a file
                             cache.exists_local[entry.path] = True

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -224,7 +224,11 @@ class _IOFile(str):
                 with os.scandir(path) as scan:
                     for entry in scan:
                         if entry.is_dir():
-                            queue.append(entry.path)
+                            # check if entry is a symlink
+                            if entry.is_symlink():
+                                pass
+                            else:
+                                queue.append(entry.path)
                         else:
                             # path is a file
                             cache.exists_local[entry.path] = True


### PR DESCRIPTION
Following symlinks in a directory has the potential of creating a self-reference, which leads to getting stuck in this loop (the user will see "Building DAG of jobs..." message). In my particular setup, Snakemake v5.18 works, while v5.20 gets stuck in this loop:

https://github.com/snakemake/snakemake/blob/e43cb8842a60db833d8a3e26c138bf1930bf4a9c/snakemake/io.py#L212-L230