### PR TITLE
Run dependencies with non-existent ancient files earlier

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1040,7 +1040,7 @@ class DAG:
                     if job_ not in visited:
                         # TODO may it happen that order determines whether
                         # _n_until_ready is incremented for this job?
-                        if all(f.is_ancient for f in files):
+                        if all(f.is_ancient and f.exists for f in files):
                             # No other reason to run job_.
                             # Since all files are ancient, we do not trigger it.
                             continue

--- a/tests/test_ancient_dag/Snakefile
+++ b/tests/test_ancient_dag/Snakefile
@@ -1,0 +1,39 @@
+shell.executable("bash")
+
+rule all:
+    input:
+        "d.out",
+
+rule A:
+    output:
+        "a.out",
+    shell:
+        "echo 'text' > {output}"
+
+rule B:
+    input:
+        ancient("a.out"),
+    output:
+        "b_{i}.out",
+    shell:
+        "cat {input} > {output}"
+
+# rule C is required for #946
+#  use `range(20)` so test will pass in < 5% of cases where issue is present
+rule C:
+    input:
+        expand("b_{i}.out", i=list(range(20))),
+    output:
+        "c.out",
+    shell:
+        "cat {input} > {output}"
+
+# For #946, 'a.out' is required as input, but does not need to be `ancient()`
+rule D:
+    input:
+        "a.out",
+        "c.out",
+    output:
+        "d.out",
+    shell:
+        "cat {input} > {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1320,3 +1320,7 @@ def test_github_issue1158():
         dpath("test_github_issue1158"),
         cluster="./qsub.py",
     )
+
+
+def test_ancient_dag():
+    run(dpath("test_ancient_dag"))


### PR DESCRIPTION
Fixes #946

### Description

During DAG creation, `ancient()` input files are not added to `_n_until_ready`, regardless of whether the input file exists. This PR adds `ancient()` input files to `_n_until_ready` if they do not exist.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
