### PR TITLE
fix: Initialize assignments dictionary when setting rule-based resources

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -818,6 +818,7 @@ def parse_set_resources(args):
     )
 
     from collections import defaultdict
+
     assignments = defaultdict(dict)
     if args.set_resources is not None:
         for entry in args.set_resources:


### PR DESCRIPTION
Initialize assignments[rule] dictionary

### Description

Add missing assignment to `assignments` dictionary. Fixes issue #1080 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
