### PR TITLE
Fixing caption in report

### DIFF
--- a/snakemake/report/report.html.jinja2
+++ b/snakemake/report/report.html.jinja2
@@ -587,7 +587,7 @@
               name: "{{ res.name }}",
               path: "{{ res.path }}",
               size: "{{ res.size|filesizeformat }}",
-              caption: "{{ res.caption }}",
+              caption: {{ res.caption|default('""', true) }},
               job_properties: {
                 rule: "{{ res.job.rule.name }}",
                 wildcards: "{{ res.wildcards }}",


### PR DESCRIPTION
It turned out that a previous PR (https://github.com/snakemake/snakemake/pull/863) did not fix the issue of endlessly loading snakemake-report results when no caption is defined.
Since the last change this behavior now occures in case a caption is set, as the jinja-Template creates a term containing multiple quotes (see https://github.com/snakemake/snakemake/issues/862#issuecomment-776893513).

This PR should solve this issue by setting `""` als default value in case no caption is set.
