### PR TITLE
add py-tes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "filelock",
         "stopit",
         "tabulate",
+        "py-tes",
     ],
     extras_require={
         "reports": ["jinja2", "networkx", "pygments", "pygraphviz"],


### PR DESCRIPTION
### Description

This is a bugfix: the py-tes is required for GA4GH-tes execution mode and needs to be installed together with Snakemake. By now it was only included in the test environment.