### PR TITLE
fixing gs cache prefix

### DIFF
--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -138,17 +138,17 @@ class RemoteObject(AbstractRemoteObject):
             - cache_mtime
             - cache.size
         """
-        for blob in self.client.list_blobs(
-            self.bucket_name, prefix=os.path.dirname(self.blob.name)
-        ):
+        subfolder = os.path.dirname(self.blob.name)
+        for blob in self.client.list_blobs(self.bucket_name, prefix=subfolder):
             # By way of being listed, it exists. mtime is a datetime object
             name = "{}/{}".format(blob.bucket.name, blob.name)
             cache.exists_remote[name] = True
             cache.mtime[name] = blob.updated
             cache.size[name] = blob.size
-        # Mark bucket as having an inventory, such that this method is
-        # only called once for this bucket.
-        cache.has_inventory.add(self.bucket_name)
+
+        # Mark bucket and prefix as having an inventory, such that this method is
+        # only called once for the subfolder in the bucket.
+        cache.has_inventory.add("%s/%s" % (self.bucket_name, subfolder))
 
     # === Implementations of abstract class members ===
 


### PR DESCRIPTION
Currently, we use the google storage bucket as an index for the cache, even though weve only potentially checked one subfolder. This leads to an error that we think weve indexed the bucket but we have not, and an MissingInputException suite of errors. This will resolve #511 and #546.

Signed-off-by: vsoch <vsochat@stanford.edu>