### PR TITLE
docs: Typo fix if rules.rst

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1112,7 +1112,7 @@ This can be done by having them return ``dict()`` objects with the names as the 
 .. code-block:: python
 
     def myfunc(wildcards):
-        return { 'foo': '{wildcards.token}.txt'.format(wildcards=wildcards)
+        return {'foo': '{wildcards.token}.txt'.format(wildcards=wildcards)}
 
     rule:
         input: unpack(myfunc)


### PR DESCRIPTION
### Description

The snakemake documentation is generally excellent, but I figured it can't hurt to fix this small typo I found. Thanks!

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
