### PR TITLE
Implement rule-specific `restart_times` directive

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -127,7 +127,7 @@ def snakemake(
     keep_logger=False,
     max_jobs_per_second=None,
     max_status_checks_per_second=100,
-    restart_times=0,
+    workflow_restart_times=0,
     attempt=1,
     verbose=False,
     force_use_threads=False,
@@ -258,7 +258,8 @@ def snakemake(
         updated_files(list):        a list that will be filled with the files that are updated or created during the workflow execution
         verbose (bool):             show additional debug output (default False)
         max_jobs_per_second (int):  maximal number of cluster/drmaa jobs per second, None to impose no limit (default None)
-        restart_times (int):        number of times to restart failing jobs (default 0)
+        workflow_restart_times (int):
+                                    number of times to restart failing jobs (default 0)
         attempt (int):              initial value of Job.attempt. This is intended for internal use only (default 1).
         force_use_threads:          whether to force use of threads over processes. helpful if shared memory is full or unavailable (default False)
         use_conda (bool):           use conda environments for each job (defined with conda directive of rules)
@@ -572,7 +573,7 @@ def snakemake(
             mode=mode,
             wrapper_prefix=wrapper_prefix,
             printshellcmds=printshellcmds,
-            restart_times=restart_times,
+            workflow_restart_times=workflow_restart_times,
             attempt=attempt,
             default_remote_provider=_default_remote_provider,
             default_remote_prefix=default_remote_prefix,
@@ -632,7 +633,7 @@ def snakemake(
                     immediate_submit=immediate_submit,
                     standalone=standalone,
                     ignore_ambiguity=ignore_ambiguity,
-                    restart_times=restart_times,
+                    workflow_restart_times=workflow_restart_times,
                     attempt=attempt,
                     lock=lock,
                     unlock=unlock,
@@ -2714,7 +2715,7 @@ def main(argv=None):
             allowed_rules=args.allowed_rules,
             max_jobs_per_second=args.max_jobs_per_second,
             max_status_checks_per_second=args.max_status_checks_per_second,
-            restart_times=args.restart_times,
+            workflow_restart_times=args.restart_times,
             attempt=args.attempt,
             force_use_threads=args.force_use_threads,
             use_conda=args.use_conda,

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -489,6 +489,12 @@ class WildcardConstraints(RuleKeywordState):
         return "wildcard_constraints"
 
 
+class RestartTimes(RuleKeywordState):
+    @property
+    def keyword(self):
+        return "restart_times"
+
+
 class Run(RuleKeywordState):
     def __init__(self, snakefile, rulename, base_indent=0, dedent=0, root=True):
         super().__init__(snakefile, base_indent=base_indent, dedent=dedent, root=root)
@@ -606,7 +612,8 @@ class Script(AbstractCmd):
         yield (
             ", input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, container_img, singularity_args, env_modules, "
-            "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir"
+            "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir, "
+            "restart_times"
         )
 
 
@@ -622,7 +629,7 @@ class Notebook(Script):
             ", input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, container_img, singularity_args, env_modules, "
             "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir, "
-            "edit_notebook"
+            "edit_notebook, restart_times"
         )
 
 
@@ -635,7 +642,7 @@ class Wrapper(Script):
             ", input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, container_img, singularity_args, env_modules, "
             "bench_record, workflow.wrapper_prefix, jobid, bench_iteration, "
-            "cleanup_scripts, shadow_dir"
+            "cleanup_scripts, shadow_dir, restart_times"
         )
 
 
@@ -674,6 +681,7 @@ rule_property_subautomata = dict(
     shadow=Shadow,
     group=Group,
     cache=Cache,
+    restart_times=RestartTimes,
 )
 
 

--- a/snakemake/ruleinfo.py
+++ b/snakemake/ruleinfo.py
@@ -36,6 +36,7 @@ class RuleInfo:
         self.cwl = None
         self.cache = False
         self.path_modifier = None
+        self.restart_times = None
 
     def apply_modifier(
         self, modifier, prefix_replacables={"input", "output", "log", "benchmark"}

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -107,6 +107,7 @@ class Rule:
             self.basedir = None
             self.path_modifer = None
             self.ruleinfo = None
+            self.restart_times = None
         elif len(args) == 1:
             other = args[0]
             self.name = other.name
@@ -155,6 +156,7 @@ class Rule:
             self.basedir = other.basedir
             self.path_modifier = other.path_modifier
             self.ruleinfo = other.ruleinfo
+            self.restart_times = other.restart_times
 
     def dynamic_branch(self, wildcards, input=True):
         def get_io(rule):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -112,7 +112,7 @@ class Workflow:
         mode=Mode.default,
         wrapper_prefix=None,
         printshellcmds=False,
-        restart_times=None,
+        workflow_restart_times=None,
         attempt=1,
         default_remote_provider=None,
         default_remote_prefix="",
@@ -182,7 +182,7 @@ class Workflow:
         self.mode = mode
         self.wrapper_prefix = wrapper_prefix
         self.printshellcmds = printshellcmds
-        self.restart_times = restart_times
+        self.workflow_restart_times = workflow_restart_times
         self.attempt = attempt
         self.default_remote_provider = default_remote_provider
         self.default_remote_prefix = default_remote_prefix
@@ -1427,7 +1427,7 @@ class Workflow:
             rule.notebook = ruleinfo.notebook
             rule.wrapper = ruleinfo.wrapper
             rule.cwl = ruleinfo.cwl
-            rule.restart_times = self.restart_times
+            rule.restart_times = self.workflow_restart_times if ruleinfo.restart_times is None else ruleinfo.restart_times
             rule.basedir = self.current_basedir
 
             if ruleinfo.cache is True:
@@ -1651,6 +1651,13 @@ class Workflow:
     def name(self, name):
         def decorate(ruleinfo):
             ruleinfo.name = name
+            return ruleinfo
+
+        return decorate
+
+    def restart_times(self, restart_times):
+        def decorate(ruleinfo):
+            ruleinfo.restart_times = restart_times
             return ruleinfo
 
         return decorate


### PR DESCRIPTION
It is possible to call snakemake with `--restart-times` to automatically restart a rule if it crashes (and, e.g., increase resource requirements for the next run). So far this is only possible for all rules together and lacks specificity.

This PR introduces a rule-specific `restart-times` directive which allows to specify the number of restart attempts for a specific rule. It fixes #367.

A (silly) example could look like this:
```python
rule all:
    input:
        "foo",


rule foo:
    output:
        touch("foo"),
    restart_times:
        1
    resources:
        mem_mb=lambda wildcards, attempt: 10 * attempt,
    run:
        print(resources.mem_mb)
        1 / 0
```