### PR TITLE
fix: --conda-frontend value not passed on to cluster jobs

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -293,6 +293,8 @@ class RealExecutor(AbstractExecutor):
             additional += " --shadow-prefix {} ".format(self.workflow.shadow_prefix)
         if self.workflow.use_conda:
             additional += " --use-conda "
+            if self.workflow.conda_frontend:
+                additional += " --conda-frontend {} ".format(self.workflow.conda_frontend)
             if self.workflow.conda_prefix:
                 additional += " --conda-prefix {} ".format(self.workflow.conda_prefix)
             if self.workflow.conda_base_path and self.assume_shared_fs:

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -294,7 +294,9 @@ class RealExecutor(AbstractExecutor):
         if self.workflow.use_conda:
             additional += " --use-conda "
             if self.workflow.conda_frontend:
-                additional += " --conda-frontend {} ".format(self.workflow.conda_frontend)
+                additional += " --conda-frontend {} ".format(
+                    self.workflow.conda_frontend
+                )
             if self.workflow.conda_prefix:
                 additional += " --conda-prefix {} ".format(self.workflow.conda_prefix)
             if self.workflow.conda_base_path and self.assume_shared_fs:


### PR DESCRIPTION
### Description

Fixes #1108.

The --conda-frontend flag is now appended to the Snakemake command used by the ClusterExecutor and the CPUExecutor, just like --conda-prefix. The default of "mamba" no longer interferes if the user wishes to use "conda".

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
