### PR TITLE
Updating pulp >=2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "psutil",
         "nbformat",
         "toposort",
-        "pulp <=1.6.8",
+        "pulp >=2.0",
     ],
     extras_require={
         "reports": ["jinja2", "networkx", "pygments", "pygraphviz"],


### PR DESCRIPTION
Testing update of pulp to avoid Python 3.8 deprecation of time.clock (used in solvers.py). This will close #617 (if it works!).