### PR TITLE
Fix asyncio create_task syntax for compatibility with python < 3.7

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -153,7 +153,10 @@ class IOCache:
                     raise e
                 queue.task_done()
 
-        tasks = [asyncio.create_task(worker(queue)) for _ in range(n_workers)]
+        tasks = [
+            asyncio.get_event_loop().create_task(worker(queue))
+            for _ in range(n_workers)
+        ]
 
         for job in jobs:
             for f in chain(job.input, job.expanded_output):


### PR DESCRIPTION
The `asyncio.create_task` method was introduced with python 3.7. To be
compatible with older version, we should use
`asyncio.get_event_loop().create_task`

https://github.com/snakemake/snakemake/issues/725


