### PR TITLE
fix: avoid mutable default argument

### DIFF
--- a/snakemake/linting/__init__.py
+++ b/snakemake/linting/__init__.py
@@ -61,10 +61,10 @@ class Linter(ABC):
 
 
 class Lint:
-    def __init__(self, title, body, links=[]):
+    def __init__(self, title, body, links=None):
         self.title = title
         self.body = body
-        self.links = links
+        self.links = links or []
 
     def __str__(self):
         width, _ = shutil.get_terminal_size()

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -596,8 +596,11 @@ class Logger:
             self.last_msg_was_job_info = False
 
 
-def format_dict(dict_like, omit_keys=[], omit_values=[]):
+def format_dict(dict_like, omit_keys=None, omit_values=None):
     from snakemake.io import Namedlist
+
+    omit_keys = omit_keys or []
+    omit_values = omit_values or []
 
     if isinstance(dict_like, Namedlist):
         items = dict_like.items()


### PR DESCRIPTION
### Description

It is considered to be an antipattern the usage of mutable types as a default argument of the function.
https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
