### PR TITLE
Threaded local iocache

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -387,14 +387,13 @@ class _IOFile(str):
             counter = 0
             for entry in os.scandir(path):
                 if entry.is_dir():
-                    if not ".snakemake" in entry.path and \
-                              not cache.in_inventory(entry.path):
+                    if not ".snakemake" in entry.path and not cache.in_inventory(
+                        entry.path
+                    ):
                         queue.add(entry.path)
                     cache.exists_local[entry.path] = True
 
-                    timestamp_path = os.path.join(
-                        entry.path, ".snakemake_timestamp"
-                    )
+                    timestamp_path = os.path.join(entry.path, ".snakemake_timestamp")
                     if os.path.exists(timestamp_path):
                         cache.mtime[entry.path] = os.lstat(timestamp_path).st_mtime
                     else:

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -127,6 +127,15 @@ class RemoteObject(AbstractRemoteObject):
         self._bucket = None
         self._blob = None
 
+    @property
+    def inventory_path(self):
+        return "{}/{}".format(self.bucket_name, self.blob.name)
+
+    @property
+    def inventory_root(self):
+        subfolder = os.path.dirname(self.blob.name)
+        return "{}/{}".format(self.bucket_name, subfolder)
+
     def inventory(self, cache: snakemake.io.IOCache):
         """Using client.list_blobs(), we want to iterate over the objects in
         the "folder" of a bucket and store information about the IOFiles in the
@@ -150,12 +159,13 @@ class RemoteObject(AbstractRemoteObject):
             cache.exists_remote[name] = True
             cache.mtime[name] = blob.updated.timestamp()
             cache.size[name] = blob.size
+            cache.exists_local[name] = snakemake.io.IOCACHE_DEFERRED
 
         cache.remaining_wait_time -= time.time() - start_time
 
         # Mark bucket and prefix as having an inventory, such that this method is
         # only called once for the subfolder in the bucket.
-        cache.has_inventory.add("%s/%s" % (self.bucket_name, subfolder))
+        cache.has_inventory.add("{}/{}".format(self.bucket_name, subfolder))
 
     # === Implementations of abstract class members ===
 

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -165,7 +165,7 @@ class RemoteObject(AbstractRemoteObject):
 
         # Mark bucket and prefix as having an inventory, such that this method is
         # only called once for the subfolder in the bucket.
-        cache.has_inventory.add("{}/{}".format(self.bucket_name, subfolder))
+        cache.has_inventory.add(self.inventory_root)
 
     # === Implementations of abstract class members ===
 

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -169,10 +169,12 @@ class AbstractRemoteObject:
 
     @property
     def inventory_path(self):
+        # To enable inventory operations, this methods needs to return the path name of the file.
         pass
 
     @property
     def inventory_root(self):
+        # To enable inventory operations, this methods needs to return the directory name of the file.
         pass
 
     @abstractmethod

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -167,13 +167,28 @@ class AbstractRemoteObject:
         self.provider = provider
         self.protocol = protocol
 
+    @property
+    def inventory_path(self):
+        #returns path as used by the IOCache inventory
+        pass
+
+    @property
+    def inventory_root(self):
+        #should return folder that that contains this object and has to becached in IOCache
+        pass
+
+    @abstractmethod
     def inventory(self, cache: snakemake.io.IOCache):
-        """From this file, try to find as much existence and modification date
-        information as possible.
+        """From this file, try to find as much existence and modification date 
+        information as possible for files in the same folder.
         """
         # If this is implemented in a remote object, results have to be stored in
         # the given IOCache object.
         pass
+
+    def _add_to_inventory(self, cache: snakemake.io.IOCache, attribute):
+        cache[self.inventory_path] = getattr(self, attribute)
+
 
     @property
     def _file(self):

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -169,17 +169,17 @@ class AbstractRemoteObject:
 
     @property
     def inventory_path(self):
-        #returns path as used by the IOCache inventory
+        # returns path as used by the IOCache inventory
         pass
 
     @property
     def inventory_root(self):
-        #should return folder that that contains this object and has to becached in IOCache
+        # should return folder that that contains this object and has to becached in IOCache
         pass
 
     @abstractmethod
     def inventory(self, cache: snakemake.io.IOCache):
-        """From this file, try to find as much existence and modification date 
+        """From this file, try to find as much existence and modification date
         information as possible for files in the same folder.
         """
         # If this is implemented in a remote object, results have to be stored in
@@ -188,7 +188,6 @@ class AbstractRemoteObject:
 
     def _add_to_inventory(self, cache: snakemake.io.IOCache, attribute):
         cache[self.inventory_path] = getattr(self, attribute)
-
 
     @property
     def _file(self):


### PR DESCRIPTION
File stat operations are slow on network filesystems such as Lustre. When stat operations are not cached,
preparing the DAG becomes very slow for large workflows, with multi-hour runs at <10% cpu usage.

This PR starts from the recently added IOCache inventory framework, and makes the following changes:

* Enable local inventory caching for absolute paths:
  (currently nonfunctional as root = path.split("/", maxsplit=1)[0] in get_inventory_root will 
   be an empty string, and therefore need_inventory will be False for these paths)
  
* Perform only an inventory of the directory of the file, and not of its subdirectories.
  This leads to more predictable behaviour, as an inventory is only obtained of directories
  with workflow files. 
  
* get_inventory_root/path is moved from IOCache to IO/Remote objects, to allow different strategies for local/remote file paths.

* Increase robustness of inventory by handling FileNotFoundErrors (fixes #611, fixes #623) and PermissionErrors (fixes #640)

* Add caching constants (e.g. IOCACHE_BROKENSYMLINK) and handling code to enable error reporting by cached responses.

* Add mtime_target caching dict which contains the mtime of the target of a symlink. This enables caching of the
  specific behaviour present in the is_newer function. 
  
* Adds background threading infrastructure to IOCache

* Enable two-staged caching, in which e.g. the file existence cache is already filled, but mtime/size is set to IOCACHE_DEFERRED.
  This two-staged approach is used for local inventory, where file existence inventory (scandir, cheap) is performed by the main  
  thread, while file stat inventory (mtime/size, expensive) is performed by background threads in IOCache.
  
* The recently added max_wait_time check was not kept for the local inventory. In my own use case, it would disable the
  inventory when it is needed most, i.e. in a large workflow with huge number of files. Also, with the non-recursive 
  inventory and background-threading, the inventory operation is still reasonably fast. 
  (Maybe an --disable-inventory flag can be considered for very small workflows that are run in huge directories.)

Together, this results in my use case (very large workflows on Lustre system) in a ~10 fold speedup. 