### PR TITLE
fix: avoid spurious KeyError when handling FileNotFoundError in input functions.

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -708,7 +708,7 @@ class Rule:
             # Function evaluation can depend on input files. Since expansion can happen during dryrun,
             # where input files are not yet present, we need to skip such cases and
             # mark them as <TBD>.
-            if e.filename in aux_params["input"]:
+            if "input" in aux_params and e.filename in aux_params["input"]:
                 value = TBDString()
             else:
                 raise e


### PR DESCRIPTION
### Description

Input functions that throw a FileNotFoundError could have let to a KeyError when handling the exception.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
