### PR TITLE
Paramspace enhancement: Use all dataframe columns when `filename_params == True`

### DIFF
--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -618,7 +618,7 @@ class Paramspace:
             self.pattern = "/".join([r"{}"] * len(self.dataframe.columns))
             self.ordered_columns = self.dataframe.columns
         else:
-            if isinstance(filename_params, bool) and filename_params:
+            if isinstance(filename_params, str) and filename_params == "*":
                 filename_params = dataframe.columns
 
             if any((param not in dataframe.columns for param in filename_params)):

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -618,6 +618,9 @@ class Paramspace:
             self.pattern = "/".join([r"{}"] * len(self.dataframe.columns))
             self.ordered_columns = self.dataframe.columns
         else:
+            if isinstance(filename_params, bool) and filename_params:
+                filename_params = dataframe.columns
+
             if any((param not in dataframe.columns for param in filename_params)):
                 raise KeyError(
                     "One or more entries of filename_params are not valid coulumn names for the param file."


### PR DESCRIPTION
This PR allows to set `filename_params=True` when creating a Paramspace object in order to automatically use all columns.

This is useful when immediately passing the dataframe to Paramspace:
```python
import pandas as pd
from snakemake.utils import Paramspace

paramspace = Paramspace(pd.read_csv('config/params.csv'), filename_params=True)
```