### PR TITLE
fix: add_stylesheet() was deprecated in Sphing v1.8 (#1071)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,4 +280,4 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 def setup(app):
-    app.add_stylesheet('sphinx-argparse.css')
+    app.add_css_file()('sphinx-argparse.css')


### PR DESCRIPTION
Should fix #1071 

I haven't tested this myself, but I'm fairly confident that the simple switch should not break anything.

The documentation is clear on this: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file