### PR TITLE
fix #821: enable --no-subworkflows command when using --cluster

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -587,6 +587,7 @@ def snakemake(
             envvars=envvars,
             max_inventory_wait_time=max_inventory_wait_time,
             conda_not_block_search_path_envvars=conda_not_block_search_path_envvars,
+            execute_subworkflows=execute_subworkflows,
         )
         success = True
 
@@ -775,7 +776,6 @@ def snakemake(
                     batch=batch,
                     keepincomplete=keep_incomplete,
                     keepmetadata=keep_metadata,
-                    executesubworkflows=execute_subworkflows,
                 )
 
     except BrokenPipeError:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -292,6 +292,8 @@ class RealExecutor(AbstractExecutor):
                 additional += ' --singularity-args "{}"'.format(
                     self.workflow.singularity_args
                 )
+        if not self.workflow.execute_subworkflows:
+            additional += " --no-subworkflows"
 
         if self.workflow.use_env_modules:
             additional += " --use-envmodules"

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -114,6 +114,7 @@ class Workflow:
         envvars=None,
         max_inventory_wait_time=20,
         conda_not_block_search_path_envvars=False,
+        execute_subworkflows=True,
     ):
         """
         Create the controller.
@@ -185,6 +186,7 @@ class Workflow:
         self._scatter = dict(overwrite_scatter or dict())
         self.overwrite_scatter = overwrite_scatter or dict()
         self.conda_not_block_search_path_envvars = conda_not_block_search_path_envvars
+        self.execute_subworkflows = execute_subworkflows
 
         self.enable_cache = False
         if cache is not None:
@@ -561,7 +563,6 @@ class Workflow:
         batch=None,
         keepincomplete=False,
         keepmetadata=True,
-        executesubworkflows=True,
     ):
 
         self.check_localrules()
@@ -724,7 +725,7 @@ class Workflow:
 
         if (
             self.subworkflows
-            and executesubworkflows
+            and self.execute_subworkflows
             and not printdag
             and not printrulegraph
             and not printfilegraph


### PR DESCRIPTION
Changes the `executesubworkflows` argument in `Workflow.execute` to the `execute_subworkflows` attribute of `Workflow`, enabling `get_additional_args` to add the `--no-subworkflows` command to the cluster submission script when appropriate.