### PR TITLE
Fix initialization of configfiles in Workflow class, fixing issue #914

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -186,7 +186,7 @@ class Workflow:
         self.attempt = attempt
         self.default_remote_provider = default_remote_provider
         self.default_remote_prefix = default_remote_prefix
-        self.configfiles = []
+        self.configfiles = overwrite_configfiles or []
         self.run_local = run_local
         self.report_text = None
         self.conda_cleanup_pkgs = conda_cleanup_pkgs


### PR DESCRIPTION
As stated in issue #914, `--configfile` flag was broken during Cloud Execution because the config file is not uploaded like other workflow files. Those config files are supposed to be added to the source list at [workflow.py:L330-L331](https://github.com/snakemake/snakemake/blob/main/snakemake/workflow.py#L330-L331) using `self.configfiles`, but this variable is actually empty (initialized with an empty list but never extended with the provided config files).

This small changes populates `self.configfiles` at initialization, fixing the uploading issue in tibanna (and probably kubernetes too, as it seems to be the same issue).