### PR TITLE
adding instruction to skip cache for google discovery client

### DIFF
--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2015-2020, Johannes Köster"
 __email__ = "koester@jimmy.harvard.edu"
 __license__ = "MIT"
 
+import logging
 import os
 import sys
 import time
@@ -21,6 +22,8 @@ from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor, sleep
 from snakemake.common import get_container_image, get_file_hash
 
+# https://github.com/googleapis/google-api-python-client/issues/299#issuecomment-343255309
+logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
 
 GoogleLifeSciencesJob = namedtuple(
     "GoogleLifeSciencesJob", "job jobname jobid callback error_callback"
@@ -144,9 +147,15 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
             raise ex
 
         # Discovery clients for Google Cloud Storage and Life Sciences API
-        self._storage_cli = discovery_build("storage", "v1", credentials=creds)
-        self._compute_cli = discovery_build("compute", "v1", credentials=creds)
-        self._api = discovery_build("lifesciences", "v2beta", credentials=creds)
+        self._storage_cli = discovery_build(
+            "storage", "v1", credentials=creds, cache_discovery=False
+        )
+        self._compute_cli = discovery_build(
+            "compute", "v1", credentials=creds, cache_discovery=False
+        )
+        self._api = discovery_build(
+            "lifesciences", "v2beta", credentials=creds, cache_discovery=False
+        )
         self._bucket_service = storage.Client()
 
     def _get_bucket(self):


### PR DESCRIPTION
I'm not sure why this issue popped up (#555) because it didn't happen with the full testing run last night, but these two changes (to logging and init of the discovery client) seem to be the recommended fix. Another option would be to return to the pinned Google library versions. I guess it's up to how we want to move forward - if we pin versions, we are less likely to see errors like these, but then perhaps we _do_ want to see them so we can stay up to date with the Google client updates.

Signed-off-by: vsoch <vsochat@stanford.edu>