### PR TITLE
Append rather than prepend Snakemake bin path for cluster execution

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -744,11 +744,13 @@ class ClusterExecutor(RealExecutor):
         if self.assume_shared_fs:
             wait_for_files.append(self.tmpdir)
             wait_for_files.extend(job.get_wait_for_files())
-            # Prepend PATH of current python executable to PATH.
+            # Append PATH of current python executable to PATH.
             # This way, we ensure that the snakemake process in the cluster node runs
-            # in the same environment as the current process.
-            # This is necessary in order to find the pulp solver backends (e.g. coincbc).
-            path = "PATH='{}':$PATH".format(os.path.dirname(sys.executable))
+            # with the pulp solver backends (e.g. coincbc) available on the PATH.
+            # Appending ensures that Snakemake's Python cannot supersede Python
+            # from a job's environment (conda activate replaces the first PATH
+            # corresponding to the current environment rather than prepending)
+            path = "PATH=${{PATH}}:'{}'".format(os.path.dirname(sys.executable))
 
         format_p = partial(
             self.format_job_pattern,


### PR DESCRIPTION
Fixes unavailble python modules when submitting jobs to cluster (#883)
as observed in some cases using workaround first reported by @yztxwd.

As reported later by @jaicher in the same issue, the Snakemake bin path
needs to be on the PATH in order to ensure that PuLP can find external
solvers (e.g. coincbc) that are used for Snakemake's ILP solver.
However, prepending Snakemake's bin path to the PATH conflicts with
conda activate when:

+ the cluster job already has some (default) conda environment(s)
  activated
+ this default conda environment is different than the one Snakemake is
  being run from

In this case, the call to conda activate replaces the entries in the
PATH coresponding to the previously active environment, leaving
Snakemake's bin path ahead of it. This makes Snakemake's version of
Python the default, leading to missing Python modules when commands are
run in a different environment than intended.

By appending Snakemake's bin path, the solvers are on the path and
should be accessible so long as there are no conflicts on the PATH for
the solvers that are unusable/unacceptable for PuLP.