### PR TITLE
update --cores documentation

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -14,13 +14,13 @@ to execute, debug, and visualize workflows.
 Useful Command Line Arguments
 -----------------------------
 
-If called without parameters, i.e.
+If called with the number of cores to use, i.e.
 
 .. code-block:: console
 
-    $ snakemake
+    $ snakemake -j 1
 
-Snakemake tries to execute the workflow specified in a file called ``Snakefile`` in the same directory (instead, the Snakefile can be given via the parameter ``-s``).
+Snakemake tries to execute the workflow specified in a file called ``Snakefile`` in the same directory (the Snakefile can be given via the parameter ``-s``).
 
 By issuing
 
@@ -38,7 +38,7 @@ Further, the reason for each rule execution can be printed via
     $ snakemake -n -r
 
 Importantly, Snakemake can automatically determine which parts of the workflow can be run in parallel.
-By specifying the number of available cores, i.e.
+By specifying more than one available core, i.e.
 
 .. code-block:: console
 

--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -18,7 +18,7 @@ If called with the number of cores to use, i.e.
 
 .. code-block:: console
 
-    $ snakemake -j 1
+    $ snakemake --cores 1
 
 Snakemake tries to execute the workflow specified in a file called ``Snakefile`` in the same directory (the Snakefile can be given via the parameter ``-s``).
 

--- a/docs/tutorial/advanced.rst
+++ b/docs/tutorial/advanced.rst
@@ -59,7 +59,7 @@ If no ``threads`` directive is given, a rule is assumed to need 1 thread.
 
 When a workflow is executed, **the number of threads the jobs need is considered by the Snakemake scheduler**.
 In particular, the scheduler ensures that the sum of the threads of all running jobs does not exceed a given number of available CPU cores.
-This number can be given with the ``--cores`` command line argument (per default, Snakemake uses only 1 CPU core).
+This number is given with the ``--cores`` command line argument, which is required.
 For example
 
 .. code:: console
@@ -75,6 +75,8 @@ For example
 would execute the workflow with 10 cores.
 Since the rule ``bwa_map`` needs 8 threads, only one job of the rule can run at a time, and the Snakemake scheduler will try to saturate the remaining cores with other jobs like, e.g., ``samtools_sort``.
 The threads directive in a rule is interpreted as a maximum: when **less cores than threads** are provided, the number of threads a rule uses will be **reduced to the number of given cores**.
+
+If ``--cores`` is given without a number, all available cores are used.
 
 Exercise
 ........


### PR DESCRIPTION
Per https://github.com/snakemake/snakemake/issues/885#issuecomment-785357924, fixes the `--cores` documentation in two places to make it clear that `--cores` is a required argument.

 I did not do an extensive search of the docs for other places to update, though, so you might leave this open for a bit.