### PR TITLE
Add more informative errors when evaluation of `--default-resources` fails

### DIFF
--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -1,6 +1,8 @@
 import re
 import tempfile
 
+from snakemake.logging import logger
+
 
 class DefaultResources:
     defaults = {
@@ -58,6 +60,19 @@ class DefaultResources:
                     # Triggers for string arguments like n1-standard-4
                     except NameError:
                         return val
+                    except Exception as e:
+                        if not (
+                            isinstance(e, FileNotFoundError) and e.filename in input
+                        ):
+                            # Missing input files are handled by the caller
+                            logger.error(
+                                "Error: Failed to evaluate DefaultResources "
+                                "value '{}'.\n"
+                                "  String arguments may need additional "
+                                "quoting. Ex: --default-resources "
+                                "\"tmpdir='/home/user/tmp'\".".format(val)
+                            )
+                        raise e
                     return value
 
                 return callable


### PR DESCRIPTION
### Description

`--default-resources` values are evaluated with `eval()` and some default resources strings can fail if not properly quoted (e.g. see #1093). This PR adds a more informative error message for `--default-resources` arguments that raise an exception.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).