### PR TITLE
[docs] Fixing reference and link to Python

### DIFF
--- a/docs/executor_tutorial/azure_aks.rst
+++ b/docs/executor_tutorial/azure_aks.rst
@@ -3,6 +3,9 @@
 Auto-scaling Azure Kubernetes cluster without shared filesystem
 ---------------------------------------------------------------
 
+.. _Snakemake: http://snakemake.readthedocs.io
+.. _Python: https://www.python.org/
+
 In this tutorial we will show how to execute a Snakemake workflow
 on an auto-scaling Azure Kubernetes cluster without a shared file-system.
 While Kubernetes is mainly known as microservice orchestration system with

--- a/docs/executor_tutorial/google_lifesciences.rst
+++ b/docs/executor_tutorial/google_lifesciences.rst
@@ -6,6 +6,7 @@ Google Life Sciences Tutorial
 
 .. _Snakemake: http://snakemake.readthedocs.io
 .. _Snakemake Remotes: https://snakemake.readthedocs.io/en/stable/snakefiles/remote_files.html
+.. _Python: https://www.python.org/
 
 
 Setup


### PR DESCRIPTION
Hi,

reStructuredText and sphinx are not my forte, but I think the Python link is broken as it's missing the link reference in the `.rst` file?

Cheers
Bruno