### PR TITLE
fix: snakemake API using only 1 job as default

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -50,7 +50,7 @@ def snakemake(
     listrules=False,
     list_target_rules=False,
     cores=1,
-    nodes=1,
+    nodes=None,
     local_cores=1,
     max_threads=None,
     resources=dict(),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -860,7 +860,7 @@ def test_pipes():
 @skip_on_windows
 def test_pipes_multiple():
     # see github issue #975
-    run(dpath("test_pipes_multiple"))
+    run(dpath("test_pipes_multiple"), cores=5)
 
 
 def test_pipes_fail():


### PR DESCRIPTION
### Description

The snakemake API specifies:

```
cores (int) – the number of provided cores (ignored when using cluster support) (default 1)
nodes (int) – the number of provided cluster nodes (ignored without cluster support) (default 1)
```
However https://github.com/snakemake/snakemake/commit/16c34c8c09f471558950d1c3755de71e38e1043d introduced a "bug" where if you use the api, e.g. `snakemake.snakemake("Snakefile", cores=10)` then cores would be set properly to 10, but `nodes` defaults to 1, so only one job at most works in parallel.

This should be fixed with this tiny change. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


**edit**

Ok somehow this gave an issue in the tests. The test needs 5 threads minimum due to many pipes, and only 3 were specified. That shouldn't have worked to begin with, so I would say this PR "works". However I'm not so sure why what I changed caused that bug to appear :upside_down_face: 