### PR TITLE
docs: link to list of dependencies from installation

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -86,4 +86,4 @@ Installation via pip
 Instead of conda, snakemake can be installed with pip.
 However, note that snakemake has non-python dependencies, such that the pip based installation has a limited functionality if those dependencies are not manually installed in addition.
 
-A list of all of Snakemake's dependencies can be found within its `meta.yaml conda recipe <https://bioconda.github.io/recipes/snakemake/README.html>`_.
+A list of Snakemake's dependencies can be found within its `meta.yaml conda recipe <https://bioconda.github.io/recipes/snakemake/README.html>`_.

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -85,3 +85,5 @@ Installation via pip
 
 Instead of conda, snakemake can be installed with pip.
 However, note that snakemake has non-python dependencies, such that the pip based installation has a limited functionality if those dependencies are not manually installed in addition.
+
+A list of all of Snakemake's dependencies can be found within its `meta.yaml conda recipe <https://bioconda.github.io/recipes/snakemake/README.html>`_.


### PR DESCRIPTION
### Description
Resolves #1328 by linking the bioconda recipe in the installation page of the documentation.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
