### PR TITLE
Add a nano syntax highlighting file

### DIFF
--- a/misc/nano/README.md
+++ b/misc/nano/README.md
@@ -1,0 +1,16 @@
+A nano syntax highlighting definition for Snakemake.
+
+To use this file in nano, copy the `syntax/snakemake.nanorc` file
+to your `$HOME` directory and add a line to your ~/.nanorc saying:
+
+    include $HOME/snakemake.nanorc
+
+
+NB. Line 12 of the syntax file contains a regular expression for
+identifying a shebang (#!) header line. This command is not
+supported in some versions of nano, so is commented out. If you
+wish to enable it, simply remove the # at the beginning of the
+line. If you are uncertain if your version of nano supports this
+command, you may remove it and try. You will see an error if it
+does not. Leaving the line commented out will result in the header
+being treated as a regular comment for highlighting purposes. 

--- a/misc/nano/syntax/snakemake.nanorc
+++ b/misc/nano/syntax/snakemake.nanorc
@@ -1,0 +1,41 @@
+# A nano syntax sheet for Snakemake files
+
+# Language: Snakemake (extended from python.nanorc
+# Maintainer: Bailey Harrington (baileythegreen@gmail.com)
+# Created: 28 September 2020
+# Last change: 13 October 2020
+
+# To use this file in nano, add a
+# line to your ~/.nanorc saying:
+# include <path_to_this_file>/snakemake.nanorc
+
+# Specify the filename patterns this syntax applies to
+syntax "python" "\.smk$" "Snakemake$" "\.snake$"
+
+# describes the shebang line as the header
+# header "^#!.*/python[-0-9._]*"
+
+# Python keywords
+color blue "\<(and|as|assert|break|class|continue|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield)\>"
+
+# the function definition keyword for Python
+color brightblue "def [0-9A-Za-z_]+"
+
+# strings
+color green "['][^']*[^\\][']" "[']{3}.*[^\\][']{3}"
+color green "["][^"]*[^\\]["]" "["]{3}.*[^\\]["]{3}"
+
+# multi-line comments
+color green start=""""[^"]" end=""""" start="'''[^']" end="'''"
+
+# regular comments
+color brightmagenta "#.*$"
+
+# Snakemake keywords
+color blue "\<(include|workdir|onsuccess|onerror|ruleorder|localrules|configfile|touch|protected|temp|input|output|params|message|threads|resources|version|run|shell|benchmark|snakefile|log)\>"
+
+# rule or subworkflow names
+color brightmagenta "(rule|subworkflow)\s*[A-Za-z_]*"
+
+# the Snakemake rule and subworkflow keywords
+color blue "(rule|subworkflow)"

--- a/misc/nano/syntax/snakemake.nanorc
+++ b/misc/nano/syntax/snakemake.nanorc
@@ -10,7 +10,7 @@
 # include <path_to_this_file>/snakemake.nanorc
 
 # Specify the filename patterns this syntax applies to
-syntax "python" "\.smk$" "Snakemake$" "\.snake$"
+syntax "python" "\.smk$" "Snakefile$" "\.snake$"
 
 # describes the shebang line as the header
 # header "^#!.*/python[-0-9._]*"

--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -1,4 +1,4 @@
-" Vim syntax file
+ Vim syntax file
 " Language: Snakemake (extended from python.vim)
 " Maintainer: Jay Hesselberth (jay.hesselberth@gmail.com)
 " Last Change: 2020 Oct 6

--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -1,4 +1,4 @@
- Vim syntax file
+" Vim syntax file
 " Language: Snakemake (extended from python.vim)
 " Maintainer: Jay Hesselberth (jay.hesselberth@gmail.com)
 " Last Change: 2020 Oct 6


### PR DESCRIPTION
Add a nano syntax highlighting file for Snakemake (snakemake.nanorc), extended from the python.nanorc file.