### PR TITLE
fix: Draft notebook filename with wildcards and params.

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -13,6 +13,7 @@ from snakemake.logging import logger
 from snakemake.common import is_local_file
 from snakemake.common import ON_WINDOWS
 from snakemake.sourcecache import SourceCache, infer_source_file
+from snakemake.utils import format
 
 KERNEL_STARTED_RE = re.compile(r"Kernel started: (?P<kernel_id>\S+)")
 KERNEL_SHUTDOWN_RE = re.compile(r"Kernel shutdown: (?P<kernel_id>\S+)")
@@ -262,6 +263,7 @@ def notebook(
     Load a script from the given basedir + path and execute it.
     """
     draft = False
+    path = format(path, wildcards=wildcards, params=params)
     if edit is not None:
         if is_local_file(path):
             if not os.path.isabs(path):

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -281,7 +281,11 @@ class RuleRecord:
             self._rule.notebook
         ):
             _, source, language, _ = script.get_source(
-                self._rule.notebook, self._rule.workflow.sourcecache, self._rule.basedir
+                self._rule.notebook,
+                self._rule.workflow.sourcecache,
+                self._rule.basedir,
+                wildcards=self.wildcards,
+                params=self.params,
             )
             language = language.split("_")[1]
             sources = notebook.get_cell_sources(source)


### PR DESCRIPTION
Closes #1351.

### Description

Also fixed report generation with notebooks containing wildcards or params.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
  * [ ] I do not know how I can test for the originally failing use case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
