### PR TITLE
Bugfix for Issue #1062: correct a typo in parameter checks

### DIFF
--- a/snakemake/remote/FTP.py
+++ b/snakemake/remote/FTP.py
@@ -66,7 +66,7 @@ class RemoteProvider(AbstractRemoteProvider):
             match = re.match("^(ftps?)://.+", file)
             if match:
                 (protocol,) = match.groups()
-                if protocol == "ftp" and encrypt_data_channel in [None, False]:
+                if protocol == "ftps" and encrypt_data_channel in [None, False]:
                     raise SyntaxError(
                         "encrypt_data_channel=False cannot be used with a ftps:// url"
                     )

--- a/tests/test_github_issue1062/Snakefile
+++ b/tests/test_github_issue1062/Snakefile
@@ -1,0 +1,18 @@
+from snakemake.remote.FTP import RemoteProvider as FTPRemoteProvider    
+FTP = FTPRemoteProvider()    
+    
+rule all:    
+    input:    
+        "robots.txt"
+
+FTP_URL = \
+    "ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+    
+rule get_fasta_ftp:    
+    input:    
+        FTP.remote(FTP_URL, keep_local=True)    
+    output:    
+        "robots.txt"
+    shell:    
+        "mv {input:q} {output:q}"    
+

--- a/tests/test_github_issue1062/Snakefile
+++ b/tests/test_github_issue1062/Snakefile
@@ -6,7 +6,7 @@ rule all:
         "robots.txt"
 
 FTP_URL = \
-    "ftp://ftp.ensembl.org/pub/release-100/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna_sm.primary_assembly.fa.gz"
+    "ftp://ftp.ensembl.org/robots.txt"
     
 rule get_fasta_ftp:    
     input:    

--- a/tests/test_github_issue1062/expected-results/.gitignore
+++ b/tests/test_github_issue1062/expected-results/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/tests/test_github_issue1062/expected-results/.gitignore
+++ b/tests/test_github_issue1062/expected-results/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1058,6 +1058,11 @@ def test_github_issue988():
     run(dpath("test_github_issue988"))
 
 
+def test_github_issue1062():
+    # old code failed in dry run
+    run(dpath("test_github_issue1062"), dryrun=True)
+
+
 def test_output_file_cache():
     test_path = dpath("test_output_file_cache")
     os.environ["SNAKEMAKE_OUTPUT_CACHE"] = "cache"


### PR DESCRIPTION
### Description

Fixed a typo in the parameter checks for remote.FTP that seems to be causing issue #1062

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
