### PR TITLE
Allow setting CONDA_SUBDIR when applying use-conda

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -134,6 +134,7 @@ def snakemake(
     use_singularity=False,
     use_env_modules=False,
     singularity_args="",
+    conda_subdir=None,
     conda_frontend="conda",
     conda_prefix=None,
     conda_cleanup_pkgs=None,
@@ -558,6 +559,7 @@ def snakemake(
             use_conda=use_conda or list_conda_envs or conda_cleanup_envs,
             use_singularity=use_singularity,
             use_env_modules=use_env_modules,
+            conda_subdir=conda_subdir,
             conda_frontend=conda_frontend,
             conda_prefix=conda_prefix,
             conda_cleanup_pkgs=conda_cleanup_pkgs,
@@ -2180,6 +2182,11 @@ def get_argument_parser(profile=None):
         "flag must also be set.",
     )
     group_conda.add_argument(
+        "--conda-subdir",
+        default=None,
+        help="Choose the conda subdir for installing environments.",
+    )
+    group_conda.add_argument(
         "--conda-frontend",
         default="conda",
         choices=["conda", "mamba"],
@@ -2648,6 +2655,7 @@ def main(argv=None):
             attempt=args.attempt,
             force_use_threads=args.force_use_threads,
             use_conda=args.use_conda,
+            conda_subdir=args.conda_subdir,
             conda_frontend=args.conda_frontend,
             conda_prefix=args.conda_prefix,
             conda_cleanup_pkgs=args.conda_cleanup_pkgs,

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -60,6 +60,7 @@ class Env:
     def __init__(self, env_file, dag, container_img=None, cleanup=None):
         self.file = env_file
 
+        self.subdir = dag.workflow.conda_subdir
         self.frontend = dag.workflow.conda_frontend
         self._env_dir = dag.workflow.persistence.conda_env_path
         self._env_archive_dir = dag.workflow.persistence.conda_env_archive_path
@@ -306,6 +307,9 @@ class Env:
                     logger.info("Downloading and installing remote packages.")
                     cmd = " ".join(
                         [
+                            "CONDA_SUBDIR={}".format(self.subdir)
+                            if self.subdir
+                            else "",
                             self.frontend,
                             "env",
                             "create",

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -87,6 +87,7 @@ class Workflow:
         debug=False,
         verbose=False,
         use_conda=False,
+        conda_subdir=None,
         conda_frontend=None,
         conda_prefix=None,
         use_singularity=False,
@@ -154,6 +155,7 @@ class Workflow:
         self.verbose = verbose
         self._rulecount = 0
         self.use_conda = use_conda
+        self.conda_subdir = conda_subdir
         self.conda_frontend = conda_frontend
         self.conda_prefix = conda_prefix
         self.use_singularity = use_singularity


### PR DESCRIPTION
This adds the possibility for manually setting `CONDA_SUBDIR` when creating environments using `conda` or `mamba`.
As many workflows/environments utilize packages from bioconda it is currently not possible to execute these workflows on Apple Silicon (arm) devices.
But, compatibility can be improved by setting `CONDA_SUBDIR=osx-64`.
This allows installing x86-packages on arm devices, while will be emulated by [Rosetta](https://support.apple.com/en-us/HT211861).