### PR TITLE
Set minimum version of smart_open to 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "nbformat",
         "toposort",
         "pulp >=2.0",
-        "smart_open",
+        "smart_open >=3.0",
         "filelock",
         "stopit",
     ],


### PR DESCRIPTION
This fixes issue #991, which is triggered when installing the latest version of snakemake-minimal from Conda.