### PR TITLE
docs: update URL to emacs snakemake-mode

### DIFF
--- a/docs/project_info/more_resources.rst
+++ b/docs/project_info/more_resources.rst
@@ -30,7 +30,7 @@ These resources are not part of the official documentation.
 * `A number of tutorials on the subject "Tools for reproducible research" <https://nbis-reproducible-research.readthedocs.io>`_
 * `Snakemake workflow used for the Kallisto paper <https://github.com/pachterlab/kallisto_paper_analysis>`_
 * `An alternative tutorial for Snakemake <https://slowkow.com/notes/snakemake-tutorial/>`_
-* `An Emacs mode for Snakemake <http://melpa.milkbox.net/#/snakemake-mode>`_
+* `An Emacs mode for Snakemake <https://melpa.org/#/snakemake-mode>`_
 * `Flexible bioinformatics pipelines with Snakemake <http://watson.nci.nih.gov/~sdavis/blog/flexible_bioinformatics_pipelines_with_snakemake/>`_
 * `Sandwiches with Snakemake <https://github.com/leipzig/SandwichesWithSnakemake>`_
 * `A visualization of the past years of Snakemake development <https://youtu.be/bq3vXrWw1yk>`_


### PR DESCRIPTION
### Description

I updated the URL to download emacs snakemake-mode. The base URL for MELPA is now melpa.org

https://melpa.org/#/snakemake-mode
https://www.reddit.com/r/emacs/comments/2k2kmv/melpamilkboxnet_is_now_melpaorg/
https://groups.google.com/g/Snakemake/c/H8i7JtPmyoc?pli=1


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
