### PR TITLE
fix: avoid superfluous calls of conda info that have slowed down Snakemake since 6.4.1.

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -414,27 +414,33 @@ class Conda:
         with cls.lock:
             if container_img not in cls.instances:
                 inst = super().__new__(cls)
-                inst.__init__(container_img=container_img, prefix_path=prefix_path)
                 cls.instances[container_img] = inst
-                inst._check()
                 return inst
             else:
                 return cls.instances[container_img]
 
     def __init__(self, container_img=None, prefix_path=None):
-        from snakemake.deployment import singularity
-        from snakemake.shell import shell
+        if not self.is_initialized:  # avoid superfluous init calls
+            from snakemake.deployment import singularity
+            from snakemake.shell import shell
 
-        if isinstance(container_img, singularity.Image):
-            container_img = container_img.path
-        self.container_img = container_img
+            if isinstance(container_img, singularity.Image):
+                container_img = container_img.path
+            self.container_img = container_img
 
-        if prefix_path is None or container_img is not None:
-            self.prefix_path = json.loads(
-                shell.check_output(self._get_cmd("conda info --json"))
-            )["conda_prefix"]
-        else:
-            self.prefix_path = prefix_path
+            if prefix_path is None or container_img is not None:
+                self.prefix_path = json.loads(
+                    shell.check_output(self._get_cmd("conda info --json"))
+                )["conda_prefix"]
+            else:
+                self.prefix_path = prefix_path
+
+            # check conda installation
+            self._check()
+
+    @property
+    def is_initialized(self):
+        return hasattr(self, "prefix_path")
 
     def _get_cmd(self, cmd):
         if self.container_img:


### PR DESCRIPTION
### Description

In 6.4.1 we had refactored the Conda class, which accendentally led to superfluous calls of `conda info`. This is fixed now.
Many thanks to @christopher-schroeder for spotting the issue and narrowing down to the Snakemake version that introduced the fix.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
