### PR TITLE
Add rule name to warning about wildcard constraints in inputs

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -525,7 +525,7 @@ class Rule:
                     contains_wildcard_constraints(item)
                     and self.workflow.mode != Mode.subprocess
                 ):
-                    logger.warning("Wildcard constraints in inputs are ignored.")
+                    logger.warning("Wildcard constraints in inputs are ignored. (rule: {})".format(self))
             # record rule if this is an output file output
             _item = IOFile(item, rule=self)
             if is_flagged(item, "temp"):

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -525,7 +525,11 @@ class Rule:
                     contains_wildcard_constraints(item)
                     and self.workflow.mode != Mode.subprocess
                 ):
-                    logger.warning("Wildcard constraints in inputs are ignored. (rule: {})".format(self))
+                    logger.warning(
+                        "Wildcard constraints in inputs are ignored. (rule: {})".format(
+                            self
+                        )
+                    )
             # record rule if this is an output file output
             _item = IOFile(item, rule=self)
             if is_flagged(item, "temp"):


### PR DESCRIPTION
This change makes it easier to find and fix the offending rules:

> Wildcard constraints in inputs are ignored. 

is changed to

> Wildcard constraints in inputs are ignored. (rule: my_rule_name)