### PR TITLE
Set open_browser to default in Tibanna API (#992)

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -2145,6 +2145,7 @@ class TibannaExecutor(ClusterExecutor):
             sfn=self.tibanna_sfn,
             verbose=not self.quiet,
             jobid=jobid,
+            open_browser=False,
             sleep=0,
         )
         exec_arn = exec_info.get("_tibanna", {}).get("exec_arn", "")


### PR DESCRIPTION
This small change set `open_browser` to `False` in the Tibanna API (see issue #992). The default behavior of Tibanna resulted in hundreds of tabs being opened while running a workflow (1 tab per job submitted).