### PR TITLE
Detect and give useful error for missing "wildcards."

### DIFF
--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -405,6 +405,11 @@ def format(_pattern, *args, stepout=1, _quote_all=False, **kwargs):
     try:
         return fmt.format(_pattern, *args, **variables)
     except KeyError as ex:
+        if str(ex).strip("'") in variables["wildcards"].keys():
+            raise NameError(
+                "The name '{0}' is unknown in this context. "
+                "Did you mean 'wildcards.{0}'".format(str(ex).strip("'"))
+            )
         raise NameError(
             "The name {} is unknown in this context. Please "
             "make sure that you defined that variable. "

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -408,7 +408,7 @@ def format(_pattern, *args, stepout=1, _quote_all=False, **kwargs):
         if str(ex).strip("'") in variables["wildcards"].keys():
             raise NameError(
                 "The name '{0}' is unknown in this context. "
-                "Did you mean 'wildcards.{0}'".format(str(ex).strip("'"))
+                "Did you mean 'wildcards.{0}'?".format(str(ex).strip("'"))
             )
         raise NameError(
             "The name {} is unknown in this context. Please "


### PR DESCRIPTION
Detect the case where a user has put a wildcard in the shell commands
without prefixing with "wildcards." This allows giving a useful error
message, rather than the more generic NameError message.