### PR TITLE
do not norm URL source paths on windows

### DIFF
--- a/snakemake/common.py
+++ b/snakemake/common.py
@@ -70,10 +70,11 @@ def smart_join(base, path, abspath=False):
         from smart_open import parse_uri
 
         uri = parse_uri("{}/{}".format(base, path))
-        # Norm the path such that it does not contain any ../,
-        # which is invalid in an URL.
-        assert uri.uri_path[0] == "/"
-        uri_path = os.path.normpath(uri.uri_path)
+        if not ON_WINDOWS:
+            # Norm the path such that it does not contain any ../,
+            # which is invalid in an URL.
+            assert uri.uri_path[0] == "/"
+            uri_path = os.path.normpath(uri.uri_path)
         return "{scheme}:/{uri_path}".format(scheme=uri.scheme, uri_path=uri_path)
 
 

--- a/snakemake/common.py
+++ b/snakemake/common.py
@@ -75,6 +75,8 @@ def smart_join(base, path, abspath=False):
             # which is invalid in an URL.
             assert uri.uri_path[0] == "/"
             uri_path = os.path.normpath(uri.uri_path)
+        else:
+            uri_path = uri.uri_path
         return "{scheme}:/{uri_path}".format(scheme=uri.scheme, uri_path=uri_path)
 
 


### PR DESCRIPTION
### Description

Otherwise, slashes would be replaced with backslashes.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
