### PR TITLE
fix: typo in sourcecache use

### DIFF
--- a/snakemake/caching/hash.py
+++ b/snakemake/caching/hash.py
@@ -71,7 +71,7 @@ class ProvenanceHashMap:
             _, source, _, _ = script.get_source(
                 wrapper.get_script(
                     job.rule.wrapper,
-                    sourcecahce=job.rule.workflow.sourcecache,
+                    sourcecache=job.rule.workflow.sourcecache,
                     prefix=workflow.wrapper_prefix,
                 ),
                 job.rule.workflow.sourcecache,


### PR DESCRIPTION
### Description

Fixes a typo in the recent PR, as mentioned by @mbargull.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
