### PR TITLE
code no longer crashes on report for run rules

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -288,7 +288,7 @@ class RuleRecord:
             # change simply makes the report just put "source" in place of the
             # the actual code source, rather than throwing an error which
             # crashes the entire generation of the `snakemake` report.
-            sources = ['source']
+            sources = ["source"]
 
         try:
             lexer = get_lexer_by_name(language)

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -278,6 +278,18 @@ class RuleRecord:
             language = language.split("_")[1]
             sources = notebook.get_cell_sources(source)
 
+        if sources is None:
+            # if the rule is not one of the types above (e.g., it is run_func),
+            # then `sources` is `None` which causes an error below when the
+            # code attempts to iterate over `None`. In `snakemake` version 5.25,
+            # instead it just printed "source" for the code. This still seems
+            # non-ideal (we'd like to access the actual code for the run rule),
+            # but I'm not sure how to do that. So in the meantime, at least this
+            # change simply makes the report just put "source" in place of the
+            # the actual code source, rather than throwing an error which
+            # crashes the entire generation of the `snakemake` report.
+            sources = ['source']
+
         try:
             lexer = get_lexer_by_name(language)
 


### PR DESCRIPTION
This commit fixes a bug in v5.26.* that was causing `snakemake --report` to crash when there were `run` rules.

The code has never handled this well: it seems like the desired behavior would be to make the "source" in the report for `run` rules to actually be the Python code being run. In < v5.26, instead in just printed "source" instead of the Python code. But then in v5.26.*, it was changed so that the code was trying to iterate over a `None` object, so the `snakemake --report` directive actually crashed when there was a `run` rule. This commit makes it go back to doing the old behavior of just printing "source", so at least it doesn't crash even if the report is uninformative as to the code being run.

Ideally, someone who knows how to actually access the code for `run` cells could fix this better.

Addresses issue #682.