### PR TITLE
fix: converting `pathlib.Path` objects for R

### DIFF
--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -190,6 +190,8 @@ class REncoder:
             return "TRUE" if value else "FALSE"
         elif isinstance(value, int) or isinstance(value, float):
             return str(value)
+        elif isinstance(value, Path):
+            return str(value)
         elif isinstance(value, collections.abc.Iterable):
             # convert all iterables to vectors
             return cls.encode_list(value)


### PR DESCRIPTION
### Description

I ran into an error with the conversion of a `pathlib.Path` object for an Rscript and received the error: `Unsupported value for conversion into R: data/score_21q3/Score_raw_sgrna_counts/SecondBatch`. I believe this small change should fix it, but, unfortunately, I don't have the time to conduct a thorough check and PR at the moment. I have added a small test to ensure that, if passed a `Path` object, the `REncoder` can change it to a string, but I only have run this on macOS. Ideally this will be confirmed on a Windows machine, too.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
