### PR TITLE
fix: quote jobid passed to status script to support multi-cluster Slurm setup

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1084,7 +1084,7 @@ class GenericClusterExecutor(ClusterExecutor):
                 try:
                     # this command shall return "success", "failed" or "running"
                     ret = subprocess.check_output(
-                        "{statuscmd} {jobid}".format(
+                        "{statuscmd} '{jobid}'".format(
                             jobid=job.jobid, statuscmd=self.statuscmd
                         ),
                         shell=True,

--- a/tests/test_cluster_statusscript_multi/Snakefile.nonstandard
+++ b/tests/test_cluster_statusscript_multi/Snakefile.nonstandard
@@ -1,0 +1,13 @@
+from snakemake import shell
+
+envvars:
+    "TESTVAR"
+
+
+
+rule all:
+	input: 'output.txt'
+
+rule compute:
+	output: 'output.txt'
+	shell: 'touch {output}'

--- a/tests/test_cluster_statusscript_multi/sbatch
+++ b/tests/test_cluster_statusscript_multi/sbatch
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo `date` >> sbatch.log
+tail -n1 $1 >> sbatch.log
+# simulate printing of job id by a random number plus the name
+# of the cluster
+echo "$RANDOM;name-of-cluster"
+cat $1 >> sbatch.log
+sh $1

--- a/tests/test_cluster_statusscript_multi/status.sh
+++ b/tests/test_cluster_statusscript_multi/status.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# The argument passed from sbatch is "jobid;cluster_name"
+
+arg="$1"
+jobid="${arg%%;*}"
+cluster="${arg##*;}"
+
+echo success

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -115,6 +115,17 @@ def test_cluster_statusscript():
     )
 
 
+@skip_on_windows
+def test_cluster_statusscript_multi():
+    os.environ["TESTVAR"] = "test"
+    run(
+        dpath("test_cluster_statusscript_multi"),
+        snakefile="Snakefile.nonstandard",
+        cluster="./sbatch",
+        cluster_status="./status.sh",
+    )
+
+
 def test15():
     run(dpath("test15"))
 


### PR DESCRIPTION
I'm a first-time contributor but long-time user, so I wanted to start by saying: Snakemake is awesome! I really appreciate all the effort to develop and maintain this awesome resource.

### Description

<!--Add a description of your PR here-->

#### Motivation

I am trying to use `--cluster-status` with a multi-cluster Slurm setup. To check the status of the job, both `sacct` and `scontrol` require the jobid and the name of the cluster. When I use the `sbatch` option `--parsable`, it returns both in the format `jobid;cluster_name`. This entire string gets passed to the custom script I pass to `--cluster-status`, which is great since it provides all the information that the script requires. The problem is that the string isn't quoted, thus the semicolon delimiter is misinterpreted as the end of a line. Thus the shell attempts to execute the name of the cluster. I discovered this behavior with Snakemake 6.2.1.

This happens because the first argument passed to the cluster status script isn't quoted:

https://github.com/snakemake/snakemake/blob/b3c4e687c87c75075393cef842b129dcec70e7f6/snakemake/executors/__init__.py#L1078-L1086

#### Proposed solution

This PR quotes the jobid string passed as the first argument to the cluster status script. I confirmed it works both in a standard Slurm setup (i.e. when `--parsable` returns only the job id) and also when specifying the cluster name with `--clusters`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). 