### PR TITLE
Bugfix/wms monitor arg ints

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -131,7 +131,7 @@ class WMSLogger:
         from snakemake.resources import parse_resources
 
         self.address = address or "http:127.0.0.1:5000"
-        self.args = parse_resources(args) or []
+        self.args = args or []
         self.metadata = metadata or {}
 
         # A token is suggested but not required, depends on server

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -128,8 +128,6 @@ class WMSLogger:
         workflow will already be running and it would not be worth stopping it.
         """
 
-        from snakemake.resources import parse_resources
-
         self.address = address or "http:127.0.0.1:5000"
         self.args = args or []
         self.metadata = metadata or {}


### PR DESCRIPTION
### Description

Fixing an issue I was experiencing when passing in wms-monitor-arg values, it was casting everything to integers, and I want to be able to pass in other things like Strings. So just removing usage of the parse_resources() in the WMS logger.

### QC
* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
