### PR TITLE
Add environment variables for cluster status checks (fixes #891)

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -120,6 +120,7 @@ Under https://github.com/snakemake-profiles/doc, you can find publicly available
 Feel free to contribute your own.
 
 The profile folder can additionally contain auxilliary files, e.g., jobscripts, or any kind of wrappers.
+It can be supplied via the environment variable ``SNAKEMAKE_PROFILE`` as well.
 See https://github.com/snakemake-profiles/doc for examples.
 
 

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -264,7 +264,7 @@ The following (simplified) script detects the job status on a given SLURM cluste
     else:
       print("failed")
 
-To use this script call snakemake similar to below, where ``status.py`` is the script above.
+To use this script call snakemake similar to below, where ``status.py`` is the script above, or set the environment variable ``SNAKEMAKE_CLUSTER_STATUS``.
 
 .. code:: console
 

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -270,6 +270,10 @@ To use this script call snakemake similar to below, where ``status.py`` is the s
 
     $ snakemake all --jobs 100 --cluster "sbatch --cpus-per-task=1 --parsable" --cluster-status ./status.py
 
+By default, Snakemake will query the script at most 10 times per second. This rate can be configured using the ``--max-status-checks-per-second`` argument,
+or the environment variable ``SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND``. It might be reasonable to choose higher numbers when more concurrent jobs are allowed
+to prevent any job checks from starving, while choosing lower rates for lower numbers of concurrent jobs.
+
 
 Constraining wildcards
 ::::::::::::::::::::::

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2022,7 +2022,8 @@ def get_argument_parser(profile=None):
         "to --cluster returns the cluster job id. Then, the status command "
         "will be invoked with the job id. Snakemake expects it to return "
         "'success' if the job was successfull, 'failed' if the job failed and "
-        "'running' if the job still runs.",
+        "'running' if the job still runs. The value can also be provided via "
+        "the environment variable $SNAKEMAKE_CLUSTER_STATUS.",
     )
     group_cluster.add_argument(
         "--drmaa-log-dir",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1797,11 +1797,11 @@ def get_argument_parser(profile=None):
     )
     group_behavior.add_argument(
         "--max-status-checks-per-second",
-        default=os.environ.get("SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND", 10),
+        default=10,
+        env_var='SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND',
         type=float,
         help="Maximal number of job status checks per second, default is 10, "
-        "fractions allowed. The value can also be provided via the environment "
-        "variable $SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND.",
+        "fractions allowed.",
     )
     group_behavior.add_argument(
         "-T",
@@ -2015,7 +2015,7 @@ def get_argument_parser(profile=None):
     )
     group_cluster.add_argument(
         "--cluster-status",
-        default=os.environ.get("SNAKEMAKE_CLUSTER_STATUS", None),
+        env_var='SNAKEMAKE_CLUSTER_STATUS',
         help="Status command for cluster execution. This is only considered "
         "in combination with the --cluster flag. If provided, Snakemake will "
         "use the status command to determine if a job has finished successfully "
@@ -2023,8 +2023,7 @@ def get_argument_parser(profile=None):
         "to --cluster returns the cluster job id. Then, the status command "
         "will be invoked with the job id. Snakemake expects it to return "
         "'success' if the job was successfull, 'failed' if the job failed and "
-        "'running' if the job still runs. The value can also be provided via "
-        "the environment variable $SNAKEMAKE_CLUSTER_STATUS.",
+        "'running' if the job still runs.",
     )
     group_cluster.add_argument(
         "--drmaa-log-dir",
@@ -2165,15 +2164,14 @@ def get_argument_parser(profile=None):
     group_conda.add_argument(
         "--conda-prefix",
         metavar="DIR",
-        default=os.environ.get("SNAKEMAKE_CONDA_PREFIX", None),
+        env_var='SNAKEMAKE_CONDA_PREFIX',
         help="Specify a directory in which the 'conda' and 'conda-archive' "
         "directories are created. These are used to store conda environments "
         "and their archives, respectively. If not supplied, the value is set "
         "to the '.snakemake' directory relative to the invocation directory. "
         "If supplied, the `--use-conda` flag must also be set. The value may "
         "be given as a relative path, which will be extrapolated to the "
-        "invocation directory, or as an absolute path. The value can also be "
-        "provided via the environment variable $SNAKEMAKE_CONDA_PREFIX.",
+        "invocation directory, or as an absolute path.",
     )
     group_conda.add_argument(
         "--conda-cleanup-envs",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1005,6 +1005,7 @@ def get_argument_parser(profile=None):
 
     group_exec.add_argument(
         "--profile",
+        env_var='SNAKEMAKE_PROFILE',
         help="""
                         Name of profile to use for configuring
                         Snakemake. Snakemake will search for a corresponding

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1016,7 +1016,8 @@ def get_argument_parser(profile=None):
                         line options in YAML format. For example,
                         '--cluster qsub' becomes 'cluster: qsub' in the YAML
                         file. Profiles can be obtained from
-                        https://github.com/snakemake-profiles.
+                        https://github.com/snakemake-profiles. The value can also
+                        be provided by the environment variable SNAKEMAKE_PROFILE.
                         """.format(
             dirs.site_config_dir, dirs.user_config_dir
         ),
@@ -1802,7 +1803,8 @@ def get_argument_parser(profile=None):
         env_var='SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND',
         type=float,
         help="Maximal number of job status checks per second, default is 10, "
-        "fractions allowed.",
+        "fractions allowed. The value can also be provided by the environment "
+        "variable SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND.",
     )
     group_behavior.add_argument(
         "-T",
@@ -2024,7 +2026,8 @@ def get_argument_parser(profile=None):
         "to --cluster returns the cluster job id. Then, the status command "
         "will be invoked with the job id. Snakemake expects it to return "
         "'success' if the job was successfull, 'failed' if the job failed and "
-        "'running' if the job still runs.",
+        "'running' if the job still runs. The value can also be provided by the "
+        "environment variable SNAKEMAKE_CLUSTER_STATUS.",
     )
     group_cluster.add_argument(
         "--drmaa-log-dir",
@@ -2172,7 +2175,8 @@ def get_argument_parser(profile=None):
         "to the '.snakemake' directory relative to the invocation directory. "
         "If supplied, the `--use-conda` flag must also be set. The value may "
         "be given as a relative path, which will be extrapolated to the "
-        "invocation directory, or as an absolute path.",
+        "invocation directory, or as an absolute path. The value can also be "
+        "provided via the environment variable $SNAKEMAKE_CONDA_PREFIX.",
     )
     group_conda.add_argument(
         "--conda-cleanup-envs",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1797,10 +1797,11 @@ def get_argument_parser(profile=None):
     )
     group_behavior.add_argument(
         "--max-status-checks-per-second",
-        default=10,
+        default=os.environ.get("SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND", 10),
         type=float,
         help="Maximal number of job status checks per second, default is 10, "
-        "fractions allowed.",
+        "fractions allowed. The value can also be provided via the environment "
+        "variable $SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND.",
     )
     group_behavior.add_argument(
         "-T",

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2014,6 +2014,7 @@ def get_argument_parser(profile=None):
     )
     group_cluster.add_argument(
         "--cluster-status",
+        default=os.environ.get("SNAKEMAKE_CLUSTER_STATUS", None),
         help="Status command for cluster execution. This is only considered "
         "in combination with the --cluster flag. If provided, Snakemake will "
         "use the status command to determine if a job has finished successfully "


### PR DESCRIPTION
The `--conda-prefix` argument already has a [nice way](https://github.com/snakemake/snakemake/blob/bd5a9239b2684b57ab0143bb709e77afa1493cdc/snakemake/__init__.py#L2177) of fetching the corresponding environment variable for a command line argument. I've implemented the same functionality for the `--cluster-status` and `--max-status-checks-per-second` arguments, using the environment variables `SNAKEMAKE_CLUSTER_STATUS` and `SNAKEMAKE_MAX_STATUS_CHECKS_PER_SECOND`. This allows HPC admins to provide a default status script that is compatible with their cluster setup, so users don't have to take care of that. The default value of 10 for `--max-status-checks-per-second` is kept when the environment variable is unset.

I've added documentation for this within the help string and the corresponding `additional_features.rst` doc file.

This fixes #891.