### PR TITLE
Add rerun-params-changed command line option

### DIFF
--- a/docs/project_info/faq.rst
+++ b/docs/project_info/faq.rst
@@ -25,7 +25,7 @@ For debugging such cases, Snakemake provides the command line flag ``--debug-dag
 
 In addition, it is advisable to check whether certain intermediate files would be created by targetting them individually via the command line.
 
-Finally, it is possible to constrain the rules that are considered for DAG creating via ``--allowed-rules``. 
+Finally, it is possible to constrain the rules that are considered for DAG creating via ``--allowed-rules``.
 This way, you can easily check rule by rule if it does what you expect.
 However, note that ``--allowed-rules`` is only meant for debugging.
 A workflow should always work fine without it.
@@ -262,7 +262,7 @@ This will cause Snakemake to re-run all jobs of that rule and everything downstr
 How should Snakefiles be formatted?
 --------------------------------------
 
-To ensure readability and consistency, you can format Snakefiles with our tool `snakefmt <https://github.com/snakemake/snakefmt>`_. 
+To ensure readability and consistency, you can format Snakefiles with our tool `snakefmt <https://github.com/snakemake/snakefmt>`_.
 
 Python code gets formatted with `black <https://github.com/psf/black>`_ and Snakemake-specific blocks are formatted using similar principles (such as `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_).
 
@@ -469,16 +469,15 @@ Similar to the solution above, you can use
 
 .. code-block:: console
 
-    $ snakemake -n -R `snakemake --list-params-changes`
+    $ snakemake -n -R `snakemake --list-code-changes`
 
-and
+Again, the list command in backticks returns the list of output files with changes, which are fed into ``-R`` to trigger a re-run.
+
+For updated parameters, you can use
 
 .. code-block:: console
 
-
-    $ snakemake -n -R `snakemake --list-code-changes`
-
-Again, the list commands in backticks return the list of output files with changes, which are fed into ``-R`` to trigger a re-run.
+    $ snakemake --rerun-params-changed
 
 
 How do I remove all files created by snakemake, i.e. like ``make clean``

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -99,6 +99,7 @@ def snakemake(
     cleanup_shadow=False,
     cleanup_scripts=True,
     force_incomplete=False,
+    force_params_changed=False,
     ignore_incomplete=False,
     list_version_changes=False,
     list_code_changes=False,
@@ -235,6 +236,7 @@ def snakemake(
         cleanup_shadow (bool):      just cleanup old shadow directories (default False)
         cleanup_scripts (bool):     delete wrapper scripts used for execution (default True)
         force_incomplete (bool):    force the re-creation of incomplete files (default False)
+        force_params_changed (bool): force the re-creation of files with updated parameters (default False)
         ignore_incomplete (bool):   ignore incomplete files (default False)
         list_version_changes (bool): list output files with changed rule version (default False)
         list_code_changes (bool):   list output files with changed rule code (default False)
@@ -643,6 +645,7 @@ def snakemake(
                     cleanup_shadow=cleanup_shadow,
                     cleanup_scripts=cleanup_scripts,
                     force_incomplete=force_incomplete,
+                    force_params_changed=force_params_changed,
                     ignore_incomplete=ignore_incomplete,
                     latency_wait=latency_wait,
                     verbose=verbose,
@@ -742,6 +745,7 @@ def snakemake(
                     ignore_ambiguity=ignore_ambiguity,
                     stats=stats,
                     force_incomplete=force_incomplete,
+                    force_params_changed=force_params_changed,
                     ignore_incomplete=ignore_incomplete,
                     list_version_changes=list_version_changes,
                     list_code_changes=list_code_changes,
@@ -1051,7 +1055,7 @@ def get_argument_parser(profile=None):
                         line options in YAML format. For example,
                         '--cluster qsub' becomes 'cluster: qsub' in the YAML
                         file. Profiles can be obtained from
-                        https://github.com/snakemake-profiles. 
+                        https://github.com/snakemake-profiles.
                         The profile can also be set via the environment variable $SNAKEMAKE_PROFILE.
                         """.format(
             dirs.site_config_dir, dirs.user_config_dir
@@ -1361,6 +1365,12 @@ def get_argument_parser(profile=None):
         "--ri",
         action="store_true",
         help=("Re-run all " "jobs the output of which is recognized as incomplete."),
+    )
+    group_exec.add_argument(
+        "--rerun-params-changed",
+        "--rp",
+        action="store_true",
+        help=("Re-run all " "jobs whose parameters have changed."),
     )
     group_exec.add_argument(
         "--shadow-prefix",
@@ -2808,6 +2818,7 @@ def main(argv=None):
             cleanup_shadow=args.cleanup_shadow,
             cleanup_scripts=not args.skip_script_cleanup,
             force_incomplete=args.rerun_incomplete,
+            force_params_changed=args.rerun_params_changed,
             ignore_incomplete=args.ignore_incomplete,
             list_version_changes=args.list_version_changes,
             list_code_changes=args.list_code_changes,

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -566,6 +566,7 @@ class Workflow:
         container_image=None,
         stats=None,
         force_incomplete=False,
+        force_params_changed=False,
         ignore_incomplete=False,
         list_version_changes=False,
         list_code_changes=False,
@@ -699,6 +700,7 @@ class Workflow:
             omitrules=omitrules,
             ignore_ambiguity=ignore_ambiguity,
             force_incomplete=force_incomplete,
+            force_params_changed=force_params_changed,
             ignore_incomplete=ignore_incomplete
             or printdag
             or printrulegraph

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1286,3 +1286,24 @@ def test_touch_pipeline_with_temp_dir():
 
 def test_all_temp():
     run(dpath("test_all_temp"), all_temp=True)
+
+
+def test_no_rerun_params_changed_without_commandline_flag():
+    tmpdir = run(dpath("test_rerun_params_changed"), config={"param1": 5}, cleanup=False)
+    run(tmpdir, config={"param1": 3}, cleanup=True)
+    shutil.rmtree(tmpdir)
+
+
+def test_rerun_params_changed_with_commandline_flag():
+    tmpdir = run(dpath("test_rerun_params_changed"), config={"param1": 5}, cleanup=False)
+    # change expected result from 5 to 3
+    path_to_expected_result = os.path.join(tmpdir, "expected-results/param.txt")
+    with open(path_to_expected_result, "w") as f_res:
+        f_res.write("3")
+    # rerun and expect 3
+    run(
+        tmpdir,
+        shellcmd="snakemake --rerun-params-changed --cores 1 --config param1=3",
+        cleanup=True
+    )
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
### Description

This command line options allows to automatically rerun all rules for which parameters have changed.

Fixes #976.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
