### PR TITLE
formulating wms monitor into logger proper

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2246,6 +2246,19 @@ def get_argument_parser(profile=None):
     return parser
 
 
+def generate_parser_metadata(parser, args):
+    """Given a populated parser, generate the original command along with
+    metadata that can be handed to a logger to use as needed.
+    """
+    command = "snakemake %s" % " ".join(
+        parser._source_to_settings["command_line"][""][1]
+    )
+    workdir = os.getcwd()
+    metadata = args.__dict__
+    metadata.update({"command": command})
+    return metadata
+
+
 def main(argv=None):
     """Main entry point."""
 
@@ -2562,7 +2575,11 @@ def main(argv=None):
             log_handler.append(slack_logger.log_handler)
 
         elif args.wms_monitor or args.log_service == "wms":
-            wms_logger = logging.WMSLogger(args.wms_monitor, args.wms_monitor_arg)
+            # Generate additional metadata for server
+            metadata = generate_parser_metadata(parser, args)
+            wms_logger = logging.WMSLogger(
+                args.wms_monitor, args.wms_monitor_arg, metadata=metadata
+            )
             log_handler.append(wms_logger.log_handler)
 
         if args.edit_notebook:

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -21,7 +21,7 @@ from importlib.machinery import SourceFileLoader
 from snakemake.workflow import Workflow
 from snakemake.dag import Batch
 from snakemake.exceptions import print_exception, WorkflowError
-from snakemake.logging import setup_logger, logger, SlackLogger
+from snakemake.logging import setup_logger, logger, SlackLogger, WMSLogger
 from snakemake.io import load_configfile
 from snakemake.shell import shell
 from snakemake.utils import update_config, available_cpu_count
@@ -123,7 +123,6 @@ def snakemake(
     updated_files=None,
     log_handler=[],
     keep_logger=False,
-    wms_monitor=None,
     max_jobs_per_second=None,
     max_status_checks_per_second=100,
     restart_times=0,
@@ -269,7 +268,6 @@ def snakemake(
                                     whether to clean up conda tarballs after env creation (default None), valid values: "tarballs", "cache"
         singularity_prefix (str):   the directory to which singularity images will be pulled (default None)
         shadow_prefix (str):        prefix for shadow directories. The job-specific shadow directories will be created in $SHADOW_PREFIX/shadow/ (default None)
-        wms-monitor (str):          workflow management system monitor. Send post requests to the specified (server/IP). (default None)
         conda_create_envs_only (bool):    if specified, only builds the conda environments specified for each job, then exits.
         list_conda_envs (bool):     list conda environments and their location on disk.
         mode (snakemake.common.Mode): execution mode
@@ -471,7 +469,6 @@ def snakemake(
             use_threads=use_threads,
             mode=mode,
             show_failed_logs=show_failed_logs,
-            wms_monitor=wms_monitor,
         )
 
     if greediness is None:
@@ -1336,10 +1333,22 @@ def get_argument_parser(profile=None):
         action="store",
         nargs="?",
         help=(
-            "IP and port of workflow management system to monitor the execution of snakemake (e.g. http://127.0.0.1:5000"
+            "IP and port of workflow management system to monitor the execution of snakemake (e.g. http://127.0.0.1:5000)"
+            " Note that if your service requires an authorization token, you must export WMS_MONITOR_TOKEN in the environment."
         ),
     )
-
+    group_exec.add_argument(
+        "--wms-monitor-arg",
+        nargs="*",
+        metavar="NAME=VALUE",
+        help=(
+            "If the workflow management service accepts extra arguments, provide."
+            " them in key value pairs with --wms-monitor-arg. For example, to run"
+            " an existing workflow using a wms monitor, you can provide the pair "
+            " id=12345 and the arguments will be provided to the endpoint to "
+            " first interact with the workflow"
+        ),
+    )
     group_exec.add_argument(
         "--scheduler-ilp-solver",
         default=recommended_lp_solver,
@@ -1911,10 +1920,10 @@ def get_argument_parser(profile=None):
     group_behavior.add_argument(
         "--log-service",
         default=None,
-        choices=["none", "slack"],
+        choices=["none", "slack", "wms"],
         help="Set a specific messaging service for logging output."
         "Snakemake will notify the service on errors and completed execution."
-        "Currently only slack is supported.",
+        "Currently slack and workflow management system (wms) are supported.",
     )
 
     group_cluster = parser.add_argument_group("CLUSTER")
@@ -2552,6 +2561,10 @@ def main(argv=None):
             slack_logger = logging.SlackLogger()
             log_handler.append(slack_logger.log_handler)
 
+        elif args.wms_monitor or args.log_service == "wms":
+            wms_logger = logging.WMSLogger(args.wms_monitor, args.wms_monitor_arg)
+            log_handler.append(wms_logger.log_handler)
+
         if args.edit_notebook:
             from snakemake import notebook
 
@@ -2679,7 +2692,6 @@ def main(argv=None):
             cluster_status=args.cluster_status,
             export_cwl=args.export_cwl,
             show_failed_logs=args.show_failed_logs,
-            wms_monitor=args.wms_monitor,
             keep_incomplete=args.keep_incomplete,
             keep_metadata=not args.drop_metadata,
             edit_notebook=args.edit_notebook,

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -10,7 +10,6 @@ import datetime
 import sys
 import os
 import json
-import requests
 import threading
 import tempfile
 from functools import partial
@@ -148,6 +147,7 @@ class WMSLogger:
         """Service Info ensures that the server is running. We exit on error
         if this isn't the case, so the function can be called in init.
         """
+        import requests
 
         # We first ensure that the server is running, period
         response = requests.get(
@@ -173,6 +173,8 @@ class WMSLogger:
         if providing an argument for an existing workflow, ensuring that
         it exists and receiving back the same identifier.
         """
+        import requests
+
         response = requests.get(
             self.address + "/create_workflow", headers=self._headers, params=self.args
         )
@@ -233,6 +235,8 @@ class WMSLogger:
         Args:
             msg (dict):     the log message dictionary
         """
+        import requests
+
         url = self.server["url"] + "/update_workflow_status"
         server_info = {
             "msg": repr(msg),


### PR DESCRIPTION
This is the first round of work to address #799. Specifically, we have the WMS monitor as a proper logger, and don't need to do any customization in the setup_logger function. We are currently using the defined API schema (defined by panoptes) although the project is thinking about changing this to some spec (see https://github.com/panoptes-organization/monitor-schema/pull/7#issuecomment-750897929). The spec in question doesn't have an update workflow endpoint, so I'm not sure how that would work yet, but I think @fgypas perhaps has something in mind.

In addition, we have added authentication, which is optional and enforced by the WMS monitor server. If authentication is required, the user must export `WMS_MONITOR_TOKEN` in their environment, which is provided by the server. We could do more complex interactions like allow a user to specify username:password for basic auth and then have the server issue a temporary token for each request, but looking at the spec that @fgypas has in mind, the [authorization part](https://ga4gh.github.io/workflow-execution-service-schemas/docs/#section/Authorization-and-Authentication) only mentions a url to go to learn about how to authenticate - I don't see any protocol that is standard for these kinds of APIs to return 401, and then the client knows to authenticate, etc. Unless that is supposed to be provided in the ` auth_instructions_url` field? (note that it's typically provided in an Www-Authenticate header.

## Discussion

I think for the create_workflow endpoint that snakemake should be sending more metadata about the run to the server. Right now it's basically sending nothing. Minimally I'd like to suggest we add:

 - snakefile path
 -  working directory 
 - any snakemake identifiers?
 - some kind of name? 

For example, for a user that creates the workflow in the interface (e.g., for snakeface) these fields are derived on that step, so when we issue the command the additional id provided hooks up to all of that. But if we run the workflow on the command line and haven't created it in the interface, a new workflow is created on behalf of the user (and it's hugely missing metadata).

Also, I think this will need to be done in stages. The first stage is keeping things as they are now, but adding the option for the token. The second stage will be the refactor of the API, with whatever spec @fgypas decides. I'm going to need to update snakeface too so I'm hoping to help with whatever I can to move this forward.

cc @johanneskoester @fgypas 

Signed-off-by: vsoch <vsochat@stanford.edu>