### PR TITLE
Allow Paths wherever wildcards are applied

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -753,7 +753,10 @@ class Rule:
                     item = [item]
                     is_iterable = False
                 for item_ in item:
-                    if check_return_type and not isinstance(item_, str):
+                    if (check_return_type
+                            and not isinstance(item_, str)
+                            and not isinstance(item_, Path)
+                            ):
                         raise WorkflowError(
                             "Function did not return str or list " "of str.", rule=self
                         )
@@ -772,7 +775,7 @@ class Rule:
         def concretize_iofile(f, wildcards, is_from_callable):
             if is_from_callable:
                 if isinstance(f, Path):
-                    f = str(Path)
+                    f = str(f)
                 return IOFile(f, rule=self).apply_wildcards(
                     wildcards,
                     fill_missing=f in self.dynamic_input,

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -753,10 +753,11 @@ class Rule:
                     item = [item]
                     is_iterable = False
                 for item_ in item:
-                    if (check_return_type
-                            and not isinstance(item_, str)
-                            and not isinstance(item_, Path)
-                            ):
+                    if (
+                        check_return_type
+                        and not isinstance(item_, str)
+                        and not isinstance(item_, PurePath)
+                    ):
                         raise WorkflowError(
                             "Function did not return str or list " "of str.", rule=self
                         )

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -756,7 +756,7 @@ class Rule:
                     if (
                         check_return_type
                         and not isinstance(item_, str)
-                        and not isinstance(item_, PurePath)
+                        and not isinstance(item_, Path)
                     ):
                         raise WorkflowError(
                             "Function did not return str or list " "of str.", rule=self


### PR DESCRIPTION
This includes expanding params, inputs, and log files. This fixes a bug when providing a Path or list of Path as the return value of an input function, for example.