### PR TITLE
Revert "ENH: use multi-stage builds + install singularity from source + use nonroot user"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,22 @@
-ARG PYTHON_VERSION="3.8"
-ARG CONDA_VERSION="latest"
-ARG SINGULARITY_VERSION="3.6.1"
-ARG NONROOT_USER="nonroot"
-ARG NONROOT_UID="1000"
-ARG NONROOT_GID="100"
-ARG DEBIAN_FRONTEND="noninteractive"
-
-# Compile Singularity.
-FROM golang:1.14.6-stretch AS singularityBuilder
-ARG DEBIAN_FRONTEND
-ARG SINGULARITY_VERSION
-WORKDIR /opt/singularity
-RUN apt-get update -qq \
-    && apt-get install --yes --no-install-recommends \
-        cryptsetup \
-        git \
-        libgpgme11-dev \
-        libseccomp-dev \
-        libssl-dev \
-        pkg-config \
-        squashfs-tools \
-        uuid-dev \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL "https://github.com/hpcng/singularity/releases/download/v${SINGULARITY_VERSION}/singularity-${SINGULARITY_VERSION}.tar.gz" \
-    | tar xz --strip-components 1 \
-    && ./mconfig --prefix=/opt/singularity \
-    && cd builddir \
-    && make \
-    && make install
-
-# Install Snakemake and its dependencies.
-FROM "continuumio/miniconda3:${CONDA_VERSION}" as snakemakeBuilder
-ARG DEBIAN_FRONTEND
-ARG PYTHON_VERSION
-RUN conda config --add channels bioconda \
-    && conda config --add channels conda-forge \
-    # Fast drop-in replacement for conda.
-    && conda install --yes --quiet mamba \
-    && mamba install --yes --quiet "python=$PYTHON_VERSION" \
-    && mamba install --yes --quiet --only-deps snakemake snakemake-minimal \
-    # Is this OK?
-    && mamba remove --yes --quiet mamba \
-    && conda clean --all --yes
-WORKDIR /tmp/snakemake
-COPY . .
-RUN python -m pip install --no-cache-dir .[reports,messaging,google-cloud]
-
-# Build final image.
-FROM "continuumio/miniconda3:${CONDA_VERSION}"
-ARG DEBIAN_FRONTEND
-ARG NONROOT_USER
-ARG NONROOT_UID
-ARG NONROOT_GID
-# Install Singularity runtime dependencies.
-RUN apt-get update -qq \
-    && apt-get install --yes --no-install-recommends \
-        cryptsetup \
-        squashfs-tools \
-    && rm -rf /var/lib/apt/lists/*
-# Create non-root user.
-RUN useradd --create-home --shell /bin/bash -u "$NONROOT_UID" -g "$NONROOT_GID" "$NONROOT_USER"
-USER "$NONROOT_UID"
-# Add Singularity and conda. This overwrites the /opt/conda directory but that is OK
-# because the snakemakeBuilder stage and the final stage are derived from the same
-# base image.
-COPY --from=snakemakeBuilder --chown="$NONROOT_UID":"$NONROOT_GID" /opt /opt
-COPY --from=singularityBuilder /opt/singularity /opt/singularity
-ENV PATH="/opt/conda/bin:/opt/singularity/bin:$PATH"
-WORKDIR /work
-ENTRYPOINT ["/opt/conda/bin/snakemake"]
-LABEL maintainer="Johannes Köster <johannes.koester@tu-dortmund.de>"
+FROM bitnami/minideb:stretch
+MAINTAINER Johannes Köster <johannes.koester@tu-dortmund.de>
+ADD . /tmp/repo
+WORKDIR /tmp/repo
+ENV PATH /opt/conda/bin:${PATH}
+ENV LANG C.UTF-8
+ENV SHELL /bin/bash
+RUN /bin/bash -c "install_packages wget bzip2 ca-certificates gnupg2 squashfs-tools git && \
+    wget -O- https://neuro.debian.net/lists/xenial.us-ca.full > /etc/apt/sources.list.d/neurodebian.sources.list && \
+    wget -O- https://neuro.debian.net/_static/neuro.debian.net.asc | apt-key add - && \
+    install_packages singularity-container"
+RUN /bin/bash -c "wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
+    rm Miniconda3-latest-Linux-x86_64.sh"
+RUN /bin/bash -c "conda install -y -c conda-forge mamba && \
+    mamba create -q -y -c conda-forge -c bioconda -n snakemake snakemake snakemake-minimal --only-deps && \
+    conda clean --all -y && \
+    source activate snakemake && \
+    which python && \
+    pip install .[reports,messaging,google-cloud]"
+RUN echo "source activate snakemake" > ~/.bashrc
+ENV PATH /opt/conda/envs/snakemake/bin:${PATH}


### PR DESCRIPTION
Reverts snakemake/snakemake#531. It seems like the changes cause issues with cloud execution: https://github.com/snakemake/snakemake/runs/1090789849#step:11:591