### PR TITLE
Group toposort pipe

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1115,6 +1115,9 @@ class GroupJob(AbstractJob):
                     if dep in self.jobs:
                         yield dep
                         if any(is_flagged(f, "pipe") for f in files):
+                            # In case of a pipe, inherit the dependencies of the producer,
+                            # such that the two jobs end up on the same toposort level.
+                            # This is important because they are executed simulataneously.
                             yield from get_dependencies(dep)
 
             dag = {job: set(get_dependencies(job)) for job in self.jobs}

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1109,10 +1109,15 @@ class GroupJob(AbstractJob):
         from toposort import toposort
 
         if self.toposorted is None:
-            dag = {
-                job: {dep for dep in self.dag.dependencies[job] if dep in self.jobs}
-                for job in self.jobs
-            }
+
+            def get_dependencies(job):
+                for dep, files in self.dag.dependencies[job].items():
+                    if dep in self.jobs:
+                        yield dep
+                        if any(is_flagged(f, "pipe") for f in files):
+                            yield from get_dependencies(dep)
+
+            dag = {job: set(get_dependencies(job)) for job in self.jobs}
 
             self.toposorted = list(toposort(dag))
 


### PR DESCRIPTION
### Description

Put pipe producer and consumer on the same toposort level in group jobs, such that they are considered to be executed simultaneously.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
