### PR TITLE
Added missing import.

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -39,6 +39,7 @@ from snakemake.io import (
     glob_wildcards,
     Wildcards,
     apply_wildcards,
+    contains_wildcard,
 )
 from snakemake.exceptions import WorkflowError
 from snakemake.script import Snakemake


### PR DESCRIPTION
This PR adds the missing import of the function `contains_wildcard` in `report/__init__.py`, which caused https://github.com/snakemake/snakemake/issues/745
