### PR TITLE
fix: fix function call when creating report and hashes for between workflow caching

### DIFF
--- a/snakemake/caching/hash.py
+++ b/snakemake/caching/hash.py
@@ -50,7 +50,7 @@ class ProvenanceHashMap:
             # resources, and filenames (which shall be irrelevant for the hash).
             h.update(job.rule.shellcmd.encode())
         elif job.is_script:
-            _, source, _ = script.get_source(
+            _, source, _, _ = script.get_source(
                 job.rule.script,
                 job.rule.workflow.sourcecache,
                 basedir=job.rule.basedir,
@@ -59,7 +59,7 @@ class ProvenanceHashMap:
             )
             h.update(source)
         elif job.is_notebook:
-            _, source, _ = script.get_source(
+            _, source, _, _ = script.get_source(
                 job.rule.notebook,
                 job.rule.workflow.sourcecache,
                 basedir=job.rule.basedir,
@@ -68,7 +68,7 @@ class ProvenanceHashMap:
             )
             h.update(source)
         elif job.is_wrapper:
-            _, source, _ = script.get_source(
+            _, source, _, _ = script.get_source(
                 wrapper.get_script(job.rule.wrapper, prefix=workflow.wrapper_prefix),
                 job.rule.workflow.sourcecache,
                 basedir=job.rule.basedir,

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -260,7 +260,7 @@ class RuleRecord:
             language = "bash"
         elif self._rule.script is not None and not contains_wildcard(self._rule.script):
             logger.info("Loading script code for rule {}".format(self.name))
-            _, source, language = script.get_source(
+            _, source, language, _ = script.get_source(
                 self._rule.script, self._rule.workflow.sourcecache, self._rule.basedir
             )
             sources = [source.decode()]
@@ -268,18 +268,19 @@ class RuleRecord:
             self._rule.wrapper
         ):
             logger.info("Loading wrapper code for rule {}".format(self.name))
-            _, source, language = script.get_source(
+            _, source, language, _ = script.get_source(
                 wrapper.get_script(
                     self._rule.wrapper,
                     self._rule.workflow.sourcecache,
                     prefix=self._rule.workflow.wrapper_prefix,
-                )
+                ),
+                self._rule.workflow.sourcecache
             )
             sources = [source.decode()]
         elif self._rule.notebook is not None and not contains_wildcard(
             self._rule.notebook
         ):
-            _, source, language = script.get_source(
+            _, source, language, _ = script.get_source(
                 self._rule.notebook, self._rule.workflow.sourcecache, self._rule.basedir
             )
             language = language.split("_")[1]

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -274,7 +274,7 @@ class RuleRecord:
                     self._rule.workflow.sourcecache,
                     prefix=self._rule.workflow.wrapper_prefix,
                 ),
-                self._rule.workflow.sourcecache
+                self._rule.workflow.sourcecache,
             )
             sources = [source.decode()]
         elif self._rule.notebook is not None and not contains_wildcard(


### PR DESCRIPTION
### Description

Creating a snakemake report currently fails due to a missing argument when calling 'get_source' and a mismatching number of returned values. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
