### PR TITLE
Fixes missing encoding on Windows when reading config file

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1565,7 +1565,7 @@ def _load_configfile(configpath_or_obj, filetype="Config"):
     import yaml
 
     if isinstance(configpath_or_obj, str) or isinstance(configpath_or_obj, Path):
-        obj = open(configpath_or_obj)
+        obj = open(configpath_or_obj, encoding="utf-8")
     else:
         obj = configpath_or_obj
 


### PR DESCRIPTION
Fixes: #433

"Utf-8" is still not the default encoding on windows. So it must be specified when reading the config file. 
