### PR TITLE
Updating google_lifesciences.py

### DIFF
--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -675,7 +675,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         commands = [
             "/bin/bash",
             "-c",
-            "wget -O /gls.py https://gist.githubusercontent.com/vsoch/f5a6a6d1894be1e67aa4156c5b40c8e9/raw/a4e9ddbeba20996ca62745fcd4d9ecd7bfa3b311/gls.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s"
+            "wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/master/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s"
             % (self.bucket.name, self.gs_logs, job.name),
         ]
 


### PR DESCRIPTION
We want to update the GLS executor to use the helper script provided in the repository, instead of the one in a gist. The gist is here https://gist.githubusercontent.com/vsoch/f5a6a6d1894be1e67aa4156c5b40c8e9/raw/a4e9ddbeba20996ca62745fcd4d9ecd7bfa3b311/gls.py in case anyone wants to do a comparison!