### PR TITLE
Enable testing report functionality on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,12 +167,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      # No win conda package exist for pygraphviz yet
       - name: Remove unix-only dependencies
         shell: python
         run: |
           import fileinput
-          excluded_on_win = ["pygraphviz", "environment-modules","pandoc","tibanna"]
+          excluded_on_win = ["environment-modules"]
           for line in fileinput.input("test-environment.yml", inplace=True):
               if all(pkg not in line for pkg in excluded_on_win):
                   print(line)
@@ -181,7 +180,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: snakemake
-          python-version: 3.8
+          python-version: 3.9
           channels: conda-forge, bioconda
 
       - name: Setup Snakemake environment

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -429,7 +429,8 @@ class FileRecord:
                 # '>' means only larger images scaled down to within max-dimensions
                 max_spec = max_width + "x" + max_height + ">"
                 png = sp.check_output(
-                    ["magick", "convert", "-resize", max_spec, self.path, "png:-"], stderr=sp.PIPE
+                    ["magick", "convert", "-resize", max_spec, self.path, "png:-"],
+                    stderr=sp.PIPE,
                 )
                 return png
             except sp.CalledProcessError as e:

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -418,7 +418,7 @@ class FileRecord:
     def png_content(self):
         assert self.is_img
 
-        convert = shutil.which("convert")
+        convert = shutil.which("magick")
         if convert is not None:
             try:
                 # 2048 aims at a reasonable balance between what displays
@@ -429,7 +429,7 @@ class FileRecord:
                 # '>' means only larger images scaled down to within max-dimensions
                 max_spec = max_width + "x" + max_height + ">"
                 png = sp.check_output(
-                    ["convert", "-resize", max_spec, self.path, "png:-"], stderr=sp.PIPE
+                    ["magick", "convert", "-resize", max_spec, self.path, "png:-"], stderr=sp.PIPE
                 )
                 return png
             except sp.CalledProcessError as e:

--- a/tests/test_report/Snakefile
+++ b/tests/test_report/Snakefile
@@ -1,5 +1,6 @@
 
 report: "report/workflow.rst"
+shell.executable("bash")
 
 
 rule all:

--- a/tests/test_report_dir/Snakefile
+++ b/tests/test_report_dir/Snakefile
@@ -1,3 +1,5 @@
+shell.executable("bash")
+
 rule a:
     output:
         report(directory("test"), caption="caption.rst", htmlindex="test.html")

--- a/tests/test_report_zip/Snakefile
+++ b/tests/test_report_zip/Snakefile
@@ -1,6 +1,6 @@
 
 report: "report/workflow.rst"
-
+shell.executable("bash")
 
 rule all:
     input:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -720,8 +720,7 @@ def test_singularity_conda():
 @connected
 def test_singularity_none():
     run(
-        dpath("test_singularity_none"),
-        use_singularity=True,
+        dpath("test_singularity_none"), use_singularity=True,
     )
 
 
@@ -729,8 +728,7 @@ def test_singularity_none():
 @connected
 def test_singularity_global():
     run(
-        dpath("test_singularity_global"),
-        use_singularity=True,
+        dpath("test_singularity_global"), use_singularity=True,
     )
 
 
@@ -964,7 +962,7 @@ def test_filegraph():
 
     # make sure the calls work
     cmd_sep = "&&" if ON_WINDOWS else ";"
-    shell("cd {workdir}" + cmd_sep +"python -m snakemake --filegraph > {dot_path}")
+    shell("cd {workdir}" + cmd_sep + "python -m snakemake --filegraph > {dot_path}")
 
     # make sure the output can be interpreted by dot
     with open(dot_path, "rb") as dot_file, open(pdf_path, "wb") as pdf_file:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -962,9 +962,13 @@ def test_filegraph():
     dot_path = os.path.join(workdir, "fg.dot")
     pdf_path = os.path.join(workdir, "fg.pdf")
 
+    if ON_WINDOWS:
+        shell.executable("bash")
+        workdir = workdir.replace("\\", "/")
+        dot_path = dot_path.replace("\\", "/")
+
     # make sure the calls work
-    cmd_sep = "&&" if ON_WINDOWS else ";"
-    shell("cd {workdir}" + cmd_sep + "python -m snakemake --filegraph > {dot_path}")
+    shell("cd {workdir};python -m snakemake --filegraph > {dot_path}")
 
     # make sure the output can be interpreted by dot
     with open(dot_path, "rb") as dot_file, open(pdf_path, "wb") as pdf_file:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -720,7 +720,8 @@ def test_singularity_conda():
 @connected
 def test_singularity_none():
     run(
-        dpath("test_singularity_none"), use_singularity=True,
+        dpath("test_singularity_none"),
+        use_singularity=True,
     )
 
 
@@ -728,7 +729,8 @@ def test_singularity_none():
 @connected
 def test_singularity_global():
     run(
-        dpath("test_singularity_global"), use_singularity=True,
+        dpath("test_singularity_global"),
+        use_singularity=True,
     )
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -152,7 +152,6 @@ def test_ancient():
     run(dpath("test_ancient"), targets=["D", "C", "old_file"])
 
 
-@skip_on_windows  # No conda-forge version of pygraphviz for windows
 def test_report():
     run(
         dpath("test_report"),
@@ -162,12 +161,10 @@ def test_report():
     )
 
 
-@skip_on_windows  # No conda-forge version of pygraphviz for windows
 def test_report_zip():
     run(dpath("test_report_zip"), report="report.zip", check_md5=False)
 
 
-@skip_on_windows  # No conda-forge version of pygraphviz for windows
 def test_report_dir():
     run(dpath("test_report_dir"), report="report.zip", check_md5=False)
 
@@ -960,14 +957,14 @@ def test_issue1281():
     run(dpath("test_issue1281"))
 
 
-@skip_on_windows  # Currently no workable pygraphviz package
 def test_filegraph():
     workdir = dpath("test_filegraph")
-    dot_path = os.path.abspath("fg.dot")
-    pdf_path = "fg.pdf"
+    dot_path = os.path.join(workdir, "fg.dot")
+    pdf_path = os.path.join(workdir, "fg.pdf")
 
     # make sure the calls work
-    shell("cd {workdir}; python -m snakemake --filegraph > {dot_path}")
+    cmd_sep = "&&" if ON_WINDOWS else ";"
+    shell("cd {workdir}" + cmd_sep +"python -m snakemake --filegraph > {dot_path}")
 
     # make sure the output can be interpreted by dot
     with open(dot_path, "rb") as dot_file, open(pdf_path, "wb") as pdf_file:


### PR DESCRIPTION
### Description

This PR enables testing on windows of the ``--report`` functionality. It works nicely. This was previously skipped for windows since no conda-forge "pygraphviz" package existed for windows. 

The PR also fixes a minor problem with imagemagick convert on Windows by using `magick convert instead of `convert`. The 'convert' command in imagemagick has been deprecated because it conflicted with built in tools on windows. 

Finally it updates Windows tests to run against python 3.9. 

### QC

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
