### PR TITLE
add short option for restart times

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Unreleased
+==========
+Added
+-----
+- Added short option ``-T`` for CLI parameter ``--restart-times`` (@mbhall88).
+
 [5.21.0] - 2020-08-11
 =====================
 

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1533,6 +1533,7 @@ def get_argument_parser(profile=None):
         "fractions allowed.",
     )
     group_behavior.add_argument(
+        "-T",
         "--restart-times",
         default=0,
         type=int,


### PR DESCRIPTION
I find myself using `--restart-times` a lot. And I'm lazy. So I added a short option. Happy to change it to another letter if `-T` is not to your liking?