### PR TITLE
docs: Unpin docutils version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ sphinx
 sphinxcontrib-napoleon
 sphinx-argparse
 sphinx_rtd_theme
-docutils==0.12
+docutils
 myst-parser
 configargparse
 appdirs


### PR DESCRIPTION
Fixes bug during docs build at line 148, in MystParser
    validator: frontend.validate_smartquotes_locales,
AttributeError: module 'docutils.frontend' has no attribute 'validate_smartquotes_locales'

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
