### PR TITLE
Fix logging path for snakemake report

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -914,7 +914,7 @@ def auto_report(dag, path, stylesheet=None):
                         # write aux files
                         parent = folder.joinpath(result.data_uri).parent
                         for aux_path in result.aux_files:
-                            #print(aux_path, parent, str(parent.joinpath(os.path.relpath(aux_path, os.path.dirname(result.path)))))
+                            # print(aux_path, parent, str(parent.joinpath(os.path.relpath(aux_path, os.path.dirname(result.path)))))
                             zipout.write(
                                 aux_path,
                                 str(

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -913,14 +913,14 @@ def auto_report(dag, path, stylesheet=None):
                             )
                         # write aux files
                         parent = folder.joinpath(result.data_uri).parent
-                        for path in result.aux_files:
-                            # print(path, parent, str(folder.joinpath(os.path.relpath(path, parent))))
+                        for aux_path in result.aux_files:
+                            #print(aux_path, parent, str(parent.joinpath(os.path.relpath(aux_path, os.path.dirname(result.path)))))
                             zipout.write(
-                                path,
+                                aux_path,
                                 str(
                                     parent.joinpath(
                                         os.path.relpath(
-                                            path, os.path.dirname(result.path)
+                                            aux_path, os.path.dirname(result.path)
                                         )
                                     )
                                 ),


### PR DESCRIPTION
This PR fixes an issue where snakemake prints the path of the last auxiliary file handled in line [935](https://github.com/snakemake/snakemake/blob/af879e08f3fc56766202337de70700abbe3a6f9f/snakemake/report/__init__.py#L935) returning something like `Report created: some/aux/file.extension`

This happens as the variable `path` gets overwriten during handling auxiliary files [916](https://github.com/snakemake/snakemake/blob/af879e08f3fc56766202337de70700abbe3a6f9f/snakemake/report/__init__.py#L916).
To prevent this the variable has been renamed .