### PR TITLE
feat: allow the base shadow directory to be created per job instead of globally for the whole workflow

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1023,6 +1023,8 @@ Shadow directories are stored one per rule execution in ``.snakemake/shadow/``,
 and are cleared on successful execution.
 Consider running with the ``--cleanup-shadow`` argument every now and then
 to remove any remaining shadow directories from aborted jobs.
+Note though that this only cleans shadow directories accessible from the machine you are running snakemake on,
+and not e.g. from local storage of compute nodes in a cluster.
 The base shadow directory can be changed with the ``--shadow-prefix`` command line argument.
 
 Flag files

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -806,7 +806,6 @@ class Job(AbstractJob):
         # Shallow simply symlink everything in the working directory.
         elif self.rule.shadow_depth == "shallow":
             for source in os.listdir(cwd):
-                print("shallow linking source {}".format(source))
                 link = os.path.join(self.shadow_dir, source)
                 os.symlink(os.path.abspath(source), link)
         elif self.rule.shadow_depth == "full":

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -87,13 +87,23 @@ class Persistence:
         for d in (
             self._metadata_path,
             self._incomplete_path,
-            self.shadow_path,
             self.conda_env_archive_path,
             self.conda_env_path,
             self.container_img_path,
             self.aux_path,
         ):
             os.makedirs(d, exist_ok=True)
+
+        try:
+            # Allow creation of shadow path to fail,
+            # since it might be node-local storage not available on the login node of a cluster
+            os.makedirs(self.shadow_path, exist_ok=True)
+        except OSError:
+            logger.info(
+                "Cannot create the base shadow directory while initializing. "
+                "Jobs that need it will still attempt to create it in their own environment"
+            )
+            pass
 
         if nolock:
             self.lock = self.noop

--- a/tests/test_shadow_prefix/Snakefile
+++ b/tests/test_shadow_prefix/Snakefile
@@ -1,7 +1,32 @@
 shell.executable("bash")
 
 rule all:
-    input:  "test.in"
+    input:  file = "test.in",
+            dependencies = ["recreate_shadow"],
     output: "shadow_prefix"
     shadow: "shallow"
-    shell: "test -h shadowdir && cp -L {input} {output}"
+    shell:  "test -h shadowdir && cp -L {input.file} {output}"
+
+rule recreate_shadow:
+    input:  "delete_shadow",
+    output: "recreate_shadow",
+    shadow: "shallow",
+    shell:  """
+        echo "rule recreate_shadow"
+        ls ../../..
+        test -h shadowdir && touch recreate_shadow
+        pwd
+        ls
+        """
+
+rule delete_shadow:
+    output: "delete_shadow",
+    shell:  """
+        echo "rule delete_shadow"
+        ls
+        echo "rm -r shadowdir"
+        rm -r shadowdir
+        pwd
+        ls
+        touch delete_shadow
+        """


### PR DESCRIPTION
### Description

Originally, the base shadow directory was created by the main snakemake process, however this prevents to use a node-local shadow directory in clusters.
Now the creation of the base shadow directory is allowed to fail in `persistency.py`, and each job ensures that the base shadow directory exists in `jobs.py`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
