### PR TITLE
feat: Added timestamp to each log message

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -272,7 +272,7 @@ class WMSLogger:
         Sends the log to the server.
 
         Args:
-            msg (dict):     the log message dictionary
+            msg (dict):    the log message dictionary
         """
         import requests
 

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -333,6 +333,7 @@ class Logger:
             os.remove(self.logfile)
 
     def handler(self, msg):
+        msg["timestamp"] = time.time()
         for handler in self.log_handler:
             handler(msg)
 


### PR DESCRIPTION
### Description

While using the `--log-handler-script` option, a lot of info is provided but time info is missing.
In this PR, I've added a timestamp to each log entry.

Not sure if possible, but it would also be nice to have the job duration when `level == job_finished`.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
