### PR TITLE
Fix issue w/ --cluster script with args in profile

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -16,6 +16,7 @@ import webbrowser
 from functools import partial
 import importlib
 import shutil
+import shlex
 from importlib.machinery import SourceFileLoader
 
 from snakemake.workflow import Workflow

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -948,7 +948,7 @@ def get_profile_file(profile, file, return_default=False):
         # script. We check for both, in case the path contains spaces or some
         # other thing that would cause shlex.split() to mangle the path
         # inaccurately.
-        if os.path.exists(p) or os.path.exist(shlex.split(p)[0]):
+        if os.path.exists(p) or os.path.exists(shlex.split(p)[0]):
             return p
 
     if return_default:

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -934,7 +934,7 @@ def unparse_config(config):
 
 def get_profile_file(profile, file, return_default=False):
     dirs = get_appdirs()
-    if os.path.isabs(profile):
+    if os.path.exists(profile):
         search_dirs = [os.path.dirname(profile)]
         profile = os.path.basename(profile)
     else:
@@ -2295,6 +2295,11 @@ def main(argv=None):
             args.jobscript = adjust_path(args.jobscript)
         if args.cluster:
             args.cluster = adjust_path(args.cluster)
+        if args.cluster_config:
+            if isinstance(args.cluster_config, list):
+                args.cluster_config = [adjust_path(cfg) for cfg in args.cluster_config]
+            else:
+                args.cluster_config = adjust_path(args.cluster_config)
         if args.cluster_sync:
             args.cluster_sync = adjust_path(args.cluster_sync)
         if args.cluster_status:

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -941,7 +941,13 @@ def get_profile_file(profile, file, return_default=False):
     get_path = lambda d: os.path.join(d, profile, file)
     for d in search_dirs:
         p = get_path(d)
-        if os.path.exists(p):
+        # "file" can actually be a full command. If so, `p` won't exist as the
+        # below would check if e.g. '/path/to/profile/script --arg1 val --arg2'
+        # exists. To fix this, we use shlex.split() to get the path to the
+        # script. We check for both, in case the path contains spaces or some
+        # other thing that would cause shlex.split() to mangle the path
+        # inaccurately.
+        if os.path.exists(p) or os.path.exist(shlex.split(p)[0]):
             return p
 
     if return_default:


### PR DESCRIPTION
This fixes an issue when using `--profile` configs that give a value for `--cluster` that has arguments.

In config.yml, relative paths to e.g. scripts that wrap qsub can be given, and snakemake attempts to inteligently find the full path ot each script. However, the full value of `--cluster` is used, which can contain arguments (e.g. job dependencies).

For example, with a profile `/path/to/profile/config.yml`:

```
cluster: "jobsubmit --depend '{dependencies}'"
# et cetera
```

Currently, snakemake will search for `/path/to/profile/jobsubmit --depend ...`, i.e. with the args intact. The attached patch tests not only `os.path.exists(pathwithargs)`, but also `os.path.exists(shlex.split(pathwithargs)[0])` to get the path to the script itself.
