### PR TITLE
fix: XRootDHelper.exists supports non posix filesystem (object store)

### DIFF
--- a/snakemake/remote/XRootD.py
+++ b/snakemake/remote/XRootD.py
@@ -7,6 +7,7 @@ import os
 from os.path import abspath, join, normpath
 import re
 
+from stat import S_ISREG
 from snakemake.remote import AbstractRemoteObject, AbstractRemoteProvider
 from snakemake.exceptions import WorkflowError, XRootDFileException
 
@@ -142,23 +143,30 @@ class XRootDHelper(object):
         return domain, dirname, filename
 
     def exists(self, url):
+
         domain, dirname, filename = self._parse_url(url)
-        status, dirlist = self.get_client(domain).dirlist(dirname)
+
+        status, statInfo = self.get_client(domain).stat(os.path.join(dirname, filename))
+
         if not status.ok:
             if status.errno == 3011:
                 return False
-            else:
-                raise XRootDFileException(
-                    "Error listing directory "
-                    + dirname
-                    + " on domain "
-                    + domain
-                    + "\n"
-                    + repr(status)
-                    + "\n"
-                    + repr(dirlist)
-                )
-        return filename in [f.name for f in dirlist.dirlist]
+            raise XRootDFileException(
+                "Error stating URL "
+                + os.path.join(dirname, filename)
+                + " on domain "
+                + domain
+                + "\n"
+                + repr(status)
+                + "\n"
+                + repr(statInfo)
+            )
+
+        return True
+        # return not (
+        #     (statInfo.flags & StatInfoFlags.IS_DIR)
+        #     or (statInfo.flags & StatInfoFlags.OTHER)
+        # )
 
     def _get_statinfo(self, url):
         domain, dirname, filename = self._parse_url(url)


### PR DESCRIPTION
### Description

Change the way `XRootDHelper` checks the existence of a URL to accommodate for object store, where listing a directory does not make sense. 

This was mentioned in an old issue: https://github.com/snakemake/snakemake/issues/809
Until `v6.7.0`, `exists` would throw an exception, as described in the issue. 
From `v6.8.0`, this PR https://github.com/snakemake/snakemake/pull/1017 changed the behavior, and `exists` would unduly return `False`

This PR uses `stat` call instead of listing the directory (adding @chrisburr as origin author, as he probably had a reason to do it this way)
A side effect is that `exists` also works for directories, while before it would return always `False` (this can easily be changed if it is an issue, these are the comments in the code).


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

Not sure how you go about testing xroot, but this is the test file I used, against real world storages 

```python

import pytest
from snakemake.remote.XRootD import XRootDHelper
from snakemake.exceptions import XRootDFileException

allURLs = (
    (
        "echoSingleSlash",
        "root://xrootd.echo.stfc.ac.uk/lhcb:user/lhcb/user/c/chaen/zozo.xml",
        True,
    ),
    (
        "echoDoubleSlash",
        "root://xrootd.echo.stfc.ac.uk//lhcb:user/lhcb/user/c/chaen/zozo.xml",
        True,
    ),
    (
        "echoDoesntExist",
        "root://xrootd.echo.stfc.ac.uk//lhcb:user/lhcb/user/c/chaen/doesntexist.xml",
        False,
    ),
    (
        "echoDirectory",
        "root://xrootd.echo.stfc.ac.uk//lhcb:user/lhcb/user/c/chaen/",
        False,
    ),
    (
        "eosSingleSlash",
        "root://eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/zozo.xml",
        True,
    ),
    (
        "eosDoubleSlash",
        "root://eoslhcb.cern.ch//eos/lhcb/grid/user/lhcb/user/c/chaen/zozo.xml",
        True,
    ),
    (
        "eosDoesntExist",
        "root://eoslhcb.cern.ch//eos/lhcb/grid/user/lhcb/user/c/chaen/notexisting",
        False,
    ),
    (
        "eosDirectoryWithSlash",
        "root://eoslhcb.cern.ch//eos/lhcb/grid/user/lhcb/user/c/chaen/test/",
        True,
    ),
    (
        "eosDirectoryWithoutSlash",
        "root://eoslhcb.cern.ch//eos/lhcb/grid/user/lhcb/user/c/chaen/test/",
        True,
    ),
    (
        "wrongHost",
        "root://eolhcb.cern.ch//eos/lhcb/grid/user/lhcb/user/c/chaen/zozo.xmlsds",
        XRootDFileException,
    ),
)

h = XRootDHelper()


@pytest.mark.parametrize("name,url,expected", allURLs)
def test_exists(name, url, expected):
    if isinstance(expected, bool):
        assert h.exists(url) == expected
    else:
        with pytest.raises(expected):
            h.exists(url)

```

## Result with `v6.7.0`

```python
(snakemake) [chaen@pceplbc04 myTest]$ pytest  --tb=line  test_exists.py::test_exists
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/chaen/workspace/snakemake
collected 10 items                                                                                                                                                                           

test_exists.py FF..F..FF.                                                                                                                                                              [100%]

========================================================================================== FAILURES ==========================================================================================
/home/chaen/workspace/snakemake/snakemake/remote/XRootD.py:143: snakemake.exceptions.XRootDFileException: Error listing directory lhcb:user/lhcb/user/c/chaen/ on domain root://xrootd.echo.stfc.ac.uk/
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
/home/chaen/workspace/snakemake/snakemake/remote/XRootD.py:143: snakemake.exceptions.XRootDFileException: Error listing directory eos/lhcb/grid/user/lhcb/user/c/chaen/ on domain root://eoslhcb.cern.ch/
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
================================================================================== short test summary info ===================================================================================
FAILED test_exists.py::test_exists[echoSingleSlash-root:/xrootd.echo.stfc.ac.uk/lhcb:user/lhcb/user/c/chaen/zozo.xml-True] - snakemake.exceptions.XRootDFileException: Error listing direct...
FAILED test_exists.py::test_exists[echoDoubleSlash-root:/xrootd.echo.stfc.ac.uk/lhcb:user/lhcb/user/c/chaen/zozo.xml-True] - AssertionError: assert False == True
FAILED test_exists.py::test_exists[eosSingleSlash-root:/eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/zozo.xml-True] - snakemake.exceptions.XRootDFileException: Error listing direc...
FAILED test_exists.py::test_exists[eosDirectoryWithSlash-root:/eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/test/-True] - AssertionError: assert False == True
FAILED test_exists.py::test_exists[eosDirectoryWithoutSlash-root:/eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/test/-True] - AssertionError: assert False == True
================================================================================ 5 failed, 5 passed in 3.48s =================================================================================
```

## Results with `v6.8.0`

```python
(snakemake) [chaen@pceplbc04 myTest]$ pytest  --tb=line  test_exists.py::test_exists
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/chaen/workspace/snakemake
collected 10 items                                                                                                                                                                           

test_exists.py FF.....FF.                                                                                                                                                              [100%]

========================================================================================== FAILURES ==========================================================================================
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
/home/chaen/workspace/snakemake/myTest/test_exists.py:64: AssertionError: assert False == True
================================================================================== short test summary info ===================================================================================
FAILED test_exists.py::test_exists[echoSingleSlash-root:/xrootd.echo.stfc.ac.uk/lhcb:user/lhcb/user/c/chaen/zozo.xml-True] - AssertionError: assert False == True
FAILED test_exists.py::test_exists[echoDoubleSlash-root:/xrootd.echo.stfc.ac.uk/lhcb:user/lhcb/user/c/chaen/zozo.xml-True] - AssertionError: assert False == True
FAILED test_exists.py::test_exists[eosDirectoryWithSlash-root:/eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/test/-True] - AssertionError: assert False == True
FAILED test_exists.py::test_exists[eosDirectoryWithoutSlash-root:/eoslhcb.cern.ch/eos/lhcb/grid/user/lhcb/user/c/chaen/test/-True] - AssertionError: assert False == True
================================================================================ 4 failed, 6 passed in 1.95s =================================================================================
```

## With this PR

```python
(snakemake) [chaen@pceplbc04 myTest]$ pytest  --tb=line  test_exists.py::test_exists
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/chaen/workspace/snakemake
collected 10 items                                                                                                                                                                           

test_exists.py ..........                                                                                                                                                              [100%]

===================================================================================== 10 passed in 1.29s =====================================================================================
```