### PR TITLE
Fix metadata starttime

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -231,9 +231,10 @@ class Persistence:
         fallback_time = time.time()
         for f in job.expanded_output:
             rec_path = self._record_path(self._incomplete_path, f)
-            if not os.path.exists(rec_path):
-                rec_path = self._record_path(self._metadata_path, f)
             starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
+            # Sometimes finished is called twice, if so, lookup the previous starttime
+            if not os.path.exists(rec_path):
+                starttime = self._read_record(self._metadata_path, f).get("starttime", None)
             endtime = f.mtime.local_or_remote() if f.exists else fallback_time
             self._record(
                 self._metadata_path,

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -231,6 +231,8 @@ class Persistence:
         fallback_time = time.time()
         for f in job.expanded_output:
             rec_path = self._record_path(self._incomplete_path, f)
+            if not os.path.exists(rec_path):
+                rec_path = self._record_path(self._metadata_path, f)
             starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
             endtime = f.mtime.local_or_remote() if f.exists else fallback_time
             self._record(

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -234,7 +234,9 @@ class Persistence:
             starttime = os.path.getmtime(rec_path) if os.path.exists(rec_path) else None
             # Sometimes finished is called twice, if so, lookup the previous starttime
             if not os.path.exists(rec_path):
-                starttime = self._read_record(self._metadata_path, f).get("starttime", None)
+                starttime = self._read_record(self._metadata_path, f).get(
+                    "starttime", None
+                )
             endtime = f.mtime.local_or_remote() if f.exists else fallback_time
             self._record(
                 self._metadata_path,


### PR DESCRIPTION
The starttime metadata for run rules would be set to None since the `_incomplete_path` did not seem to exist for them. Instead, fall back to using the `_metadata_path`.

I do not fully understand the changes that caused this bug, and thus, while this seems to fix things to me, I don't know that this is the right way to fix things.  @mhulsman or @johanneskoester You two worked on the PR related to this, perhaps you could help me understand the proper way to fix things?

Resolves: #741