### PR TITLE
Add snakefmt mention in faq and streamline vim

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinxcontrib.napoleon',
-    'sphinxarg.ext'
+    'sphinxarg.ext',
+    'sphinx.ext.autosectionlabel'
 ]
 
 # Snakemake theme (made by SciAni).

--- a/docs/project_info/faq.rst
+++ b/docs/project_info/faq.rst
@@ -259,19 +259,22 @@ This can be done by invoking Snakemake with the ``--forcerules`` or ``-R`` flag,
 
 This will cause Snakemake to re-run all jobs of that rule and everything downstream (i.e. directly or indirectly depending on the rules output).
 
+How should Snakefiles be formatted?
+--------------------------------------
+
+To ensure readability and consistency, you can format Snakefiles with our tool `snakefmt <https://github.com/snakemake/snakefmt>`_. 
+
+Python code gets formatted with `black <https://github.com/psf/black>`_ and Snakemake-specific blocks are formatted using similar principles (such as `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_).
+
 How do I enable syntax highlighting in Vim for Snakefiles?
 ----------------------------------------------------------
 
-A vim syntax highlighting definition for Snakemake is available `here <https://github.com/snakemake/snakemake/raw/master/misc/vim/syntax/snakemake.vim>`_.
-You can copy that file to ``$HOME/.vim/syntax`` directory and add
+Instructions for doing this are located `here
+<https://github.com/snakemake/snakemake/tree/master/misc/vim>`_.
 
-.. code-block:: vim
-
-    au BufNewFile,BufRead Snakefile set syntax=snakemake
-    au BufNewFile,BufRead *.smk set syntax=snakemake
-
-to your ``$HOME/.vimrc`` file. Highlighting can be forced in a vim session with ``:set syntax=snakemake``.
-
+Note that you can also format Snakefiles in Vim using :ref:`snakefmt
+<How should Snakefiles be formatted?>`, with instructions located `here
+<https://github.com/snakemake/snakefmt/blob/master/docs/editor_integration.md#vim>`_!
 
 I want to import some helper functions from another python file. Is that possible?
 ----------------------------------------------------------------------------------

--- a/misc/vim/ftdetect/snakemake.vim
+++ b/misc/vim/ftdetect/snakemake.vim
@@ -6,7 +6,4 @@
 " Usage
 "
 " copy to $HOME/.vim/ftdetect directory
-au BufNewFile,BufRead Snakefile set filetype=snakemake 
-au BufNewFile,BufRead *.rules set filetype=snakemake 
-au BufNewFile,BufRead *.snakefile set filetype=snakemake 
-au BufNewFile,BufRead *.snake set filetype=snakemake 
+au BufNewFile,BufRead Snakefile,*.smk set filetype=snakemake 


### PR DESCRIPTION
## Added
* FAQ: add section about possibility of formatting Snakemake files with `snakefmt`
* Add Sphinx extension to `conf.py` allowing easy internal header referencing as per [here](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#links-to-sections-in-the-same-document)

## Modified
* FAQ: rewrite syntax highlighting section, referencing the vim README page. Also in this FAQ section, reference `snakefmt`'s new vim plugin for formatting
* Vim filetype detection: placed in one line and use two canonical Snakemake filename patterns only : 'Snakefile' and '*.smk'

For the last bullet point: the FAQ currently reads that Snakemake files are `Snakefile` and `*,smk` (https://snakemake.readthedocs.io/en/stable/project_info/faq.html#id20) but the filetype detection plugin detects `Snakefile`, `*.rules`, `*.snakefile`, `*.snake` (https://github.com/snakemake/snakemake/blob/master/misc/vim/ftdetect/snakemake.vim). 
I was only aware of `Snakefile` and `*.smk` so proposed moving to this here.
