### PR TITLE
fix: provide temporary IPYTHONDIR for notebook execution in order to avoid race conditions in https://github.com/ipython/ipython/blob/master/IPython/paths.py#L20 upon execution of multiple notebooks at the same time.

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -71,37 +71,43 @@ class JupyterNotebook(ScriptBase):
             fname_out = os.path.join(os.getcwd(), fname_out)
             output_parameter = "--output {fname_out:q}"
 
-        if edit is not None:
-            logger.info("Opening notebook for editing.")
-            cmd = (
-                "jupyter notebook --browser ':' --no-browser --log-level ERROR --ip {edit.ip} --port {edit.port} "
-                "--NotebookApp.quit_button=True {{fname:q}}".format(edit=edit)
-            )
-        else:
-            cmd = (
-                "jupyter-nbconvert --log-level ERROR --execute {output_parameter} "
-                "--to notebook --ExecutePreprocessor.timeout=-1 {{fname:q}}".format(
-                    output_parameter=output_parameter
+        with tempfile.TemporaryDirectory() as tmp:
+            if edit is not None:
+                logger.info("Opening notebook for editing.")
+                cmd = (
+                    "jupyter notebook --browser ':' --no-browser --log-level ERROR --ip {edit.ip} --port {edit.port} "
+                    "--NotebookApp.quit_button=True {{fname:q}}".format(edit=edit)
                 )
+            else:
+                cmd = (
+                    "jupyter-nbconvert --log-level ERROR --execute {output_parameter} "
+                    "--to notebook --ExecutePreprocessor.timeout=-1 {{fname:q}}".format(
+                        output_parameter=output_parameter,
+                    )
+                )
+
+            if ON_WINDOWS:
+                fname = fname.replace("\\", "/")
+                fname_out = fname_out.replace("\\", "/") if fname_out else fname_out
+
+            self._execute_cmd(
+                cmd,
+                fname_out=fname_out,
+                fname=fname,
+                additional_envvars={"IPYTHONDIR": tmp.name},
             )
 
-        if ON_WINDOWS:
-            fname = fname.replace("\\", "/")
-            fname_out = fname_out.replace("\\", "/") if fname_out else fname_out
+            if edit:
+                logger.info("Saving modified notebook.")
+                nb = nbformat.read(fname, as_version=4)
 
-        self._execute_cmd(cmd, fname_out=fname_out, fname=fname)
+                self.remove_preamble_cell(nb)
 
-        if edit:
-            logger.info("Saving modified notebook.")
-            nb = nbformat.read(fname, as_version=4)
+                # clean up all outputs
+                for cell in nb["cells"]:
+                    cell["outputs"] = []
 
-            self.remove_preamble_cell(nb)
-
-            # clean up all outputs
-            for cell in nb["cells"]:
-                cell["outputs"] = []
-
-            nbformat.write(nb, self.local_path)
+                nbformat.write(nb, self.local_path)
 
     def insert_preamble_cell(self, preamble, notebook):
         import nbformat

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -94,7 +94,7 @@ class JupyterNotebook(ScriptBase):
                 cmd,
                 fname_out=fname_out,
                 fname=fname,
-                additional_envvars={"IPYTHONDIR": tmp.name},
+                additional_envvars={"IPYTHONDIR": tmp},
             )
 
             if edit:

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -219,6 +219,17 @@ class shell:
             envvars["TEMPDIR"] = tmpdir_resource
             envvars["TEMP"] = tmpdir_resource
 
+        if "additional_envvars" in kwargs:
+            env = kwargs["additional_envvars"]
+            if not isinstance(env, dict) or not all(
+                isinstance(v, str) for v in env.values()
+            ):
+                raise WorkflowError(
+                    "Given environment variables for shell command have to be a dict of strings, "
+                    "but the following was provided instead:\n{}".format(env)
+                )
+            envvars.update(env)
+
         if conda_env and cls.conda_block_conflicting_envvars:
             # remove envvars that conflict with conda
             for var in ["R_LIBS", "PYTHONPATH", "PERLLIB", "PERL5LIB"]:


### PR DESCRIPTION


### Description

This should fix this error in uncovar: https://github.com/IKIM-Essen/uncovar/runs/4291269611?check_suite_focus=true#step:7:760
```
Traceback (most recent call last):
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/bin/jupyter-nbconvert", line 11, in <module>
    sys.exit(main())
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_core/application.py", line 264, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/traitlets/config/application.py", line 846, in launch_instance
    app.start()
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/nbconvertapp.py", line 361, in start
    self.convert_notebooks()
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/nbconvertapp.py", line 533, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/nbconvertapp.py", line 498, in convert_single_notebook
    output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/nbconvertapp.py", line 427, in export_single_notebook
    output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/exporters/exporter.py", line 186, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/exporters/exporter.py", line 204, in from_file
    return self.from_notebook_node(nbformat.read(file_stream, as_version=4), resources=resources, **kw)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/exporters/notebook.py", line 32, in from_notebook_node
    nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/exporters/exporter.py", line 143, in from_notebook_node
    nb_copy, resources = self._preprocess(nb_copy, resources)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/exporters/exporter.py", line 323, in _preprocess
    nbc, resc = preprocessor(nbc, resc)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/preprocessors/base.py", line 47, in __call__
    return self.preprocess(nb, resources)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbconvert/preprocessors/execute.py", line 80, in preprocess
    with self.setup_kernel():
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbclient/client.py", line 460, in setup_kernel
    self.start_new_kernel(**kwargs)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbclient/util.py", line 84, in wrapped
    return just_run(coro(*args, **kwargs))
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbclient/util.py", line 62, in just_run
    return loop.run_until_complete(coro)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbclient/client.py", line 416, in async_start_new_kernel
    await ensure_async(self.km.start_kernel(extra_arguments=self.extra_arguments, **kwargs))
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/nbclient/util.py", line 96, in ensure_async
    result = await obj
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/manager.py", line 657, in start_kernel
    kernel_cmd, kw = self.pre_start_kernel(**kw)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/manager.py", line 292, in pre_start_kernel
    kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/manager.py", line 210, in format_kernel_cmd
    cmd = self.kernel_spec.argv + extra_arguments
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/manager.py", line 114, in kernel_spec
    self._kernel_spec = self.kernel_spec_manager.get_kernel_spec(self.kernel_name)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/kernelspec.py", line 228, in get_kernel_spec
    resource_dir = self._find_spec_directory(kernel_name.lower())
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/kernelspec.py", line 204, in _find_spec_directory
    for kernel_dir in [kd for kd in self.kernel_dirs if os.path.isdir(kd)]:
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/traitlets/traitlets.py", line 577, in __get__
    return self.get(obj, cls)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/traitlets/traitlets.py", line 540, in get
    default = obj.trait_defaults(self.name)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/traitlets/traitlets.py", line 1580, in trait_defaults
    return self._get_trait_default_generator(names[0])(self)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/jupyter_client/kernelspec.py", line 158, in _kernel_dirs_default
    dirs.append(os.path.join(get_ipython_dir(), 'kernels'))
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/site-packages/IPython/paths.py", line 70, in get_ipython_dir
    os.makedirs(ipdir)
  File "/github/workspace/.tests/.snakemake/conda/ef3802cb519924eb937d04e949367948/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/github/home/.ipython'

```
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
