### PR TITLE
feat: fail with an error if snakemake cannot write job metadata.

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1029,7 +1029,7 @@ class Job(AbstractJob):
                     self, keep_metadata=keep_metadata
                 )
             except IOError as e:
-                logger.warning(
+                raise WorkflowError(
                     "Error recording metadata for finished job "
                     "({}). Please ensure write permissions for the "
                     "directory {}".format(e, self.dag.workflow.persistence.path)


### PR DESCRIPTION


### Description

As proposed by @nh13 in #364.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
