### PR TITLE
Fix NFS latency causing denied permissions (#1073)

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1098,32 +1098,28 @@ class GenericClusterExecutor(ClusterExecutor):
         else:
 
             def job_status(job):
-                if os.path.exists(active_job.jobfinished):
-                    try:
-                        os.remove(active_job.jobfinished)
-                    except PermissionError:
-                        os.chmod(active_job.jobfinished, stat.S_IWRITE)
-                        os.remove(active_job.jobfinished)
-                    try:
-                        os.remove(active_job.jobscript)
-                    except PermissionError:
-                        os.chmod(active_job.jobscript, stat.S_IWRITE)
-                        os.remove(active_job.jobscript)
+
+                def try_remove(filename): 
+                    # shall return True if file existed and was
+                    # deleted, else return False
+                    if os.path.exists(filename):
+                        try:
+                            os.remove(filename)
+                        except PermissionError:
+                            os.chmod(filename, stat.S_IWRITE)
+                            os.remove(filename)
+                        return True
+                    else:
+                        return False
+
+                if try_remove(active_job.jobfinished):
+                    try_remove(active_job.jobscript)
                     return success
-                
-                if os.path.exists(active_job.jobfailed):
-                    try:
-                        os.remove(active_job.jobfailed)
-                    except PermissionError:
-                        os.chmod(active_job.jobfailed, stat.S_IWRITE)
-                        os.remove(active_job.jobfailed)
-                    try:
-                        os.remove(active_job.jobscript)
-                    except PermissionError:
-                        os.chmod(active_job.jobscript, stat.S_IWRITE)
-                        os.remove(active_job.jobscript)
+                if try_remove(active_job.jobfailed):
+                    try_remove(active_job.script)
                     return failed
                 return running
+                
         while True:
             with self.lock:
                 if not self.wait:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1099,15 +1099,31 @@ class GenericClusterExecutor(ClusterExecutor):
 
             def job_status(job):
                 if os.path.exists(active_job.jobfinished):
-                    os.remove(active_job.jobfinished)
-                    os.remove(active_job.jobscript)
+                    try:
+                        os.remove(active_job.jobfinished)
+                    except PermissionError:
+                        os.chmod(active_job.jobfinished, stat.S_IWRITE)
+                        os.remove(active_job.jobfinished)
+                    try:
+                        os.remove(active_job.jobscript)
+                    except PermissionError:
+                        os.chmod(active_job.jobscript, stat.S_IWRITE)
+                        os.remove(active_job.jobscript)
                     return success
+                
                 if os.path.exists(active_job.jobfailed):
-                    os.remove(active_job.jobfailed)
-                    os.remove(active_job.jobscript)
+                    try:
+                        os.remove(active_job.jobfailed)
+                    except PermissionError:
+                        os.chmod(active_job.jobfailed, stat.S_IWRITE)
+                        os.remove(active_job.jobfailed)
+                    try:
+                        os.remove(active_job.jobscript)
+                    except PermissionError:
+                        os.chmod(active_job.jobscript, stat.S_IWRITE)
+                        os.remove(active_job.jobscript)
                     return failed
                 return running
-
         while True:
             with self.lock:
                 if not self.wait:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1098,8 +1098,7 @@ class GenericClusterExecutor(ClusterExecutor):
         else:
 
             def job_status(job):
-
-                def try_remove(filename): 
+                def try_remove(filename):
                     # shall return True if file existed and was
                     # deleted, else return False
                     if os.path.exists(filename):
@@ -1119,7 +1118,7 @@ class GenericClusterExecutor(ClusterExecutor):
                     try_remove(active_job.script)
                     return failed
                 return running
-                
+
         while True:
             with self.lock:
                 if not self.wait:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1115,7 +1115,7 @@ class GenericClusterExecutor(ClusterExecutor):
                     try_remove(active_job.jobscript)
                     return success
                 if try_remove(active_job.jobfailed):
-                    try_remove(active_job.script)
+                    try_remove(active_job.jobscript)
                     return failed
                 return running
 


### PR DESCRIPTION
### Description
Changed how `.jobfinished`, `.jobscript` and `.jobfailed` files are removed. On NFS systems with considerable latency, in edge cases these files would show as existing but not writable and could not be removed (see #1073). This PR addresses that by wrapping the removal of the files in a `try/except` that forces write permissions if the removal fails.
I do not think this behavior is currently covered by a test. Likely it should not be anyway, given that it is a difficult-to-reproduce error. However, in the environment I worked in, this error occurred once every ~1500 steps in short running steps (5-15 s) and caused considerable headache. With this fix, 10,000 steps of the same pipeline ran through without issue. 

### QC
* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
