### PR TITLE
fix: Don't handle the same job output error twice when --keep-going is set

### DIFF
--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -532,6 +532,8 @@ class JobScheduler:
                     # we do the same as in case of errors during execution
                     print_exception(e, self.workflow.linemaps)
                     self._handle_error(job)
+                    if self.keepgoing:
+                        continue
                     return
 
             if self.update_resources:


### PR DESCRIPTION
### Description

Hoping I understand Snakemake's scheduler loop logic correctly. This should fix #1244.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
