### PR TITLE
Fixing quotes for --default-resources example

### DIFF
--- a/docs/executing/cloud.rst
+++ b/docs/executing/cloud.rst
@@ -207,7 +207,7 @@ a full machine type:
 
 .. code-block:: console
 
-    --default-resources machine_type="n1-standard"
+    --default-resources "machine_type=n1-standard"
 
 
 If you want to specify the machine type as a resource, you can do that too:

--- a/setup.py
+++ b/setup.py
@@ -72,10 +72,10 @@ setup(
         "reports": ["jinja2", "networkx", "pygments", "pygraphviz"],
         "messaging": ["slacker"],
         "google-cloud": [
-            "crc32c",
             "oauth2client",
-            "google-api-python-client==1.9.1",
-            "google-cloud-storage==1.28.1",
+            "google-crc32c",
+            "google-api-python-client",
+            "google-cloud-storage",
         ],
     },
     classifiers=[

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -18,7 +18,7 @@ try:
     import google.cloud
     from google.cloud import storage
     from google.api_core import retry
-    from crc32c import crc32
+    from google_crc32c import Checksum
 except ImportError as e:
     raise WorkflowError(
         "The Python 3 packages 'google-cloud-sdk' and `crc32c` "
@@ -56,7 +56,7 @@ class Crc32cCalculator:
 
     def __init__(self, fileobj):
         self._fileobj = fileobj
-        self.digest = 0
+        self.checksum = Checksum()
 
     def write(self, chunk):
         self._fileobj.write(chunk)
@@ -65,14 +65,14 @@ class Crc32cCalculator:
     def _update(self, chunk):
         """Given a chunk from the read in file, update the hexdigest
         """
-        self.digest = crc32(chunk, self.digest)
+        self.checksum.update(chunk)
 
     def hexdigest(self):
         """Return the hexdigest of the hasher.
            The Base64 encoded CRC32c is in big-endian byte order.
            See https://cloud.google.com/storage/docs/hashes-etags
         """
-        return base64.b64encode(struct.pack(">I", self.digest)).decode("utf-8")
+        return base64.b64encode(self.checksum.digest()).decode("utf-8")
 
 
 class RemoteProvider(AbstractRemoteProvider):
@@ -173,10 +173,9 @@ class RemoteObject(AbstractRemoteObject):
         else:
             return self._iofile.size_local
 
-    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=1800, maximum=600)
+    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=600)
     def download(self):
-        """Download with maximum retry of 600 seconds (10 minutes) for a total 
-           duration of 1800 seconds (30 minutes)
+        """Download with maximum retry duration of 600 seconds (10 minutes)
         """
         if not self.exists():
             return None

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -190,10 +190,8 @@ class RemoteObject(AbstractRemoteObject):
             self.blob.download_to_file(parser)
         os.sync()
 
-        # Debugging output
+        # **Important** hash can be incorrect or missing if not refreshed
         self.blob.reload()
-        print(parser.hexdigest())
-        print(self.blob.crc32c)
 
         # Compute local hash and verify correct
         if parser.hexdigest() != self.blob.crc32c:

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -191,6 +191,7 @@ class RemoteObject(AbstractRemoteObject):
         os.sync()
 
         # Debugging output
+        self.blob.reload()
         print(parser.hexdigest())
         print(self.blob.crc32c)
 

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -173,9 +173,9 @@ class RemoteObject(AbstractRemoteObject):
         else:
             return self._iofile.size_local
 
-    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=600)
+    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=1800)
     def download(self):
-        """Download with maximum retry of 600 seconds (10 minutes)
+        """Download with maximum retry of 1800 seconds (30 minutes)
         """
         if not self.exists():
             return None

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -173,9 +173,10 @@ class RemoteObject(AbstractRemoteObject):
         else:
             return self._iofile.size_local
 
-    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=1800)
+    @retry.Retry(predicate=google_cloud_retry_predicate, deadline=1800, maximum=600)
     def download(self):
-        """Download with maximum retry of 1800 seconds (30 minutes)
+        """Download with maximum retry of 600 seconds (10 minutes) for a total 
+           duration of 1800 seconds (30 minutes)
         """
         if not self.exists():
             return None
@@ -189,6 +190,10 @@ class RemoteObject(AbstractRemoteObject):
             parser = Crc32cCalculator(blob_file)
             self.blob.download_to_file(parser)
         os.sync()
+
+        # Debugging output
+        print(parser.hexdigest())
+        print(self.blob.crc32c)
 
         # Compute local hash and verify correct
         if parser.hexdigest() != self.blob.crc32c:


### PR DESCRIPTION
The quotes for any --default-resources command line arguments need to be around the whole group.