### PR TITLE
remove space from problem name

### DIFF
--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -556,7 +556,7 @@ class JobScheduler:
             )
             for temp_file in temp_files
         }
-        prob = pulp.LpProblem("Job scheduler", pulp.LpMaximize)
+        prob = pulp.LpProblem("JobScheduler", pulp.LpMaximize)
 
         total_temp_size = max(sum([temp_file.size for temp_file in temp_files]), 1)
         total_core_requirement = sum(


### PR DESCRIPTION
This removes the space from the LpProblem name to prevent the following warning:
  `warnings.warn("Spaces are not permitted in the name. Converted to '_'")` from https://github.com/coin-or/pulp/blob/76b28fb9005ca2e78974c80dd8dd2ef2d696f1f6/pulp/pulp.py#L1194-L1195.