### PR TITLE
Fix conda support on Windows

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -8,7 +8,6 @@ import re
 import subprocess
 import tempfile
 from urllib.request import urlopen
-from urllib.parse import urlparse
 from urllib.error import URLError
 import hashlib
 import shutil
@@ -178,7 +177,7 @@ class Env:
                     if l and not l.startswith("#") and not l.startswith("@"):
                         pkg_url = l
                         logger.info(pkg_url)
-                        parsed = urlparse(pkg_url)
+                        parsed = utils.urlparse(pkg_url)
                         pkg_name = os.path.basename(parsed.path)
                         # write package name to list
                         print(pkg_name, file=pkg_list)
@@ -216,7 +215,7 @@ class Env:
         env_file = self.file
         tmp_file = None
 
-        url_scheme, *_ = urlparse(env_file)
+        url_scheme, *_ = utils.urlparse(env_file)
         if (url_scheme and not url_scheme == "file") or (
             not url_scheme and env_file.startswith("git+file:/")
         ):

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -346,8 +346,8 @@ class Env:
                             "env",
                             "create",
                             "--quiet",
-                            "--file '{}'".format(target_env_file),
-                            "--prefix '{}'".format(env_path),
+                            '--file "{}"'.format(target_env_file),
+                            '--prefix "{}"'.format(env_path),
                         ]
                     )
                     if self._container_img:
@@ -510,12 +510,28 @@ class Conda:
             )
 
     def bin_path(self):
-        return os.path.join(self.prefix_path, "bin")
+        if ON_WINDOWS:
+            return os.path.join(self.prefix_path, "Scripts")
+        else:
+            return os.path.join(self.prefix_path, "bin")
 
     def shellcmd(self, env_path, cmd):
         # get path to activate script
         activate = os.path.join(self.bin_path(), "activate")
+
+        if ON_WINDOWS:
+            activate = activate.replace("\\", "/")
+            env_path = env_path.replace("\\", "/")
+
         return "source {} '{}'; {}".format(activate, env_path, cmd)
+
+    def shellcmd_win(self, env_path, cmd):
+        """ Prepend the windows activate bat script. """
+        # get path to activate script
+        activate = os.path.join(self.bin_path(), "activate.bat").replace("\\", "/")
+        env_path = env_path.replace("\\", "/")
+
+        return '"{}" "{}"&&{}'.format(activate, env_path, cmd)
 
 
 def is_mamba_available():

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -6,7 +6,6 @@ __license__ = "MIT"
 import subprocess
 import shutil
 import os
-from urllib.parse import urlparse
 import hashlib
 from distutils.version import LooseVersion
 
@@ -15,6 +14,7 @@ from snakemake.deployment.conda import Conda
 from snakemake.common import lazy_property, SNAKEMAKE_SEARCHPATH
 from snakemake.exceptions import WorkflowError
 from snakemake.logging import logger
+from snakemake.utils import urlparse
 
 
 SNAKEMAKE_MOUNTPOINT = "/mnt/snakemake"

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -12,7 +12,6 @@ import json
 from collections import defaultdict
 from itertools import chain, filterfalse
 from operator import attrgetter
-from urllib.parse import urlparse
 
 from snakemake.io import (
     IOFile,
@@ -22,7 +21,7 @@ from snakemake.io import (
     is_flagged,
     get_flag_value,
 )
-from snakemake.utils import format, listfiles
+from snakemake.utils import format, listfiles, urlparse
 from snakemake.exceptions import RuleException, ProtectedOutputException, WorkflowError
 from snakemake.logging import logger
 from snakemake.common import DYNAMIC_FILL, lazy_property, get_uuid, TBDString

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -1,6 +1,5 @@
 import os, sys
 from urllib.error import URLError
-from urllib.parse import urlparse
 import tempfile
 import re
 import shutil
@@ -9,6 +8,7 @@ from snakemake.exceptions import WorkflowError
 from snakemake.shell import shell
 from snakemake.script import get_source, ScriptBase, PythonScript, RScript
 from snakemake.logging import logger
+from snakemake.utils import urlparse
 
 KERNEL_STARTED_RE = re.compile(r"Kernel started: (?P<kernel_id>\S+)")
 KERNEL_SHUTDOWN_RE = re.compile(r"Kernel shutdown: (?P<kernel_id>\S+)")

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -19,12 +19,12 @@ except ImportError:
     #  Should there be a warning? Should there be a runtime flag?
     pass
 import copy
-from urllib.parse import urlparse
 import collections
 
 # module-specific
 import snakemake.io
 from snakemake.logging import logger
+from snakemake.utils import urlparse
 
 
 class StaticRemoteObjectProxy(ObjectProxy):

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -13,7 +13,7 @@ import stat
 import tempfile
 import threading
 
-from snakemake.utils import format, argvquote, _find_bash_on_windows
+from snakemake.utils import format, argvquote, cmd_exe_quote, _find_bash_on_windows
 from snakemake.common import ON_WINDOWS
 from snakemake.logging import logger
 from snakemake.deployment import singularity
@@ -113,6 +113,11 @@ class shell:
     ):
         if "stepout" in kwargs:
             raise KeyError("Argument stepout is not allowed in shell command.")
+
+        if ON_WINDOWS and not cls.get_executable():
+            # If bash is not used on Windows quoting must be handled in a special way
+            kwargs["quote_func"] = cmd_exe_quote
+
         cmd = format(cmd, *args, stepout=2, **kwargs)
         context = inspect.currentframe().f_back.f_locals
         # add kwargs to context (overwriting the locals of the caller)

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -144,9 +144,15 @@ class shell:
             logger.info("Activating environment modules: {}".format(env_modules))
 
         if conda_env:
-            cmd = Conda(container_img, prefix_path=conda_base_path).shellcmd(
-                conda_env, cmd
-            )
+            if ON_WINDOWS and not cls.get_executable():
+                # If we use cmd.exe directly on winodws we need to prepend batch activation script.
+                cmd = Conda(container_img, prefix_path=conda_base_path).shellcmd_win(
+                    conda_env, cmd
+                )
+            else:
+                cmd = Conda(container_img, prefix_path=conda_base_path).shellcmd(
+                    conda_env, cmd
+                )
 
         tmpdir = None
         if len(cmd.replace("'", r"'\''")) + 2 > MAX_ARG_LEN:

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -17,7 +17,6 @@ from operator import attrgetter
 import copy
 import subprocess
 from pathlib import Path
-from urllib.parse import urlparse
 from urllib.request import pathname2url, url2pathname
 
 from snakemake.logging import logger, format_resources, format_resource_names
@@ -73,7 +72,7 @@ from snakemake.common import (
     Gather,
     smart_join,
 )
-from snakemake.utils import simplify_path
+from snakemake.utils import simplify_path, urlparse
 from snakemake.checkpoints import Checkpoint, Checkpoints
 from snakemake.resources import DefaultResources
 from snakemake.caching.local import OutputFileCache as LocalOutputFileCache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from snakemake.common import ON_WINDOWS
 from snakemake.utils import _find_bash_on_windows
 
 skip_on_windows = pytest.mark.skipif(ON_WINDOWS, reason="Unix stuff")
+only_on_windows = pytest.mark.skipif(not ON_WINDOWS, reason="Windows stuff")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_conda/Snakefile
+++ b/tests/test_conda/Snakefile
@@ -1,3 +1,5 @@
+shell.executable("bash")
+
 rule all:
     input:
         expand("test{i}.out2", i=range(3))
@@ -8,7 +10,7 @@ rule a:
     conda:
         "test-env.yaml"
     shell:
-        "bwa 2> {output} || true"
+        "Tm -h > {output} || true"
 
 
 rule b:
@@ -19,4 +21,4 @@ rule b:
     conda:
         "test-env.yaml"
     shell:
-        "bwa 2> {output} || true"
+        "Tm -h > {output} || true"

--- a/tests/test_conda/expected-results/test0.out
+++ b/tests/test_conda/expected-results/test0.out
@@ -1,28 +1,17 @@
+usage: Tm [-h] [--uncorrected] [-d DNA] [--na NA] [--mg MG] [--dntp DNTP]
+          [--version]
+          seq
 
-Program: bwa (alignment via Burrows-Wheeler transformation)
-Version: 0.7.17-r1188
-Contact: Heng Li <lh3@sanger.ac.uk>
+Calculate nucleotide melting temps
 
-Usage:   bwa <command> [options]
+positional arguments:
+  seq                nucleotide sequence
 
-Command: index         index sequences in the FASTA format
-         mem           BWA-MEM algorithm
-         fastmap       identify super-maximal exact matches
-         pemerge       merge overlapping paired ends (EXPERIMENTAL)
-         aln           gapped/ungapped alignment
-         samse         generate alignment (single ended)
-         sampe         generate alignment (paired ended)
-         bwasw         BWA-SW for long queries
-
-         shm           manage indices in shared memory
-         fa2pac        convert FASTA to PAC format
-         pac2bwt       generate BWT from PAC
-         pac2bwtgen    alternative algorithm for generating BWT
-         bwtupdate     update .bwt to the new format
-         bwt2sa        generate SA from BWT and Occ
-
-Note: To use BWA, you need to first index the genome with `bwa index'.
-      There are three alignment algorithms in BWA: `mem', `bwasw', and
-      `aln/samse/sampe'. If you are not sure which to use, try `bwa mem'
-      first. Please `man ./bwa.1' for the manual.
-
+optional arguments:
+  -h, --help         show this help message and exit
+  --uncorrected      Do not use monovalent/divalent cation corrections
+  -d DNA, --dna DNA  DNA concentration (nM)
+  --na NA            Na+ concentration (mM)
+  --mg MG            Mg++ concentration (mM)
+  --dntp DNTP        Nucleotide triphosphate concentration (mM)
+  --version          show program's version number and exit

--- a/tests/test_conda/expected-results/test1.out
+++ b/tests/test_conda/expected-results/test1.out
@@ -1,28 +1,17 @@
+usage: Tm [-h] [--uncorrected] [-d DNA] [--na NA] [--mg MG] [--dntp DNTP]
+          [--version]
+          seq
 
-Program: bwa (alignment via Burrows-Wheeler transformation)
-Version: 0.7.17-r1188
-Contact: Heng Li <lh3@sanger.ac.uk>
+Calculate nucleotide melting temps
 
-Usage:   bwa <command> [options]
+positional arguments:
+  seq                nucleotide sequence
 
-Command: index         index sequences in the FASTA format
-         mem           BWA-MEM algorithm
-         fastmap       identify super-maximal exact matches
-         pemerge       merge overlapping paired ends (EXPERIMENTAL)
-         aln           gapped/ungapped alignment
-         samse         generate alignment (single ended)
-         sampe         generate alignment (paired ended)
-         bwasw         BWA-SW for long queries
-
-         shm           manage indices in shared memory
-         fa2pac        convert FASTA to PAC format
-         pac2bwt       generate BWT from PAC
-         pac2bwtgen    alternative algorithm for generating BWT
-         bwtupdate     update .bwt to the new format
-         bwt2sa        generate SA from BWT and Occ
-
-Note: To use BWA, you need to first index the genome with `bwa index'.
-      There are three alignment algorithms in BWA: `mem', `bwasw', and
-      `aln/samse/sampe'. If you are not sure which to use, try `bwa mem'
-      first. Please `man ./bwa.1' for the manual.
-
+optional arguments:
+  -h, --help         show this help message and exit
+  --uncorrected      Do not use monovalent/divalent cation corrections
+  -d DNA, --dna DNA  DNA concentration (nM)
+  --na NA            Na+ concentration (mM)
+  --mg MG            Mg++ concentration (mM)
+  --dntp DNTP        Nucleotide triphosphate concentration (mM)
+  --version          show program's version number and exit

--- a/tests/test_conda/expected-results/test2.out
+++ b/tests/test_conda/expected-results/test2.out
@@ -1,28 +1,17 @@
+usage: Tm [-h] [--uncorrected] [-d DNA] [--na NA] [--mg MG] [--dntp DNTP]
+          [--version]
+          seq
 
-Program: bwa (alignment via Burrows-Wheeler transformation)
-Version: 0.7.17-r1188
-Contact: Heng Li <lh3@sanger.ac.uk>
+Calculate nucleotide melting temps
 
-Usage:   bwa <command> [options]
+positional arguments:
+  seq                nucleotide sequence
 
-Command: index         index sequences in the FASTA format
-         mem           BWA-MEM algorithm
-         fastmap       identify super-maximal exact matches
-         pemerge       merge overlapping paired ends (EXPERIMENTAL)
-         aln           gapped/ungapped alignment
-         samse         generate alignment (single ended)
-         sampe         generate alignment (paired ended)
-         bwasw         BWA-SW for long queries
-
-         shm           manage indices in shared memory
-         fa2pac        convert FASTA to PAC format
-         pac2bwt       generate BWT from PAC
-         pac2bwtgen    alternative algorithm for generating BWT
-         bwtupdate     update .bwt to the new format
-         bwt2sa        generate SA from BWT and Occ
-
-Note: To use BWA, you need to first index the genome with `bwa index'.
-      There are three alignment algorithms in BWA: `mem', `bwasw', and
-      `aln/samse/sampe'. If you are not sure which to use, try `bwa mem'
-      first. Please `man ./bwa.1' for the manual.
-
+optional arguments:
+  -h, --help         show this help message and exit
+  --uncorrected      Do not use monovalent/divalent cation corrections
+  -d DNA, --dna DNA  DNA concentration (nM)
+  --na NA            Na+ concentration (mM)
+  --mg MG            Mg++ concentration (mM)
+  --dntp DNTP        Nucleotide triphosphate concentration (mM)
+  --version          show program's version number and exit

--- a/tests/test_conda/test-env.yaml
+++ b/tests/test_conda/test-env.yaml
@@ -2,4 +2,4 @@ channels:
   - bioconda
   - conda-forge
 dependencies:
-  - bwa ==0.7.17
+  - melt ==1.0.3

--- a/tests/test_conda_cmd_exe/Snakefile
+++ b/tests/test_conda_cmd_exe/Snakefile
@@ -1,0 +1,23 @@
+
+rule all:
+    input:
+        expand("test{i}.out2", i=range(3))
+
+rule a:
+    output:
+        "test{i}.out"
+    conda:
+        "test-env.yaml"
+    shell:
+        'make --version > {output} || VER>NUL'
+
+
+rule b:
+    input:
+        "test{i}.out"
+    output:
+        "test{i}.out2"
+    conda:
+        "test-env.yaml"
+    shell:
+        "make --version > {output} || VER>NUL"

--- a/tests/test_conda_cmd_exe/expected-results/test0.out
+++ b/tests/test_conda_cmd_exe/expected-results/test0.out
@@ -1,0 +1,6 @@
+GNU Make 4.3
+Built for Windows32
+Copyright (C) 1988-2020 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.

--- a/tests/test_conda_cmd_exe/expected-results/test1.out
+++ b/tests/test_conda_cmd_exe/expected-results/test1.out
@@ -1,0 +1,6 @@
+GNU Make 4.3
+Built for Windows32
+Copyright (C) 1988-2020 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.

--- a/tests/test_conda_cmd_exe/expected-results/test2.out
+++ b/tests/test_conda_cmd_exe/expected-results/test2.out
@@ -1,0 +1,6 @@
+GNU Make 4.3
+Built for Windows32
+Copyright (C) 1988-2020 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.

--- a/tests/test_conda_cmd_exe/test-env.yaml
+++ b/tests/test_conda_cmd_exe/test-env.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - make   ==4.3

--- a/tests/test_conda_custom_prefix/Snakefile
+++ b/tests/test_conda_custom_prefix/Snakefile
@@ -1,4 +1,13 @@
+import platform
 shell.executable("bash")
+
+
+if platform.system() == "Windows":
+    custom_path = "custom/*/Scripts/snakemake.exe"
+else:
+    custom_path = "custom/*/bin/snakemake"
+
+
 rule all:
     input:
         expand("test{i}.out", i=range(3))
@@ -8,6 +17,8 @@ rule a:
         "test{i}.out"
     conda:
         "test-env.yaml"
+    params:
+        custom_path=custom_path
     shell:
-        "test -e custom/*/bin/snakemake && "
+        "test -e {params.custom_path} && "
         "snakemake --version > {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -391,17 +391,14 @@ def test_issue328():
         pass
 
 
-@skip_on_windows  # test uses bwa which is non windows
 def test_conda():
     run(dpath("test_conda"), use_conda=True)
 
 
-@skip_on_windows  # test uses bwa which is non windows
 def test_upstream_conda():
     run(dpath("test_conda"), use_conda=True, conda_frontend="conda")
 
 
-@skip_on_windows  # Conda support is partly broken on Win
 def test_conda_custom_prefix():
     run(
         dpath("test_conda_custom_prefix"),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from common import *
-from .conftest import skip_on_windows, ON_WINDOWS
+from .common import *
+from .conftest import skip_on_windows, only_on_windows, ON_WINDOWS
 
 
 def test_list_untracked():
@@ -406,6 +406,13 @@ def test_conda_custom_prefix():
         conda_prefix="custom",
         set_pythonpath=False,
     )
+
+
+@only_on_windows
+def test_conda_cmd_exe():
+    # Tests the conda environment activation when cmd.exe
+    # is used as the shell
+    run(dpath("test_conda_cmd_exe"), use_conda=True)
 
 
 @skip_on_windows  # Conda support is partly broken on Win


### PR DESCRIPTION
### Description

This PR fixes the issues which prevented conda support on Windows. 

* Fixes a underlying issues with snakemake codebase using `urllib.parse.urlparse` to distinguish between URI's and paths. That doesn't work on windows. 
* Fixes a number of problem with forward vs. backwards slashes, double vs. single quotes etc. 
* Fixes the conda tests so they use a small packages which is also available on Windows. (the 'bwa' is posix only). 


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
