### PR TITLE
fix: Remove unnecessary output

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -289,7 +289,6 @@ class Job(AbstractJob):
 
     @group.setter
     def group(self, group):
-        print(group, type(group))
         self._group = group
 
     @property


### PR DESCRIPTION
### Description

This is not exactly a fix but removes a `print`-command which seems to be missed during cleaning up.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
