### PR TITLE
[docs] Fix link in tutorial for snakefiles rule ref

### DIFF
--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -374,7 +374,7 @@ Step 6: Using custom scripts
 ::::::::::::::::::::::::::::
 
 Usually, a workflow not only consists of invoking various tools, but also contains custom code to e.g. calculate summary statistics or create plots.
-While Snakemake also allows you to directly :ref:`write Python code inside a rule <.. _snakefiles-rules>`_, it is usually reasonable to move such logic into separate scripts.
+While Snakemake also allows you to directly :ref:`write Python code inside a rule <.. _snakefiles-rules>`, it is usually reasonable to move such logic into separate scripts.
 For this purpose, Snakemake offers the ``script`` directive.
 Add the following rule to your Snakefile:
 


### PR DESCRIPTION
Hi,

Was almost finishing my goal for reading Snakemake docs for tonight, when I spotted one issue in the rendered tutorial.

![image](https://user-images.githubusercontent.com/304786/95676275-597cd100-0c19-11eb-99aa-913406e4e146.png)

Haven't tested this syntax yet (sorry, :bed:  time :zzz: ). I copied from another file, removing the extra `_`. Will try to render it locally after I set up my environment build docs if I have time during breakfast or $work break :+1: 

Cheers
Bruno

