### PR TITLE
apply latency-wait argument value to GLS job

### DIFF
--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -75,7 +75,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
             or (
                 "snakemake {target} --snakefile %s "
                 "--force -j{cores} --keep-target-files --keep-remote "
-                "--latency-wait 0 --scheduler {workflow.scheduler_type} "
+                "--latency-wait {latency_wait} --scheduler {workflow.scheduler_type} "
                 "--attempt 1 {use_threads} --max-inventory-time 0 "
                 "{overwrite_config} {rules} --nocolor "
                 "--notemp --no-hooks --nolock " % self.snakefile


### PR DESCRIPTION
The `exec_job` should apply the parameterized value, or default, of `latency_wait` that was provided to the GoogleLifeSciencesExecutor. 
The value was fixed at 0 with `--latency-wait 0`. Changing this to `--latency-wait {latency_wait}` means it will accept the user's configured `latency_wait` value or the default value of `3`.