### PR TITLE
Separate metadata and incomplete job tracking

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -219,7 +219,7 @@ def snakemake(
         lock (bool):                lock the working directory when executing the workflow (default True)
         unlock (bool):              just unlock the working directory (default False)
         cleanup_metadata (list):    just cleanup metadata of given list of output files (default None)
-        drop_metadata (bool):       drop metadata tracking information after job (code/input/params/version change listings will be incomplete) (default False)
+        drop_metadata (bool):       drop metadata file tracking information after job finishes (--report and --list_x_changes information will be incomplete) (default False)
         conda_cleanup_envs (bool):  just cleanup unused conda environments (default False)
         cleanup_shadow (bool):      just cleanup old shadow directories (default False)
         cleanup_scripts (bool):     delete wrapper scripts used for execution (default True)
@@ -1573,7 +1573,9 @@ def get_argument_parser(profile=None):
     group_utils.add_argument(
         "--drop-metadata",
         action="store_true",
-        help="Drop metadata after job completion.",
+        help="Drop metadata file tracking information after job finishes. "
+        "Provenance-information based reports (e.g. --report and the "
+        "--list_x_changes functions) will be empty or incomplete.",
     )
     group_utils.add_argument("--version", "-v", action="version", version=__version__)
 

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -163,6 +163,7 @@ def snakemake(
     export_cwl=None,
     show_failed_logs=False,
     keep_incomplete=False,
+    keep_metadata=True,
     messaging=None,
     edit_notebook=None,
     envvars=None,
@@ -218,6 +219,7 @@ def snakemake(
         lock (bool):                lock the working directory when executing the workflow (default True)
         unlock (bool):              just unlock the working directory (default False)
         cleanup_metadata (list):    just cleanup metadata of given list of output files (default None)
+        drop_metadata (bool):       drop metadata tracking information after job (code/input/params/version change listings will be incomplete) (default False)
         conda_cleanup_envs (bool):  just cleanup unused conda environments (default False)
         cleanup_shadow (bool):      just cleanup old shadow directories (default False)
         cleanup_scripts (bool):     delete wrapper scripts used for execution (default True)
@@ -744,6 +746,7 @@ def snakemake(
                     export_cwl=export_cwl,
                     batch=batch,
                     keepincomplete=keep_incomplete,
+                    keepmetadata=keep_metadata
                 )
 
     except BrokenPipeError:
@@ -1566,6 +1569,11 @@ def get_argument_parser(profile=None):
         "--keep-incomplete",
         action="store_true",
         help="Do not remove incomplete output files by failed jobs.",
+    )
+    group_utils.add_argument(
+        "--drop-metadata",
+        action="store_true",
+        help="Drop metadata after job completion.",
     )
     group_utils.add_argument("--version", "-v", action="version", version=__version__)
 
@@ -2582,6 +2590,7 @@ def main(argv=None):
             show_failed_logs=args.show_failed_logs,
             wms_monitor=args.wms_monitor,
             keep_incomplete=args.keep_incomplete,
+            keep_metadata=not args.drop_metadata,
             edit_notebook=args.edit_notebook,
             envvars=args.envvars,
             overwrite_groups=overwrite_groups,

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -746,7 +746,7 @@ def snakemake(
                     export_cwl=export_cwl,
                     batch=batch,
                     keepincomplete=keep_incomplete,
-                    keepmetadata=keep_metadata
+                    keepmetadata=keep_metadata,
                 )
 
     except BrokenPipeError:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -66,6 +66,7 @@ class AbstractExecutor:
         printthreads=True,
         latency_wait=3,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         self.workflow = workflow
         self.dag = dag
@@ -75,6 +76,7 @@ class AbstractExecutor:
         self.printthreads = printthreads
         self.latency_wait = latency_wait
         self.keepincomplete = keepincomplete
+        self.keepmetadata = keepmetadata
 
     def get_default_remote_provider_args(self):
         if self.workflow.default_remote_provider:
@@ -200,6 +202,7 @@ class RealExecutor(AbstractExecutor):
         latency_wait=3,
         assume_shared_fs=True,
         keepincomplete=False,
+        keepmetadata=False,
     ):
         super().__init__(
             workflow,
@@ -209,6 +212,7 @@ class RealExecutor(AbstractExecutor):
             printshellcmds=printshellcmds,
             latency_wait=latency_wait,
             keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
         self.assume_shared_fs = assume_shared_fs
         self.stats = Stats()
@@ -247,6 +251,7 @@ class RealExecutor(AbstractExecutor):
             ignore_missing_output=ignore_missing_output,
             latency_wait=self.latency_wait,
             assume_shared_fs=self.assume_shared_fs,
+            keep_metadata=self.keepmetadata,
         )
         self.stats.report_job_end(job)
 
@@ -285,6 +290,8 @@ class RealExecutor(AbstractExecutor):
 
         if self.workflow.use_env_modules:
             additional += " --use-envmodules"
+        if not self.keepmetadata:
+            additional += " --drop-metadata"
 
         return additional
 
@@ -380,6 +387,7 @@ class CPUExecutor(RealExecutor):
         latency_wait=3,
         cores=1,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         super().__init__(
             workflow,
@@ -389,6 +397,7 @@ class CPUExecutor(RealExecutor):
             printshellcmds=printshellcmds,
             latency_wait=latency_wait,
             keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
 
         self.exec_job = "\\\n".join(
@@ -600,6 +609,7 @@ class ClusterExecutor(RealExecutor):
         disable_default_remote_provider_args=False,
         disable_get_default_resources_args=False,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         from ratelimiter import RateLimiter
 
@@ -612,6 +622,8 @@ class ClusterExecutor(RealExecutor):
             printshellcmds=printshellcmds,
             latency_wait=latency_wait,
             assume_shared_fs=assume_shared_fs,
+            keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
 
         if not self.assume_shared_fs:
@@ -855,6 +867,7 @@ class GenericClusterExecutor(ClusterExecutor):
         assume_shared_fs=True,
         max_status_checks_per_second=1,
         keepincomplete=False,
+        keepmetadata=True,
     ):
 
         self.submitcmd = submitcmd
@@ -880,6 +893,8 @@ class GenericClusterExecutor(ClusterExecutor):
             restart_times=restart_times,
             assume_shared_fs=assume_shared_fs,
             max_status_checks_per_second=max_status_checks_per_second,
+            keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
 
         if statuscmd:
@@ -1100,6 +1115,7 @@ class SynchronousClusterExecutor(ClusterExecutor):
         restart_times=0,
         assume_shared_fs=True,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         super().__init__(
             workflow,
@@ -1114,6 +1130,8 @@ class SynchronousClusterExecutor(ClusterExecutor):
             restart_times=restart_times,
             assume_shared_fs=assume_shared_fs,
             max_status_checks_per_second=10,
+            keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
         self.submitcmd = submitcmd
         self.external_jobid = dict()
@@ -1209,6 +1227,7 @@ class DRMAAExecutor(ClusterExecutor):
         assume_shared_fs=True,
         max_status_checks_per_second=1,
         keepincomplete=False,
+        keepmetadata=True
     ):
         super().__init__(
             workflow,
@@ -1223,6 +1242,8 @@ class DRMAAExecutor(ClusterExecutor):
             restart_times=restart_times,
             assume_shared_fs=assume_shared_fs,
             max_status_checks_per_second=max_status_checks_per_second,
+            keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
         )
         try:
             import drmaa
@@ -1388,6 +1409,7 @@ class KubernetesExecutor(ClusterExecutor):
         local_input=None,
         restart_times=None,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         self.workflow = workflow
 
@@ -1757,6 +1779,7 @@ class TibannaExecutor(ClusterExecutor):
         restart_times=None,
         max_status_checks_per_second=1,
         keepincomplete=False,
+        keepmetadata=True,
     ):
         self.workflow = workflow
         self.workflow_sources = []

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1227,7 +1227,7 @@ class DRMAAExecutor(ClusterExecutor):
         assume_shared_fs=True,
         max_status_checks_per_second=1,
         keepincomplete=False,
-        keepmetadata=True
+        keepmetadata=True,
     ):
         super().__init__(
             workflow,

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1003,7 +1003,9 @@ class Job(AbstractJob):
                 )
         if not error:
             try:
-                self.dag.workflow.persistence.finished(self,keep_metadata=keep_metadata)
+                self.dag.workflow.persistence.finished(
+                    self, keep_metadata=keep_metadata
+                )
             except IOError as e:
                 logger.warning(
                     "Error recording metadata for finished job "

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -980,6 +980,7 @@ class Job(AbstractJob):
         ignore_missing_output=False,
         assume_shared_fs=True,
         latency_wait=None,
+        keep_metadata=True,
     ):
         if assume_shared_fs:
             if not error and handle_touch:
@@ -1002,7 +1003,7 @@ class Job(AbstractJob):
                 )
         if not error:
             try:
-                self.dag.workflow.persistence.finished(self)
+                self.dag.workflow.persistence.finished(self,keep_metadata=keep_metadata)
             except IOError as e:
                 logger.warning(
                     "Error recording metadata for finished job "

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -13,6 +13,7 @@ import time
 from base64 import urlsafe_b64encode, b64encode
 from functools import lru_cache, partial
 from itertools import filterfalse, count
+import pathlib
 
 from snakemake.logging import logger
 from snakemake.jobs import jobfiles
@@ -63,20 +64,27 @@ class Persistence:
         # place to store any auxiliary information needed during a run (e.g. source tarballs)
         self.aux_path = os.path.join(self.path, "auxiliary")
 
-        self.incomplete_oldapproach = os.path.exists(
-            self._metadata_path
-        ) and not os.path.exists(self._incomplete_path)
-        if self.incomplete_oldapproach:
-            self.incomplete = self._incomplete_oldapproach
-            self.started = self._started_oldapproach
-        else:
-            self.incomplete = self._incomplete_newapproach
-            self.started = self._started_newapproach
+        # migration of .snakemake folder structure
+        migration_indicator = pathlib.Path(
+            os.path.join(self._incomplete_path, "migration_underway")
+        )
+        if (
+            os.path.exists(self._metadata_path)
+            and not os.path.exists(self._incomplete_path)
+        ) or migration_indicator.exists():
             os.makedirs(self._incomplete_path, exist_ok=True)
-            self._incomplete_cache = None
+
+            migration_indicator.touch()
+
+            self.migrate_v1_to_v2()
+
+            migration_indicator.unlink()
+
+        self._incomplete_cache = None
 
         for d in (
             self._metadata_path,
+            self._incomplete_path,
             self.shadow_path,
             self.conda_env_archive_path,
             self.conda_env_path,
@@ -93,6 +101,26 @@ class Persistence:
             self.unlock = self.noop
 
         self._read_record = self._read_record_cached
+
+    def migrate_v1_to_v2(self):
+        logger.info("Migrating .snakemake folder to new format...")
+        for pos, filename in enumerate(os.listdir(self._metadata_path)):
+            with open(os.path.join(self._metadata_path, filename), "r") as f:
+                try:
+                    record = json.load(f)
+                except json.JSONDecodeError:
+                    continue  # not a properly formatted JSON file
+
+                if record.get("incomplete", False):
+                    shutil.copyfile(
+                        os.path.join(self._metadata_path, filename),
+                        os.path.join(self._incomplete_path, filename),
+                    )
+            # this can take a while for large folders...
+            if (pos % 10000) == 0 and pos > 0:
+                logger.info("{} files migrated".format(pos))
+
+        logger.info("Migration complete")
 
     @property
     def files(self):
@@ -171,7 +199,7 @@ class Persistence:
             if d not in in_use:
                 shutil.rmtree(os.path.join(self.conda_env_archive_path, d))
 
-    def _started_newapproach(self, job, external_jobid=None):
+    def started(self, job, external_jobid=None):
         for f in job.output:
             self._record(
                 self._incomplete_path,
@@ -179,24 +207,10 @@ class Persistence:
                 f,
             )
 
-    def _started_oldapproach(self, job, external_jobid=None):
-        for f in job.output:
-            self._record(
-                self._metadata_path,
-                {"incomplete": True, "external_jobid": external_jobid},
-                f,
-            )
-
     def finished(self, job, keep_metadata=True):
-        records_path = (
-            self._metadata_path
-            if self.incomplete_oldapproach
-            else self._incomplete_path
-        )
-
         if not keep_metadata:
             for f in job.expanded_output:
-                self._delete_record(records_path, f)
+                self._delete_record(self._incomplete_path, f)
             return
 
         version = str(job.rule.version) if job.rule.version is not None else None
@@ -208,7 +222,7 @@ class Persistence:
         conda_env = self._conda_env(job)
         fallback_time = time.time()
         for f in job.expanded_output:
-            rec_path = self._record_path(records_path, f)
+            rec_path = self._record_path(self._incomplete_path, f)
             starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
             endtime = f.mtime if os.path.exists(f) else fallback_time
             self._record(
@@ -230,21 +244,14 @@ class Persistence:
                 },
                 f,
             )
-            if not self.incomplete_oldapproach:
-                self._delete_record(self._incomplete_path, f)
+            self._delete_record(self._incomplete_path, f)
 
     def cleanup(self, job):
         for f in job.expanded_output:
             self._delete_record(self._incomplete_path, f)
             self._delete_record(self._metadata_path, f)
 
-    def _incomplete_oldapproach(self, job):
-        def marked_incomplete(f):
-            return self._read_record(self._metadata_path, f).get("incomplete", False)
-
-        return any(map(lambda f: f.exists and marked_incomplete(f), job.output))
-
-    def _incomplete_newapproach(self, job):
+    def incomplete(self, job):
         if self._incomplete_cache is None:
             self._cache_incomplete_folder()
 
@@ -267,14 +274,9 @@ class Persistence:
         }
 
     def external_jobids(self, job):
-        records_path = (
-            self._metadata_path
-            if self.incomplete_oldapproach
-            else self._incomplete_path
-        )
         return list(
             set(
-                self._read_record(records_path, f).get("external_jobid", None)
+                self._read_record(self._incomplete_path, f).get("external_jobid", None)
                 for f in job.output
             )
         )

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -193,45 +193,45 @@ class Persistence:
             if self.incomplete_oldapproach
             else self._incomplete_path
         )
+
         if not keep_metadata:
             for f in job.expanded_output:
                 self._delete_record(records_path, f)
-        else:
-            version = str(job.rule.version) if job.rule.version is not None else None
-            code = self._code(job.rule)
-            input = self._input(job)
-            log = self._log(job)
-            params = self._params(job)
-            shellcmd = job.shellcmd
-            conda_env = self._conda_env(job)
-            fallback_time = time.time()
-            for f in job.expanded_output:
-                rec_path = self._record_path(records_path, f)
-                starttime = (
-                    os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
-                )
-                endtime = f.mtime if os.path.exists(f) else fallback_time
-                self._record(
-                    self._metadata_path,
-                    {
-                        "version": version,
-                        "code": code,
-                        "rule": job.rule.name,
-                        "input": input,
-                        "log": log,
-                        "params": params,
-                        "shellcmd": shellcmd,
-                        "incomplete": False,
-                        "starttime": starttime,
-                        "endtime": endtime,
-                        "job_hash": hash(job),
-                        "conda_env": conda_env,
-                        "container_img_url": job.container_img_url,
-                    },
-                    f,
-                )
-                if not self.incomplete_oldapproach:
-                    self._delete_record(self._incomplete_path, f)
+            return
+
+        version = str(job.rule.version) if job.rule.version is not None else None
+        code = self._code(job.rule)
+        input = self._input(job)
+        log = self._log(job)
+        params = self._params(job)
+        shellcmd = job.shellcmd
+        conda_env = self._conda_env(job)
+        fallback_time = time.time()
+        for f in job.expanded_output:
+            rec_path = self._record_path(records_path, f)
+            starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
+            endtime = f.mtime if os.path.exists(f) else fallback_time
+            self._record(
+                self._metadata_path,
+                {
+                    "version": version,
+                    "code": code,
+                    "rule": job.rule.name,
+                    "input": input,
+                    "log": log,
+                    "params": params,
+                    "shellcmd": shellcmd,
+                    "incomplete": False,
+                    "starttime": starttime,
+                    "endtime": endtime,
+                    "job_hash": hash(job),
+                    "conda_env": conda_env,
+                    "container_img_url": job.container_img_url,
+                },
+                f,
+            )
+            if not self.incomplete_oldapproach:
+                self._delete_record(self._incomplete_path, f)
 
     def cleanup(self, job):
         for f in job.expanded_output:

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -63,7 +63,9 @@ class Persistence:
         # place to store any auxiliary information needed during a run (e.g. source tarballs)
         self.aux_path = os.path.join(self.path, "auxiliary")
 
-        self.incomplete_oldapproach =  os.path.exists(self._metadata_path) and not os.path.exists(self._incomplete_path)
+        self.incomplete_oldapproach = os.path.exists(
+            self._metadata_path
+        ) and not os.path.exists(self._incomplete_path)
         if self.incomplete_oldapproach:
             self.incomplete = self._incomplete_oldapproach
             self.started = self._started_oldapproach
@@ -91,7 +93,6 @@ class Persistence:
             self.unlock = self.noop
 
         self._read_record = self._read_record_cached
-
 
     @property
     def files(self):
@@ -177,6 +178,7 @@ class Persistence:
                 {"external_jobid": external_jobid},
                 f,
             )
+
     def _started_oldapproach(self, job, external_jobid=None):
         for f in job.output:
             self._record(
@@ -185,8 +187,12 @@ class Persistence:
                 f,
             )
 
-    def finished(self, job,keep_metadata=True):
-        records_path = self._metadata_path if self.incomplete_oldapproach else self._incomplete_path
+    def finished(self, job, keep_metadata=True):
+        records_path = (
+            self._metadata_path
+            if self.incomplete_oldapproach
+            else self._incomplete_path
+        )
         if not keep_metadata:
             for f in job.expanded_output:
                 self._delete_record(records_path, f)
@@ -201,7 +207,9 @@ class Persistence:
             fallback_time = time.time()
             for f in job.expanded_output:
                 rec_path = self._record_path(records_path, f)
-                starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
+                starttime = (
+                    os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
+                )
                 endtime = f.mtime if os.path.exists(f) else fallback_time
                 self._record(
                     self._metadata_path,
@@ -233,16 +241,20 @@ class Persistence:
     def _incomplete_oldapproach(self, job):
         def marked_incomplete(f):
             return self._read_record(self._metadata_path, f).get("incomplete", False)
+
         return any(map(lambda f: f.exists and marked_incomplete(f), job.output))
 
     def _incomplete_newapproach(self, job):
         if self._incomplete_cache is None:
             self._cache_incomplete_folder()
 
-        if self._incomplete_cache is False: #cache deactivated
+        if self._incomplete_cache is False:  # cache deactivated
+
             def marked_incomplete(f):
                 return self._exists_record(self._incomplete_path, f)
+
         else:
+
             def marked_incomplete(f):
                 rec_path = self._record_path(self._incomplete_path, f)
                 return rec_path in self._incomplete_cache
@@ -250,10 +262,16 @@ class Persistence:
         return any(map(lambda f: f.exists and marked_incomplete(f), job.output))
 
     def _cache_incomplete_folder(self):
-        self._incomplete_cache = {file_entry.path for file_entry in os.scandir(self._incomplete_path)}
+        self._incomplete_cache = {
+            file_entry.path for file_entry in os.scandir(self._incomplete_path)
+        }
 
     def external_jobids(self, job):
-        records_path = self._metadata_path if self.incomplete_oldapproach else self._incomplete_path
+        records_path = (
+            self._metadata_path
+            if self.incomplete_oldapproach
+            else self._incomplete_path
+        )
         return list(
             set(
                 self._read_record(records_path, f).get("external_jobid", None)
@@ -424,7 +442,6 @@ class Persistence:
         self._read_record_cached.cache_clear()
         self._read_record = self._read_record_uncached
         self._incomplete_cache = False
-
 
 
 def _bool_or_gen(func, job, file=None):

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -88,6 +88,7 @@ class JobScheduler:
         force_use_threads=False,
         assume_shared_fs=True,
         keepincomplete=False,
+        keepmetadata=True,
         scheduler_type=None,
         scheduler_ilp_solver=None,
     ):
@@ -109,6 +110,7 @@ class JobScheduler:
         self.greediness = 1
         self.max_jobs_per_second = max_jobs_per_second
         self.keepincomplete = keepincomplete
+        self.keepmetadata = keepmetadata
         self.scheduler_type = scheduler_type
         self.scheduler_ilp_solver = scheduler_ilp_solver
 
@@ -171,6 +173,7 @@ class JobScheduler:
                     latency_wait=latency_wait,
                     cores=local_cores,
                     keepincomplete=keepincomplete,
+                    keepmetadata=keepmetadata,
                 )
             if cluster or cluster_sync:
                 if cluster_sync:
@@ -195,6 +198,7 @@ class JobScheduler:
                     latency_wait=latency_wait,
                     assume_shared_fs=assume_shared_fs,
                     keepincomplete=keepincomplete,
+                    keepmetadata=keepmetadata,
                 )
                 if workflow.immediate_submit:
                     self._submit_callback = partial(
@@ -220,6 +224,7 @@ class JobScheduler:
                     assume_shared_fs=assume_shared_fs,
                     max_status_checks_per_second=max_status_checks_per_second,
                     keepincomplete=keepincomplete,
+                    keepmetadata=keepmetadata,
                 )
         elif kubernetes:
             self._local_executor = CPUExecutor(
@@ -232,6 +237,7 @@ class JobScheduler:
                 latency_wait=latency_wait,
                 cores=local_cores,
                 keepincomplete=keepincomplete,
+                keepmetadata=keepmetadata,
             )
 
             self._executor = KubernetesExecutor(
@@ -245,6 +251,7 @@ class JobScheduler:
                 latency_wait=latency_wait,
                 cluster_config=cluster_config,
                 keepincomplete=keepincomplete,
+                keepmetadata=keepmetadata,
             )
         elif tibanna:
             self._local_executor = CPUExecutor(
@@ -258,6 +265,7 @@ class JobScheduler:
                 latency_wait=latency_wait,
                 cores=local_cores,
                 keepincomplete=keepincomplete,
+                keepmetadata=keepmetadata,
             )
 
             self._executor = TibannaExecutor(
@@ -273,6 +281,7 @@ class JobScheduler:
                 printshellcmds=printshellcmds,
                 latency_wait=latency_wait,
                 keepincomplete=keepincomplete,
+                keepmetadata=keepmetadata,
             )
         elif google_lifesciences:
             self._local_executor = CPUExecutor(
@@ -314,6 +323,7 @@ class JobScheduler:
                 latency_wait=latency_wait,
                 cores=cores,
                 keepincomplete=keepincomplete,
+                keepmetadata=keepmetadata,
             )
         if self.max_jobs_per_second and not self.dryrun:
             max_jobs_frac = Fraction(self.max_jobs_per_second).limit_denominator()

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -549,6 +549,7 @@ class Workflow:
         export_cwl=False,
         batch=None,
         keepincomplete=False,
+        keepmetadata=True,
     ):
 
         self.check_localrules()
@@ -913,6 +914,7 @@ class Workflow:
             force_use_threads=force_use_threads,
             assume_shared_fs=assume_shared_fs,
             keepincomplete=keepincomplete,
+            keepmetadata=keepmetadata,
             scheduler_type=scheduler_type,
             scheduler_ilp_solver=scheduler_ilp_solver,
         )


### PR DESCRIPTION
Very large numbers of metadata files in the .snakemake/metadata folder can lead to slow performance on network file systems (e.g. Lustre) when checking if jobs are incomplete (--rerun-incomplete). 

1) This code separates the metadata and job-incomplete tracking, by creating an extra .snakemake/incomplete folder.
For the latter, it implements caching, as a simple file existence check suffices to determine if a job is incomplete.  The number of tracking files in the incomplete folder usually remains low, as these are deleted after a job finishes. This results in large speedups when combining --rerun-incomplete with a workflow with many files on a network file system.

Code has been added to enable backwards compatibility with the current .snakemake folder structure.

2) The PR adds also a command line option to make storing of persistent metadata optional to reduce the small file load. 



