### PR TITLE
If necessary, create tmpdir before job is executed. Fix bug in source cache when using git+file URLs. Pass resources to script shell commands.

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -720,6 +720,10 @@ class Job(AbstractJob):
 
         self.remove_existing_output()
 
+        # Create tmpdir if necessary
+        if self.resources.get("tmpdir"):
+            os.makedirs(self.resources.tmpdir, exist_ok=True)
+
         for f, f_ in zip(self.output, self.rule.output):
             f.prepare()
 

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -360,6 +360,8 @@ class ScriptBase(ABC):
             shadow_dir=self.shadow_dir,
             env_modules=self.env_modules,
             singularity_args=self.singularity_args,
+            resources=self.resources,
+            threads=self.threads,
             **kwargs
         )
 

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import re
 import os
 import tempfile
+import io
 
 from snakemake.common import is_local_file, get_appdirs
 from snakemake.exceptions import WorkflowError
@@ -78,7 +79,7 @@ class SourceCache:
         from smart_open import open
 
         if str(path_or_uri).startswith("git+file:"):
-            return git_content(path_or_uri)
+            return io.BytesIO(git_content(path_or_uri).encode())
 
         try:
             return open(path_or_uri, mode)


### PR DESCRIPTION
### Description

Fixes issue https://github.com/snakemake/snakemake/issues/1059 and https://github.com/snakemake/snakemake-wrappers/issues/382.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
