### PR TITLE
docs: Fix typo in rules.rst (—draft-notebook)

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -953,7 +953,7 @@ For example, running
 
 .. code-block:: console
 
-    snakemake --cores 1 --edit-notebook test.txt --use-conda
+    snakemake --cores 1 --draft-notebook test.txt --use-conda
 
 will generate skeleton code in ``notebooks/hello.py.ipynb`` and additionally print instructions on how to open and execute the notebook in VSCode.
 


### PR DESCRIPTION
### Description

Quick fix for a little typo regarding the new `—draft-notebook`-option.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
