### PR TITLE
adding google life sciences logging save to storage bucket

### DIFF
--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+# This is a helper script for the Google Life Sciences instance to be able to:
+# 1. download a blob from storage, which is required at the onset of the Snakemake
+#     gls.py download <bucket> <source> <destination>
+# workflow step to obtain the working directory.
+# 2. Upload logs back to storage (or some specified directory of files)
+#    gls.py save <bucket> <source-dir> <destination-dir>
+#    gls.py save <bucket> /google/logs/output source/logs
+
+import argparse
+import datetime
+
+from google.cloud import storage
+from glob import glob
+import sys
+import os
+
+
+def download_blob(bucket_name, source_blob_name, destination_file_name):
+    """Downloads a blob from the bucket."""
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+
+    blob.download_to_filename(destination_file_name)
+
+    print("Blob {} downloaded to {}.".format(source_blob_name, destination_file_name))
+
+
+def save_files(bucket_name, source_path, destination_path):
+    """given a directory path, save all files recursively to storage
+    """
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(bucket_name)
+
+    # destination path should be stripped of path indicators too
+    bucket_name = bucket_name.strip("/")
+    destination_path = destination_path.strip("/")
+
+    # These are fullpaths
+    filenames = get_source_files(source_path)
+    print("\nThe following files will be uploaded: %s" % "\n".join(filenames))
+
+    if not filenames:
+        print("Did not find any filenames under %s" % source_path)
+
+    # Do the upload!
+    for filename in filenames:
+
+        # The relative path of the filename from the source path
+        relative_path = filename.replace(source_path, "", 1).strip("/")
+
+        # The path in storage includes relative path from destination_path
+        storage_path = os.path.join(destination_path, relative_path)
+        full_path = os.path.join(bucket_name, storage_path)
+        print(f"{filename} -> {full_path}")
+
+        # Get the blob
+        blob = bucket.blob(storage_path)
+        if not blob.exists():
+            print("Uploading %s to %s" % (filename, full_path))
+            blob.upload_from_filename(filename)
+
+
+def get_source_files(source_path):
+    """Given a directory, return a listing of files to upload
+    """
+    filenames = []
+    if not os.path.exists(source_path):
+        print("%s does not exist!" % source_path)
+        sys.exit(0)
+
+    for x in os.walk(source_path):
+        for name in glob(os.path.join(x[0], "*")):
+            if not os.path.isdir(name):
+                filenames.append(name)
+    return filenames
+
+
+def add_ending_slash(filename):
+    """Since we want to replace based on having an ending slash, ensure it's there
+    """
+    if not filename.endswith("/"):
+        filename = "%s/" % filename
+    return filename
+
+
+def blob_commands(args):
+    if args.command == "download":
+        download_blob(
+            args.bucket_name, args.source_blob_name, args.destination_file_name
+        )
+    elif args.command == "save":
+        save_files(args.bucket_name, args.source_path, args.destination_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Download file from storage
+    download_parser = subparsers.add_parser("download", help=download_blob.__doc__)
+    download_parser.add_argument("bucket_name", help="Your cloud storage bucket.")
+    download_parser.add_argument("source_blob_name")
+    download_parser.add_argument("destination_file_name")
+
+    # Save logs to storage
+    save_parser = subparsers.add_parser("save", help=save_files.__doc__)
+    save_parser.add_argument("bucket_name", help="Your cloud storage bucket.")
+    save_parser.add_argument("source_path")
+    save_parser.add_argument("destination_path")
+
+    args = parser.parse_args()
+    blob_commands(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will address discussion in #457 to save google life sciences logs from the instance to cloud storage. This works by way of:

 - modifying the same download script to also handle uploads, the one in the gist. Note that I'm also adding the source code here (google_lifesciences_helper.py) so that after it's merged, we can update to use this file instead of a random gist.
 - defining a google life sciences logs directory to be in the storage prefix + google-lifesciences-logs + `<job name>`
 - adding an extra action after the job step to save whatever output is found under `/google/logs` to this location
 - giving the user a message to look for them here.

Along with debub statements for the logging directory, the message to the user is also updated to include where to look for logs:

```
Get status with:
gcloud config set project snakemake-testing
gcloud beta lifesciences operations describe projects/snakemake-testing/locations/us-central1/operations/8491560402244231150
gcloud beta lifesciences operations list
Logs will be saved to: snakemake-testing/snakemake-testing-ls8kbk1d/google-lifescience-logs
```
The logs step has `alwaysRun` set to true to ensure that we run it even on fail.  Here is what the output folder looks like, note that "logs" (generated by snakemake) is distinct from "google-lifesciences-logs) (also note that I've updated this name to be google-lifesciences-logs and not google-lifescience-logs.

![image](https://user-images.githubusercontent.com/814322/92027356-a5398200-ed1f-11ea-9e86-78072c795480.png)

The subfolders in there are named based on the step (job):

![image](https://user-images.githubusercontent.com/814322/92027461-d1550300-ed1f-11ea-8a65-2635c17f30f6.png)

And within that folder, there is the expected output and actions from the instance:

![image](https://user-images.githubusercontent.com/814322/92027503-e29e0f80-ed1f-11ea-81ca-932be8a3e111.png)

I was first put off when I realized that we don't have the entire snakemake workflow in one pipeline (each job is treated separately) but I think this strategy is better, at least for logging, because it means the logs will show up as soon as a step is finished, and the user doens't need to wait for the entire workflow to finish.

Here is what an output file looks like

<details>

```
--2020-09-02 19:20:49--  https://gist.githubusercontent.com/vsoch/f5a6a6d1894be1e67aa4156c5b40c8e9/raw/a4e9ddbeba20996ca62745fcd4d9ecd7bfa3b311/gls.py
Resolving gist.githubusercontent.com (gist.githubusercontent.com)... 151.101.0.133, 151.101.64.133, 151.101.128.133, ...
Connecting to gist.githubusercontent.com (gist.githubusercontent.com)|151.101.0.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4071 (4.0K) [text/plain]
Saving to: ‘/download.py’

     0K ...                                                   100% 47.2M=0s

2020-09-02 19:20:49 (47.2 MB/s) - ‘/download.py’ saved [4071/4071]

Blob source/cache/workdir-a7b13fdf66b12d741848cf7aa5a364baf240a3e33b7eaae7fab6f1d8b5671e90.tar.gz downloaded to /tmp/workdir.tar.gz.
env.yml
Snakefile
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Job counts:
	count	jobs
	1	copy
	1

[Wed Sep  2 19:20:53 2020]
rule copy:
    input: gcp-public-data-landsat/LC08/01/001/003/LC08_L1GT_001003_20170430_20170501_01_RT/LC08_L1GT_001003_20170430_20170501_01_RT_MTL.txt
    output: snakemake-testing/snakemake-testing-ls8kbk1d/landsat-data.txt
    jobid: 0
    resources: mem_mb=100, disk_mb=128000

Downloading from remote: gcp-public-data-landsat/LC08/01/001/003/LC08_L1GT_001003_20170430_20170501_01_RT/LC08_L1GT_001003_20170430_20170501_01_RT_MTL.txt
Finished download.
Uploading to remote: snakemake-testing/snakemake-testing-ls8kbk1d/landsat-data.txt
Finished upload.
[Wed Sep  2 19:20:53 2020]
Finished job 0.
1 of 1 steps (100%) done
Complete log: /workdir/.snakemake/log/2020-09-02T192052.620149.snakemake.log
--2020-09-02 19:20:55--  https://gist.githubusercontent.com/vsoch/f5a6a6d1894be1e67aa4156c5b40c8e9/raw/a4e9ddbeba20996ca62745fcd4d9ecd7bfa3b311/gls.py
Resolving gist.githubusercontent.com (gist.githubusercontent.com)... 151.101.0.133, 151.101.64.133, 151.101.128.133, ...
Connecting to gist.githubusercontent.com (gist.githubusercontent.com)|151.101.0.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4071 (4.0K) [text/plain]
Saving to: ‘/gls.py’

     0K ...                                                   100% 5.27M=0.001s

2020-09-02 19:20:55 (5.27 MB/s) - ‘/gls.py’ saved [4071/4071]
```

</details>

and example of stdout (there was no error so it worked as expected

<details>
```
Blob source/cache/workdir-a7b13fdf66b12d741848cf7aa5a364baf240a3e33b7eaae7fab6f1d8b5671e90.tar.gz downloaded to /tmp/workdir.tar.gz.
env.yml
Snakefile
```
</details>

Hopefully this would be useful in the case of a more complicated error (in the stdout) - we will wait to see!

Signed-off-by: vsoch <vsochat@stanford.edu>