### PR TITLE
fix: Issue #1253 (problems editing Jupyter Notebooks)

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -42,12 +42,12 @@ class JupyterNotebook(ScriptBase):
 
         nb["cells"].append(nbformat.v4.new_code_cell("# start coding here"))
 
-        os.makedirs(os.path.dirname(str(self.local_path)), exist_ok=True)
+        os.makedirs(os.path.dirname(self.local_path), exist_ok=True)
 
-        with open(str(self.local_path), "wb") as out:
+        with open(self.local_path, "wb") as out:
             out.write(nbformat.writes(nb).encode())
 
-        self.source = open(str(self.local_path)).read()
+        self.source = open(self.local_path).read()
 
         self.evaluate(edit=listen)
 
@@ -101,7 +101,7 @@ class JupyterNotebook(ScriptBase):
             for cell in nb["cells"]:
                 cell["outputs"] = []
 
-            nbformat.write(nb, str(self.local_path))
+            nbformat.write(nb, self.local_path)
 
     def insert_preamble_cell(self, preamble, notebook):
         import nbformat

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -42,12 +42,12 @@ class JupyterNotebook(ScriptBase):
 
         nb["cells"].append(nbformat.v4.new_code_cell("# start coding here"))
 
-        os.makedirs(os.path.dirname(self.local_path), exist_ok=True)
+        os.makedirs(os.path.dirname(str(self.local_path)), exist_ok=True)
 
-        with open(self.local_path, "wb") as out:
+        with open(str(self.local_path), "wb") as out:
             out.write(nbformat.writes(nb).encode())
 
-        self.source = open(self.local_path).read()
+        self.source = open(str(self.local_path)).read()
 
         self.evaluate(edit=listen)
 
@@ -101,7 +101,7 @@ class JupyterNotebook(ScriptBase):
             for cell in nb["cells"]:
                 cell["outputs"] = []
 
-            nbformat.write(nb, self.local_path)
+            nbformat.write(nb, str(self.local_path))
 
     def insert_preamble_cell(self, preamble, notebook):
         import nbformat

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -393,7 +393,7 @@ class ScriptBase(ABC):
 
     @property
     def local_path(self):
-        path = self.path[7:]
+        path = str(self.path)#[7:]
         if not os.path.isabs(path):
             return smart_join(self.basedir, path)
         return path

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -393,10 +393,8 @@ class ScriptBase(ABC):
 
     @property
     def local_path(self):
-        path = str(self.path)#[7:]
-        if not os.path.isabs(path):
-            return smart_join(self.basedir, path)
-        return path
+        assert self.is_local
+        return self.path.get_path_or_uri()
 
     @abstractmethod
     def get_preamble(self):


### PR DESCRIPTION
### Description
Snakemake 6.10 was unable to open Jupyter Notebooks for editing as the use of LocalSourceFile objects for file paths was not supported in notebook.py or script.py (affecting Notebooks). This PR addresses that issue (logged as GH Issue #1253  )

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
