### PR TITLE
Allow params expansion to handle FileNotFoundError (fixes #927)

### DIFF
--- a/snakemake/common.py
+++ b/snakemake/common.py
@@ -38,13 +38,6 @@ else:
     async_run = asyncio.run
 
 
-class TBDInt(int):
-    """An integer that prints into <TBD>"""
-
-    def __str__(self):
-        return "<TBD>"
-
-
 # A string that prints as TBD
 TBDString = "<TBD>"
 

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -25,7 +25,7 @@ from snakemake.io import (
 from snakemake.utils import format, listfiles
 from snakemake.exceptions import RuleException, ProtectedOutputException, WorkflowError
 from snakemake.logging import logger
-from snakemake.common import DYNAMIC_FILL, lazy_property, get_uuid
+from snakemake.common import DYNAMIC_FILL, lazy_property, get_uuid, TBDString
 
 
 def format_files(job, io, dynamicio):
@@ -35,7 +35,7 @@ def format_files(job, io, dynamicio):
         elif is_flagged(f, "pipe"):
             yield "{} (pipe)".format(f)
         elif is_flagged(f, "checkpoint_target"):
-            yield "<TBD>"
+            yield TBDString
         else:
             yield f
 

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -682,8 +682,8 @@ class Rule:
             value = incomplete_checkpoint_func(e)
             incomplete = True
         except FileNotFoundError as e:
-            # Resources can depend on input files. Since expansion can happen during dryrun,
-            # where input files are not yet present, we need to skip such resources and
+            # Function evaluation can depend on input files. Since expansion can happen during dryrun,
+            # where input files are not yet present, we need to skip such cases and
             # mark them as [TBD].
             if e.filename in aux_params["input"]:
                 # use zero for resource if it cannot yet be determined

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -683,13 +683,13 @@ class Rule:
             incomplete = True
         except FileNotFoundError as e:
             # Resources can depend on input files. Since expansion can happen during dryrun,
-                        # where input files are not yet present, we need to skip such resources and
-                        # mark them as [TBD].
-            if e.filename in aux_params['input']:
+            # where input files are not yet present, we need to skip such resources and
+            # mark them as [TBD].
+            if e.filename in aux_params["input"]:
                 # use zero for resource if it cannot yet be determined
                 value = TBDInt(0)
             else:
-                raise e    
+                raise e
         except (Exception, BaseException) as e:
             if raw_exceptions:
                 raise e

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -52,7 +52,7 @@ from snakemake.exceptions import (
     IncompleteCheckpointException,
 )
 from snakemake.logging import logger
-from snakemake.common import Mode, lazy_property, TBDInt
+from snakemake.common import Mode, lazy_property, TBDString
 
 
 class Rule:
@@ -684,10 +684,9 @@ class Rule:
         except FileNotFoundError as e:
             # Function evaluation can depend on input files. Since expansion can happen during dryrun,
             # where input files are not yet present, we need to skip such cases and
-            # mark them as [TBD].
+            # mark them as <TBD>.
             if e.filename in aux_params["input"]:
-                # use zero for resource if it cannot yet be determined
-                value = TBDInt(0)
+                value = TBDString
             else:
                 raise e
         except (Exception, BaseException) as e:


### PR DESCRIPTION
Previously a param value that depended on input that had not been generated previously would fail. Analogous to how resource expansion occurs, I might expect the param expansion to identify the value depends on input not yet available, and display a <TBD> value.

These changes allow for that features by moving the code which handles this in resource expansion to the more general `apply_input_function`. With the FileNotFoundError handling occurring there, the code in the resource expansion could be simplified. 

This was tested on and passed the minimal reproducible example, resolving #927, but may interfere in unexpected ways with other code.

The output of `snakemake -n -p` for a rule with `shell: echo {params}` where the param depends on the input now looks something like 
```
echo <TBD>
```