### PR TITLE
add LockException

### DIFF
--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -532,3 +532,17 @@ class IncompleteCheckpointException(Exception):
 
 class CacheMissException(Exception):
     pass
+
+
+class LockException(WorkflowError):
+    def __init__(self):
+        super().__init__(
+            "Error: Directory cannot be locked. Please make "
+            "sure that no other Snakemake process is trying to create "
+            "the same files in the following directory:\n{}\n"
+            "If you are sure that no other "
+            "instances of snakemake are running on this directory, "
+            "the remaining lock was likely caused by a kill signal or "
+            "a power loss. It can be removed with "
+            "the --unlock argument.".format(os.getcwd())
+        )

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -15,6 +15,7 @@ from functools import lru_cache, partial
 from itertools import filterfalse, count
 from pathlib import Path
 
+import snakemake.exceptions
 from snakemake.logging import logger
 from snakemake.jobs import jobfiles
 from snakemake.utils import listfiles
@@ -167,7 +168,7 @@ class Persistence:
 
     def lock(self):
         if self.locked:
-            raise IOError("Another snakemake process " "has locked this directory.")
+            raise snakemake.exceptions.LockException()
         self._lock(self.all_inputfiles(), "input")
         self._lock(self.all_outputfiles(), "output")
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -765,20 +765,7 @@ class Workflow:
         dag.update_checkpoint_dependencies()
         dag.check_dynamic()
 
-        try:
-            self.persistence.lock()
-        except IOError:
-            logger.error(
-                "Error: Directory cannot be locked. Please make "
-                "sure that no other Snakemake process is trying to create "
-                "the same files in the following directory:\n{}\n"
-                "If you are sure that no other "
-                "instances of snakemake are running on this directory, "
-                "the remaining lock was likely caused by a kill signal or "
-                "a power loss. It can be removed with "
-                "the --unlock argument.".format(os.getcwd())
-            )
-            return False
+        self.persistence.lock()
 
         if cleanup_shadow:
             self.persistence.cleanup_shadow()


### PR DESCRIPTION
### Description

Stub for this PR. Let me know if this is something you will/won't support :smile: 

I'm using the API, and I am trying to catch the case where snakemake can not lock the directory. However since no exception is called it gets hard to catch that.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
