### PR TITLE
Show Job ID on missing output error

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -479,6 +479,7 @@ class DAG:
                     "filesystem latency. If that is the case, consider to increase the "
                     "wait time with --latency-wait.",
                     rule=job.rule,
+                    jobid=self.jobid(job)
                 )
 
         # Ensure that outputs are of the correct type (those flagged with directory()

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -479,7 +479,7 @@ class DAG:
                     "filesystem latency. If that is the case, consider to increase the "
                     "wait time with --latency-wait.",
                     rule=job.rule,
-                    jobid=self.jobid(job)
+                    jobid=self.jobid(job),
                 )
 
         # Ensure that outputs are of the correct type (those flagged with directory()

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -254,11 +254,11 @@ class IOException(RuleException):
 
 class MissingOutputException(RuleException):
     def __init__(
-        self, message=None, include=None, lineno=None, snakefile=None, rule=None
+        self, message=None, include=None, lineno=None, snakefile=None, rule=None, jobid=""
     ):
         message = (
-            "Job completed successfully, but some output files are missing. {}".format(
-                message
+            "Job {} completed successfully, but some output files are missing. {}".format(
+                message, jobid
             )
         )
         super().__init__(message, include, lineno, snakefile, rule)


### PR DESCRIPTION
Currently, a missing output file leads to an exception indicating the file, but not the job id. Tracing issues is much easier if at least the internal job ID is available to find matching log files (which may not contain the respective file name).