### PR TITLE
Update Miniconda download URLs

### DIFF
--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -83,14 +83,14 @@ Assuming that you have a 64-bit system, on Linux, download and install Miniconda
 
 .. code:: console
 
-    $ wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+    $ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
     $ bash Miniconda3-latest-Linux-x86_64.sh
 
 On MacOS X, download and install with
 
 .. code:: console
 
-    $ curl https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
+    $ curl https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -o Miniconda3-latest-MacOSX-x86_64.sh
     $ bash Miniconda3-latest-MacOSX-x86_64.sh
 
 For a 32-bit system, URLs and file names are analogous but without the ``_64``.


### PR DESCRIPTION
Miniconda download locations [have moved](https://docs.conda.io/en/latest/miniconda.html#miniconda). Fixes #612.