### PR TITLE
Remove f-strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Unreleased
+==========
+Fixed
+-----
+- f-strings in runtime code were replaced with `format` syntax as we still support python 3.5 (@mbhall88)
+
 [5.32.0] - 2021-01-15
 =====================
 Changed

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -483,7 +483,8 @@ class DAG:
                 raise MissingOutputException(
                     str(e) + "\nThis might be due to "
                     "filesystem latency. If that is the case, consider to increase the "
-                    "wait time with --latency-wait." + f"\nJob id: {job.jobid}",
+                    "wait time with --latency-wait."
+                    + "\nJob id: {jobid}".format(jobid=job.jobid),
                     rule=job.rule,
                     jobid=self.jobid(job),
                 )

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1512,11 +1512,14 @@ class KubernetesExecutor(ClusterExecutor):
                 encoded_size = len(encoded_contents)
                 if encoded_size > 1048576:
                     logger.warning(
-                        f"Skipping the source file {f} for secret key {key}. "
-                        f"Its base64 encoded size {encoded_size} exceeds "
+                        "Skipping the source file {f} for secret key {key}. "
+                        "Its base64 encoded size {encoded_size} exceeds "
                         "the maximum file size (1MB) that can be passed "
                         "from host to kubernetes.".format(
-                            f=f, source_file_size=source_file_size
+                            f=f,
+                            source_file_size=source_file_size,
+                            key=key,
+                            encoded_size=encoded_size,
                         )
                     )
                     continue
@@ -1539,11 +1542,11 @@ class KubernetesExecutor(ClusterExecutor):
         if config_map_size > 1048576:
             logger.warning(
                 "The total size of the included files and other Kubernetes secrets "
-                f"is {config_map_size}, exceeding the 1MB limit.\n"
+                "is {}, exceeding the 1MB limit.\n".format(config_map_size)
             )
             logger.warning(
                 "The following are the largest files. Consider removing some of them "
-                f"(you need remove at least {config_map_size - 1048576} bytes):"
+                "(you need remove at least {} bytes):".format(config_map_size - 1048576)
             )
 
             entry_sizes = {
@@ -1578,8 +1581,8 @@ class KubernetesExecutor(ClusterExecutor):
                 # Can't find the pod. Maybe it's already been
                 # destroyed. Proceed with a warning message.
                 logger.warning(
-                    f"[WARNING] 404 not found when trying to delete the pod: {j.jobid}\n"
-                    "[WARNING] Ignore this error\n"
+                    "[WARNING] 404 not found when trying to delete the pod: {jobid}\n"
+                    "[WARNING] Ignore this error\n".format(jobid=jobid)
                 )
             else:
                 raise e

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1493,7 +1493,7 @@ class Reason:
                     )
         s = "; ".join(s)
         if self.finished:
-            return f"Finished (was: {s})"
+            return "Finished (was: {s})".format(s=s)
         return s
 
     def __bool__(self):


### PR DESCRIPTION
### Fixed

- f-strings in runtime code were replaced with `format` syntax as we still support python 3.5

There are also f-strings in the following files but I didn't touch them as I think they are in files that will only be executed in dev environments.

```
tests/common.py: line 198
docs/snakefiles/rules.rst: lines 1374, 1385, 1387
```