### PR TITLE
Update/gs retry deadline 10 mins

### DIFF
--- a/docs/executor_tutorial/google_lifesciences.rst
+++ b/docs/executor_tutorial/google_lifesciences.rst
@@ -166,16 +166,16 @@ storage instead of the local filesystem.
 
     rule bwa_map:
         input:
-        fastq="samples/{sample}.fastq",
-        idx=multiext("genome.fa", ".amb", ".ann", ".bwt", ".pac", ".sa")
-    conda:
-        "environment.yml"
-    output:
-        "mapped_reads/{sample}.bam"
-    params:
-        idx=lambda w, input: os.path.splitext(input.idx[0])[0]
-    shell:
-        "bwa mem {params.idx} {input.fastq} | samtools view -Sb - > {output}"
+            fastq="samples/{sample}.fastq",
+            idx=multiext("genome.fa", ".amb", ".ann", ".bwt", ".pac", ".sa")
+        conda:
+            "environment.yml"
+        output:
+            "mapped_reads/{sample}.bam"
+        params:
+            idx=lambda w, input: os.path.splitext(input.idx[0])[0]
+        shell:
+            "bwa mem {params.idx} {input.fastq} | samtools view -Sb - > {output}"
 
     rule samtools_sort:
         input:

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -173,8 +173,10 @@ class RemoteObject(AbstractRemoteObject):
         else:
             return self._iofile.size_local
 
-    @retry.Retry(predicate=google_cloud_retry_predicate)
+    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=600)
     def download(self):
+        """Download with maximum retry of 600 seconds (10 minutes)
+        """
         if not self.exists():
             return None
 


### PR DESCRIPTION
This will attempt to address the Google Storage crc32c error, which might actually be a timeout at 120 seconds for the retry. Here we test increasing the timeout to 10 minutes. I've also fixed a spacing issue with the Google Lifesciences Tutorial snakefile.