### PR TITLE
enable (local) multithreaded subworkflows

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -741,6 +741,7 @@ class Workflow:
                         subworkflow.snakefile,
                         workdir=subworkflow.workdir,
                         targets=subworkflow_targets,
+                        cores=self.cores,
                         configfiles=[subworkflow.configfile]
                         if subworkflow.configfile
                         else None,


### PR DESCRIPTION
Passes cores to subworkflows at evaluation time. Resolves #208.