### PR TITLE
parse_config recognizes bools

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -873,12 +873,20 @@ def parse_key_value_arg(arg, errmsg):
     return key, val
 
 
+def _bool_parser(value):
+    if value == "True":
+        return True
+    elif value == "False":
+        return False
+    raise ValueError
+
+
 def parse_config(args):
     """Parse config from args."""
     import yaml
 
     yaml_base_load = lambda s: yaml.load(s, Loader=yaml.loader.BaseLoader)
-    parsers = [int, float, yaml_base_load, str]
+    parsers = [int, float, _bool_parser, yaml_base_load, str]
     config = dict()
     if args.config is not None:
         valid = re.compile(r"[a-zA-Z_]\w*$")


### PR DESCRIPTION
With the changes made in https://github.com/snakemake/snakemake/pull/709 booleans (True/False) do not get recognized anymore as booleans, but as their string representation. My guess is that was an unintended side-effect. This should fix that.

example command: `snakemake -j1 --config mybool="True" --dryrun --quiet` and if we would print the config in the Snakefile

5.27.4
{'mybool': True}

5.28.0
{'mybool': 'True'}

this PR
{'mybool': True}
