### PR TITLE
do not access jobid during checkpoint update

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1295,7 +1295,7 @@ class DAG:
                 depending = list(self.depending[job])
                 # re-evaluate depending jobs, replace and update DAG
                 for j in depending:
-                    logger.info("Updating job {} ({}).".format(self.jobid(j), j))
+                    logger.info("Updating job {}.".format(j))
                     newjob = j.updated()
                     self.replace_job(j, newjob, recursive=False)
                     updated = True


### PR DESCRIPTION
This is faster and simpler than always updating jobids during a checkpoint handling. The jobid update happens during postprocess at the end of the checkpoint update.

Fixes #817.