### PR TITLE
Report: Fix missing caption in results

### DIFF
--- a/snakemake/report/report.html.jinja2
+++ b/snakemake/report/report.html.jinja2
@@ -587,7 +587,7 @@
               name: "{{ res.name }}",
               path: "{{ res.path }}",
               size: "{{ res.size|filesizeformat }}",
-              caption: {{ res.caption }},
+              caption: "{{ res.caption }}",
               job_properties: {
                 rule: "{{ res.job.rule.name }}",
                 wildcards: "{{ res.wildcards }}",


### PR DESCRIPTION
This PR fixes a bug where the results in the report keep loading endlessly in case no caption is provided for a result (see https://github.com/snakemake/snakemake/issues/862).