### PR TITLE
docs: Fix syntax error in docs/conf.py and update sphinx.ext.napoleon import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,4 +280,4 @@ texinfo_documents = [
 #texinfo_no_detailmenu = False
 
 def setup(app):
-    app.add_css_file()('sphinx-argparse.css')
+    app.add_css_file('sphinx-argparse.css')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
     'sphinxarg.ext',
     'sphinx.ext.autosectionlabel'
 ]


### PR DESCRIPTION
### Description

Fixes #1082 

Also, fixes a syntax error introduced in #1076.

Tested building the docs locally, and am confident it should fix the issues without breaking anything.
