### PR TITLE
docs: Remove missed lambda from advanced tutorial

### DIFF
--- a/docs/tutorial/advanced.rst
+++ b/docs/tutorial/advanced.rst
@@ -192,7 +192,7 @@ We modify the rule ``bwa_map`` accordingly:
     rule bwa_map:
         input:
             "data/genome.fa",
-            lambda wildcards: config["samples"][wildcards.sample]
+            get_bwa_map_input_fastqs
         output:
             "mapped_reads/{sample}.bam"
         params:


### PR DESCRIPTION
### Description

The lambda used in the `bwa_map` rule was replaced with a named function in #911, but this single occurrence was missed

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
