### PR TITLE
fix: Re-enable bash strict mode on Linux

### DIFF
--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -85,6 +85,8 @@ class shell:
                     )
                 cls._process_prefix = "set -euo pipefail; "
                 cls._win_command_prefix = "-c"
+        elif os.path.split(cmd)[-1].lower() == "bash":
+            cls._process_prefix = "set -euo pipefail; "
         cls._process_args["executable"] = cmd
 
     @classmethod

--- a/tests/test_strict_mode/Snakefile
+++ b/tests/test_strict_mode/Snakefile
@@ -1,0 +1,12 @@
+shell.executable("bash")
+
+rule a:
+    output:
+        "test.out"
+    shell:
+        """
+        echo 'prints 1'
+        $(exit 1)  # Should fail with set -e
+        echo 'prints 2'
+        echo 'hello' > {output}
+        """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1286,3 +1286,7 @@ def test_touch_pipeline_with_temp_dir():
 
 def test_all_temp():
     run(dpath("test_all_temp"), all_temp=True)
+
+
+def test_strict_mode():
+    run(dpath("test_strict_mode"), shouldfail=True)


### PR DESCRIPTION
### Description

Bash strict mode (`set -euo pipefail`) was disabled on Linux in v6.5.0. This PR adds back bash strict mode and adds a test for bash strict mode.

This PR should fix #1121. Thanks to @ptrebert for identifying the problem.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
