### PR TITLE
Fix Issue #783: Pass `nodes` to subworkflows to allow parallel execution on cluster backend.

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -745,6 +745,7 @@ class Workflow:
                         workdir=subworkflow.workdir,
                         targets=subworkflow_targets,
                         cores=self.cores,
+                        nodes=self.nodes,
                         configfiles=[subworkflow.configfile]
                         if subworkflow.configfile
                         else None,


### PR DESCRIPTION
In my hands this fixes the behavior observed in issue #783, allowing subworkflows jobs to also be executed in parallel .

This was achieved by passing the 'nodes' argument to subworkflows.

This fix is essentially a copy of: https://github.com/snakemake/snakemake/pull/723

Is there anything else that would similarly profit from being passed to `subworkflows`?