### PR TITLE
Enable compression for zipped reports

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -21,7 +21,7 @@ from collections import namedtuple, defaultdict
 from itertools import accumulate, chain
 import urllib.parse
 import hashlib
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 from pathlib import Path
 
 import requests
@@ -871,7 +871,7 @@ def auto_report(dag, path, stylesheet=None):
     # TODO look into supporting .WARC format, also see (https://webrecorder.io)
 
     if not mode_embedded:
-        with ZipFile(path, mode="w") as zipout:
+        with ZipFile(path, compression=ZIP_DEFLATED, mode="w") as zipout:
             folder = Path(Path(path).stem)
             # store results in data folder
             for subcats in results.values():


### PR DESCRIPTION
Currently zipped snakemake-reports no not contain any compression as the default compression method is `ZIP_STORED`.
As that method does not perform any compression it appears reasonable to me setting the compression method to `ZIP_DEFLATED` with a default compression level of 6.

In a test run a 4.8GB zipped snakemake-report got reduced to 1.3GB.