### PR TITLE
Fix lpvariable

### DIFF
--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -566,7 +566,7 @@ class JobScheduler:
                 upBound=1,
                 cat=pulp.LpInteger,
             )
-            for idx, job in enumerate(jobs)
+            for idx, _ in enumerate(jobs)
         }
 
         temp_files = {
@@ -575,19 +575,19 @@ class JobScheduler:
 
         temp_job_improvement = {
             temp_file: pulp.LpVariable(
-                temp_file, lowBound=0, upBound=1, cat="Continuous"
+                "temp_file_{}".format(idx), lowBound=0, upBound=1, cat="Continuous"
             )
-            for temp_file in temp_files
+            for idx, _ in enumerate(temp_files)
         }
 
         temp_file_deletable = {
             temp_file: pulp.LpVariable(
-                "deletable_{}".format(temp_file),
+                "deletable_{}".format(idx),
                 lowBound=0,
                 upBound=1,
                 cat=pulp.LpInteger,
             )
-            for temp_file in temp_files
+            for idx, _ in enumerate(temp_files)
         }
         prob = pulp.LpProblem("JobScheduler", pulp.LpMaximize)
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -566,7 +566,7 @@ class JobScheduler:
                 upBound=1,
                 cat=pulp.LpInteger,
             )
-            for idx, _ in enumerate(jobs)
+            for idx, job in enumerate(jobs)
         }
 
         temp_files = {
@@ -577,7 +577,7 @@ class JobScheduler:
             temp_file: pulp.LpVariable(
                 "temp_file_{}".format(idx), lowBound=0, upBound=1, cat="Continuous"
             )
-            for idx, _ in enumerate(temp_files)
+            for idx, temp_file in enumerate(temp_files)
         }
 
         temp_file_deletable = {
@@ -587,7 +587,7 @@ class JobScheduler:
                 upBound=1,
                 cat=pulp.LpInteger,
             )
-            for idx, _ in enumerate(temp_files)
+            for idx, temp_file in enumerate(temp_files)
         }
         prob = pulp.LpProblem("JobScheduler", pulp.LpMaximize)
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -561,7 +561,7 @@ class JobScheduler:
         # assert self.resources["_cores"] > 0
         scheduled_jobs = {
             job: pulp.LpVariable(
-                "job_{job}_{idx}".format(job=job, idx=idx),
+                "job_{idx}".format(idx=idx),
                 lowBound=0,
                 upBound=1,
                 cat=pulp.LpInteger,


### PR DESCRIPTION
It happens that ilp scheduling fails caused by a too long LpVariable-name(see [https://github.com/snakemake/snakemake/issues/635](https://github.com/snakemake/snakemake/issues/635)).
This occurs as the scheduler takes the name of a temp file as variable name.
Additionally, based on the file name pulp throws warning incase it contains illegal characters.

To solve both issues variables variables now consist of a prefix (preventing the illegal character warning) and a index value replacing the file names. Ensuring that variable names keep short and do not contain any special characters.

