### PR TITLE
Optimizations to handle large workflows

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -935,11 +935,11 @@ class DAG:
         for job in candidates:
             update_needrun(job)
 
-        queue = list(filter(reason, candidates))
+        queue = deque(filter(reason, candidates))
         visited = set(queue)
         candidates_set = set(candidates)
         while queue:
-            job = queue.pop(0)
+            job = queue.popleft()
             _needrun.add(job)
 
             for job_, files in dependencies[job].items():

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -9,7 +9,7 @@ import shutil
 import textwrap
 import time
 import tarfile
-from collections import defaultdict, Counter
+from collections import defaultdict, Counter, deque
 from itertools import chain, filterfalse, groupby
 from functools import partial
 from pathlib import Path
@@ -937,6 +937,7 @@ class DAG:
 
         queue = list(filter(reason, candidates))
         visited = set(queue)
+        candidates_set = set(candidates)
         while queue:
             job = queue.pop(0)
             _needrun.add(job)
@@ -949,7 +950,7 @@ class DAG:
                     queue.append(job_)
 
             for job_, files in depending[job].items():
-                if job_ in candidates:
+                if job_ in candidates_set:
                     reason(job_).updated_input_run.update(files)
                     if not job_ in visited:
                         visited.add(job_)
@@ -1070,9 +1071,11 @@ class DAG:
         if jobs is None:
             jobs = self.needrun_jobs
 
+        potential_new_ready_jobs = False
         candidate_groups = set()
         for job in jobs:
             if not self.finished(job) and self._ready(job):
+                potential_new_ready_jobs = True
                 if job.group is None:
                     self._ready_jobs.add(job)
                 else:
@@ -1085,6 +1088,7 @@ class DAG:
             for group in candidate_groups
             if all(self._ready(job) for job in group)
         )
+        return potential_new_ready_jobs
 
     def get_jobs_or_groups(self):
         visited_groups = set()
@@ -1252,7 +1256,7 @@ class DAG:
 
         # mark depending jobs as ready
         # skip jobs that are marked as until jobs
-        self.update_ready(
+        potential_new_ready_jobs = self.update_ready(
             j
             for job in jobs
             for j in self.depending[job]
@@ -1281,6 +1285,9 @@ class DAG:
                 self.pull_container_imgs()
             if self.workflow.use_conda:
                 self.create_conda_envs()
+            potential_new_ready_jobs = True
+
+        return potential_new_ready_jobs
 
     def new_job(self, rule, targetfile=None, format_wildcards=None):
         """Create new job for given rule and (optional) targetfile.
@@ -1459,10 +1466,10 @@ class DAG:
 
     def bfs(self, direction, *jobs, stop=lambda job: False):
         """Perform a breadth-first traversal of the DAG."""
-        queue = list(jobs)
+        queue = deque(jobs)
         visited = set(queue)
         while queue:
-            job = queue.pop(0)
+            job = queue.popleft()
             if stop(job):
                 # stop criterion reached for this node
                 continue

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1491,25 +1491,29 @@ class PeriodicityDetector:
 
     def is_periodic(self, value):
         """Returns the periodic substring or None if not periodic."""
-        #short-circuit: need at least min_repeat characters
+        # short-circuit: need at least min_repeat characters
         if len(value) < self.min_repeat:
             return None
 
-        #short-circuit: need at least min_repeat same characters
+        # short-circuit: need at least min_repeat same characters
         last_letter = value[-1]
         counter = collections.Counter(value)
         if counter[last_letter] < self.min_repeat:
             return None
 
-        #short-circuit: need at least min_repeat same characters
+        # short-circuit: need at least min_repeat same characters
         pos = 2
-        while (value[-pos] != last_letter):  # as long as last letter is not seen, repeat length is minimally pos
-            if (len(value) < (pos * self.min_repeat)
-                    or counter[value[-pos]] < self.min_repeat):
+        while (
+            value[-pos] != last_letter
+        ):  # as long as last letter is not seen, repeat length is minimally pos
+            if (
+                len(value) < (pos * self.min_repeat)
+                or counter[value[-pos]] < self.min_repeat
+            ):
                 return None
             pos += 1
 
-        #now do the expensive regex
+        # now do the expensive regex
         m = self.regex.search(value)  # search for a periodic suffix.
         if m is not None:
             return m.group("value")

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1482,6 +1482,7 @@ class PeriodicityDetector:
             max_repeat (int): The maximum length of the periodic substring.
             min_repeat (int): The minimum length of the periodic substring.
         """
+        self.min_repeat = min_repeat
         self.regex = re.compile(
             "((?P<value>.+)(?P=value){{{min_repeat},{max_repeat}}})$".format(
                 min_repeat=min_repeat - 1, max_repeat=max_repeat - 1
@@ -1490,6 +1491,25 @@ class PeriodicityDetector:
 
     def is_periodic(self, value):
         """Returns the periodic substring or None if not periodic."""
+        #short-circuit: need at least min_repeat characters
+        if len(value) < self.min_repeat:
+            return None
+
+        #short-circuit: need at least min_repeat same characters
+        last_letter = value[-1]
+        counter = collections.Counter(value)
+        if counter[last_letter] < self.min_repeat:
+            return None
+
+        #short-circuit: need at least min_repeat same characters
+        pos = 2
+        while (value[-pos] != last_letter):  # as long as last letter is not seen, repeat length is minimally pos
+            if (len(value) < (pos * self.min_repeat)
+                    or counter[value[-pos]] < self.min_repeat):
+                return None
+            pos += 1
+
+        #now do the expensive regex
         m = self.regex.search(value)  # search for a periodic suffix.
         if m is not None:
             return m.group("value")

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -355,18 +355,13 @@ class JobScheduler:
         except AttributeError:
             raise TypeError("Executor does not support stats")
 
-    def candidate(self, job):
-        """ Return whether a job is a candidate to be executed. """
-        return (
-            job not in self.running
-            and job not in self.failed
-            and (self.dryrun or (not job.dynamic_input and not self.dag.dynamic(job)))
-        )
-
     @property
     def open_jobs(self):
         """ Return open jobs. """
-        return filter(self.candidate, list(job for job in self.dag.ready_jobs))
+        jobs = self.dag.ready_jobs - (self.running |  self.failed)
+        if not self.dryrun:
+            jobs = [job for job in jobs if not job.dynamic_input and not self.dag.dynamic(job)]
+        return jobs
 
     @property
     def remaining_jobs(self):
@@ -502,7 +497,7 @@ class JobScheduler:
                     return
 
             try:
-                self.dag.finish(job, update_dynamic=update_dynamic)
+                potential_new_ready_jobs = self.dag.finish(job, update_dynamic=update_dynamic)
             except (RuleException, WorkflowError) as e:
                 # if an error occurs while processing job output,
                 # we do the same as in case of errors during execution
@@ -525,8 +520,8 @@ class JobScheduler:
                 self.progress()
 
             if (
-                any(self.open_jobs)
-                or not self.running
+                not self.running 
+                or (potential_new_ready_jobs and self.open_jobs)
                 or self.workflow.immediate_submit
             ):
                 # go on scheduling if open jobs are ready or no job is running

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -358,7 +358,10 @@ class JobScheduler:
     @property
     def open_jobs(self):
         """ Return open jobs. """
-        jobs = self.dag.ready_jobs - (self.running | self.failed)
+        jobs = set(self.dag.ready_jobs)
+        jobs -= self.running
+        jobs -= self.failed
+
         if not self.dryrun:
             jobs = [
                 job

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -358,9 +358,13 @@ class JobScheduler:
     @property
     def open_jobs(self):
         """ Return open jobs. """
-        jobs = self.dag.ready_jobs - (self.running |  self.failed)
+        jobs = self.dag.ready_jobs - (self.running | self.failed)
         if not self.dryrun:
-            jobs = [job for job in jobs if not job.dynamic_input and not self.dag.dynamic(job)]
+            jobs = [
+                job
+                for job in jobs
+                if not job.dynamic_input and not self.dag.dynamic(job)
+            ]
         return jobs
 
     @property
@@ -497,7 +501,9 @@ class JobScheduler:
                     return
 
             try:
-                potential_new_ready_jobs = self.dag.finish(job, update_dynamic=update_dynamic)
+                potential_new_ready_jobs = self.dag.finish(
+                    job, update_dynamic=update_dynamic
+                )
             except (RuleException, WorkflowError) as e:
                 # if an error occurs while processing job output,
                 # we do the same as in case of errors during execution
@@ -520,7 +526,7 @@ class JobScheduler:
                 self.progress()
 
             if (
-                not self.running 
+                not self.running
                 or (potential_new_ready_jobs and self.open_jobs)
                 or self.workflow.immediate_submit
             ):


### PR DESCRIPTION
Large workflows (njobs>10k) can become very slow due to some code which scales O(n^2). 

    * Change candidates in update_needrun from list to set 
       (enable quick member check)

    * Use deque for faster bfs jobs traversal
       (prevents memory copy due to popping of first item)

    * Optimize open_jobs using set operations.

    * Only run open_jobs if new jobs have potentially been added to ready jobs

    * Add short-circuits to the periodicity detector to improve its speed.