### PR TITLE
ensure that singularity with GLS exits with a clear error message

### DIFF
--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -789,9 +789,10 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         # capabilities - this won't currently work (Singularity in Docker)
         # We either need to add CAPS or run in privileged mode (ehh)
         if job.needs_singularity and self.workflow.use_singularity:
-            logger.warning(
+            raise WorkflowError(
                 "Singularity requires additional capabilities that "
-                "aren't yet supported for standard Docker runs."
+                "aren't yet supported for standard Docker runs, and "
+                "is not supported for the Google Life Sciences executor."
             )
 
         # location looks like: "projects/<project>/locations/<location>"


### PR DESCRIPTION
GLS does not support Singularity, but we currently issue a warning and continue. We should be raising a workflow exception and giving a clear message to the user that Singularity is not supported. See https://github.com/snakemake/snakemake/pulls#issuecomment-751803456.

Signed-off-by: vsoch <vsochat@stanford.edu>