### PR TITLE
converting GS updated datetime to epoch time float timestamp

### DIFF
--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -143,7 +143,7 @@ class RemoteObject(AbstractRemoteObject):
             # By way of being listed, it exists. mtime is a datetime object
             name = "{}/{}".format(blob.bucket.name, blob.name)
             cache.exists_remote[name] = True
-            cache.mtime[name] = blob.updated
+            cache.mtime[name] = blob.updated.timestamp()
             cache.size[name] = blob.size
 
         # Mark bucket and prefix as having an inventory, such that this method is


### PR DESCRIPTION
This should be a quick fix to convert the GS blob timestamp (when last updated) to an int (since epoch time) so we can compare. This will fix https://github.com/snakemake/snakemake/issues/572. Here is how I quickly tested:

```
blob.updated
datetime.datetime(2020, 6, 2, 10, 56, 4, 988000, tzinfo=<UTC>)

# float
blob.updated.timestamp()
1591095364.988

# int
int(blob.updated.timestamp())
1591095364
```

Signed-off-by: vsoch <vsochat@stanford.edu>