### PR TITLE
Allow --unlock without --cores locally

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2299,7 +2299,7 @@ def main(argv=None):
                 )
                 sys.exit(1)
     elif args.cores is None:
-        if local_exec and not args.dryrun:
+        if local_exec and not (args.dryrun or args.unlock):
             print(
                 "Error: you need to specify the maximum number of CPU cores to "
                 "be used at the same time. If you want to use N cores, say --cores N or "


### PR DESCRIPTION
While there has been a lot of discussion on `--cores` as a required option and what, if any, a default should be (e.g. #283, #308, #312, #450 ), based on stepping through the code, if I am not mistaken it appears `--unlock` can be safely excluded from requiring `--cores` if `local_exec`. I tested this change locally. Closes #530.

The relevant function calls for unlocking:
https://github.com/snakemake/snakemake/blob/a813ea96fcd546c63654f06ce67e429104e5ca5c/snakemake/workflow.py#L683-L687

https://github.com/snakemake/snakemake/blob/a813ea96fcd546c63654f06ce67e429104e5ca5c/snakemake/persistence.py#L175-L176

https://github.com/snakemake/snakemake/blob/a813ea96fcd546c63654f06ce67e429104e5ca5c/snakemake/__init__.py#L767-L768

https://github.com/snakemake/snakemake/blob/a813ea96fcd546c63654f06ce67e429104e5ca5c/snakemake/persistence.py#L164-L173