### PR TITLE
Add quotes to tmp dir in wait-for-file options

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -769,7 +769,7 @@ class ClusterExecutor(RealExecutor):
         wait_for_files = []
         scheduler_solver_path = ""
         if self.assume_shared_fs:
-            wait_for_files.append(self.tmpdir)
+            wait_for_files.append("'" + self.tmpdir + "'")
             wait_for_files.extend(job.get_wait_for_files())
             # Prepend PATH of current python executable to PATH.
             # This way, we ensure that the snakemake process in the cluster node runs


### PR DESCRIPTION
Hello Snakemake team,

### Description

**Context**: Job submission to SGE cluster using `qsub` from a folder with a path containing a white space.

**Problem**: First batch of jobs is successfully submitted but snakemake issue an error regarding missing files. Below is the typical error issued when submitting a job from `$HOME/test test/':
```
Waiting at most 10 seconds for missing files.
Missing files after 10 seconds:
test/.snakemake/tmp.6tq2tga_
```
The error is due to the absence of quotes around the tmp directory path when generating the job script. The typical line for the the `wait-for-files` options is as follows:
```bash
--wait-for-files /XXXX/test test/.snakemake/tmp.6tq2tga_ test test2 --latency-wait 10 \
```
but should be:
```bash
--wait-for-files '/XXXX/test test/.snakemake/tmp.6tq2tga_' test test2 --latency-wait 10 \
```

**Solution**: Add quotes when appending the path to the `wait_for_files` list.

#### Comments

The solution has been tested in cases with white space and and with special character (&).

I am not fluent enough in Python so feel free to edit the code if needed.

#### Minimal reproducible example

In case this needs to be reproduced.
```bash
# Create working directory
mkdir "test test"
cd "test test"

# Create status directory for qsub and output directory
mkdir status
mkdir output

# Create test file
touch test

# Create snakefile
cat  << EOF > snakefile
rule test_rule:
    input:
        "test"
    output:
        "output/a.txt"
    shell:
        'sleep 10 && echo h=$(hostname) "{input}" > "{output}"'
EOF

# Submit job
snakemake --cluster "qsub -V -cwd -o status -j y" --jobs 20 -w 10

# Print status
cat status/*
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

Thank you for considering this patch.