### PR TITLE
Ensure output files of failed jobs are always removed in cluster mode

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -835,6 +835,10 @@ class ClusterExecutor(RealExecutor):
         # By removing it again, we make sure that it is gone on the host FS.
         if not self.keepincomplete:
             self.workflow.persistence.cleanup(job)
+            # Also cleanup the jobs output files, in case the remote job
+            # was not able to, due to e.g. timeout.
+            logger.debug("Cleanup failed jobs output files.")
+            job.cleanup()
 
     def print_cluster_job_error(self, job_info, jobid):
         job = job_info.job

--- a/tests/test_github_issue627/Snakefile
+++ b/tests/test_github_issue627/Snakefile
@@ -1,0 +1,18 @@
+rule:
+    shell:
+        """
+        set +e
+        python -m snakemake --cores 1 -p --profile . -s Snakefile.internal
+        RETVAL=$?
+        set -e
+
+        if [ "$RETVAL" == 0 ]; then
+            echo "Snakemake did not correctly discover that the job failed"
+            exit 1
+        fi
+
+        if [ -f "./job.txt" ]; then
+            echo "Output file of failed job exists"
+            exit 1
+        fi
+        """

--- a/tests/test_github_issue627/Snakefile.internal
+++ b/tests/test_github_issue627/Snakefile.internal
@@ -1,0 +1,4 @@
+rule:
+    output: "job.txt"
+    shell:
+        "./job.py"

--- a/tests/test_github_issue627/config.yaml
+++ b/tests/test_github_issue627/config.yaml
@@ -1,0 +1,2 @@
+cluster: "./run_locally.sh"
+cluster-status: "./local_job_status.sh"

--- a/tests/test_github_issue627/job.py
+++ b/tests/test_github_issue627/job.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import time
+
+file = open("job.txt", "w")
+
+for i in range(300):
+    file.write(str(i) + "\n")
+    file.flush()
+    time.sleep(1)

--- a/tests/test_github_issue627/local_job_status.sh
+++ b/tests/test_github_issue627/local_job_status.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+STATUS=$(ps aux | awk '{print $2}' | grep "$1")
+if [ -z "$STATUS" ]; then
+  echo "failed"
+else
+  echo "running"
+fi

--- a/tests/test_github_issue627/run_locally.sh
+++ b/tests/test_github_issue627/run_locally.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+PID=$(bash -c "setsid $1 > /dev/null 2>&1 & echo \"\$!\"")
+echo "$PID"
+
+bash -c "sleep 2; kill -SIGKILL \"$PID\"" > /dev/null 2>&1 &

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1003,6 +1003,11 @@ def test_github_issue413():
     run(dpath("test_github_issue413"), no_tmpdir=True)
 
 
+@skip_on_windows
+def test_github_issue627():
+    run(dpath("test_github_issue627"))
+
+
 def test_github_issue727():
     run(dpath("test_github_issue727"))
 


### PR DESCRIPTION
Originally, when running in `--cluster` mode, snakemake relied on the child snakemake-processes within the cluster jobs to delete their output files if they failed. In practice, e.g. when using the SLURM scheduler, the jobs are killed with SIGKILL if they run over their time or memory limits. This made it impossible for them to clean up their own output files. There are workarounds for that, but especially running out of memory seems impossible to handle to me.

That is why the master process of snakemake should handle the cleanup, if running on a cluster. This process can detect if a job has failed or not (with custom `--cluster-status` if necessary), and can then clean up after the child process.

This works at least if the master process is active during the whole computation, but e.g. not with `--immediate-submit`.

This commit also adds a test case (test_github_issue627) that simulates a cluster environment. It launches a child job and kills it with SIGKILL, and asserts that
1. snakemake terminates with exit code != 0 and
2. the output file of that child job is deleted.

This fixes #627