### PR TITLE
Fix #488

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -779,7 +779,7 @@ class ClusterExecutor(RealExecutor):
         logger.debug("Jobscript:\n{}".format(content))
         with open(jobscript, "w") as f:
             print(content, file=f)
-        os.chmod(jobscript, os.stat(jobscript).st_mode | stat.S_IXUSR)
+        os.chmod(jobscript, os.stat(jobscript).st_mode | stat.S_IXUSR | stat.S_IRUSR)
 
     def cluster_params(self, job):
         """Return wildcards object for job from cluster_config."""


### PR DESCRIPTION
Enforce read and execut bit on job script.
Weird acl inheritance can cause that os.stat() reports no permissions but read and execute are required.