### PR TITLE
fixing bug with using touch alongside remote prefix

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -461,9 +461,16 @@ class Workflow:
         assert (
             self.default_remote_provider is not None
         ), "No default remote provider is defined, calling this anyway is a bug"
-        path = "{}/{}".format(self.default_remote_prefix, path)
-        path = os.path.normpath(path)
-        return self.default_remote_provider.remote(path)
+
+        # This will convert any AnnotatedString to str
+        fullpath = "{}/{}".format(self.default_remote_prefix, path)
+        fullpath = os.path.normpath(fullpath)
+        remote = self.default_remote_provider.remote(fullpath)
+
+        # Important, update with previous flags in case of AnnotatedString #596
+        if hasattr(path, "flags"):
+            remote.flags.update(path.flags)
+        return remote
 
     def execute(
         self,

--- a/tests/test_google_lifesciences.py
+++ b/tests/test_google_lifesciences.py
@@ -52,3 +52,22 @@ def test_google_lifesciences():
         )
     finally:
         cleanup_google_storage(storage_prefix)
+
+
+@pytest.mark.skip(
+    reason="Cannot test using touch with a remote prefix until the container image is deployed."
+)
+@google_credentials
+def test_touch_remote_prefix():
+    storage_prefix = "snakemake-testing-%s" % next(tempfile._get_candidate_names())
+    workdir = dpath("test_touch_remote_prefix")
+    try:
+        run(
+            workdir,
+            use_conda=True,
+            default_remote_prefix="snakemake-testing/%s" % storage_prefix,
+            google_lifesciences=True,
+            google_lifesciences_cache=True,
+        )
+    finally:
+        cleanup_google_storage(storage_prefix)

--- a/tests/test_touch_remote_prefix/Snakefile.touch
+++ b/tests/test_touch_remote_prefix/Snakefile.touch
@@ -1,0 +1,11 @@
+rule all:
+    input: "fileJob2.txt"
+
+rule job1:
+    output: "fileJob1"
+    shell: "echo Hello World -- job1 > {output}"
+
+rule job2:
+    input: "fileJob1"
+    output: touch("fileJob2.txt")
+    shell: "echo Hello World! -- job2"

--- a/tests/test_touch_remote_prefix/expected-results/fileJob1
+++ b/tests/test_touch_remote_prefix/expected-results/fileJob1
@@ -1,0 +1,1 @@
+Hello World -- job1


### PR DESCRIPTION
This should address an issue that using touch() in a Snakefile with a remote prefix seems to strip away the touch (and likely any other flags that were present with the output or input argument. The reason comes down to the apply_remote_prefix function for a rule, which uses the workflow.apply_remote_prefix. In the case that an AnnotatedString is passed (with one or more flags such as touch) the conversion to a fullpath to derive the remote path strips away the annotations. This PR does a simple fix to check if the path has a flags attribute, and if so, update the object to maintain them. We assume that:

 - There will be no other passed types that have an equivalent flags attribute that might be mistakenly added
 - The original path cannot have a remote_object flag already defined (that would be overwritten).

I've added a test to run with the GLS executor (where the error is derived) but we can only enable it when the container image with the fix is deployed (which is used for the worker).
 
This will close #596 - there are lots of debugging notes there for anyone that wants more details.

Signed-off-by: vsoch <vsochat@stanford.edu>