### PR TITLE
Bump copyright period to 2021

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Snakemake'
-copyright = '2014-2016, Johannes Koester'
+copyright = '2014-2021, Johannes Koester'
 
 import snakemake
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
### Description

Reject if there's a reason why copyright should stop in 2021, otherwise, probably better like this, even just for the looks.

Possible extension: make the year bump automatic with datetime. Is there a reason not to do this @johanneskoester?