### PR TITLE
fix: proper error message when defining cache eligibility for rules with multiple output files and no multiext declaration.

### DIFF
--- a/snakemake/caching/__init__.py
+++ b/snakemake/caching/__init__.py
@@ -47,7 +47,9 @@ class AbstractOutputFileCache:
             )
             yield from ((f, f[prefix_len:]) for f in job.output)
         else:
-            assert len(job.output) == 1, "bug: multiple output files in cacheable job but multiext not used for declaring them"
+            assert (
+                len(job.output) == 1
+            ), "bug: multiple output files in cacheable job but multiext not used for declaring them"
             yield (job.output[0], "")
 
     def raise_write_error(self, entry, exception=None):

--- a/snakemake/caching/__init__.py
+++ b/snakemake/caching/__init__.py
@@ -47,6 +47,7 @@ class AbstractOutputFileCache:
             )
             yield from ((f, f[prefix_len:]) for f in job.output)
         else:
+            assert len(job.output) == 1, "bug: multiple output files in cacheable job but multiext not used for declaring them"
             yield (job.output[0], "")
 
     def raise_write_error(self, entry, exception=None):

--- a/snakemake/caching/local.py
+++ b/snakemake/caching/local.py
@@ -134,8 +134,6 @@ class OutputFileCache(AbstractOutputFileCache):
         provenance_hash = self.provenance_hash_map.get_provenance_hash(job)
         base_path = self.path / provenance_hash
 
-        logger.debug(list(self.get_outputfiles(job))) # TODO dbg
-
         return (
             (Path(outputfile), base_path.with_suffix(ext))
             for outputfile, ext in self.get_outputfiles(job)

--- a/snakemake/caching/local.py
+++ b/snakemake/caching/local.py
@@ -95,6 +95,12 @@ class OutputFileCache(AbstractOutputFileCache):
             if not cachefile.exists():
                 self.raise_cache_miss_exception(job)
 
+            logger.debug(
+                "Output file {} exists as {} in the cache.".format(
+                    outputfile, cachefile
+                )
+            )
+
             self.check_readable(cachefile)
             if cachefile.is_dir():
                 # For directories, create a new one and symlink each entry.

--- a/snakemake/caching/local.py
+++ b/snakemake/caching/local.py
@@ -134,6 +134,8 @@ class OutputFileCache(AbstractOutputFileCache):
         provenance_hash = self.provenance_hash_map.get_provenance_hash(job)
         base_path = self.path / provenance_hash
 
+        logger.debug(list(self.get_outputfiles(job))) # TODO dbg
+
         return (
             (Path(outputfile), base_path.with_suffix(ext))
             for outputfile, ext in self.get_outputfiles(job)

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1541,6 +1541,14 @@ class Workflow:
                 rule.is_handover = True
 
             if ruleinfo.cache is True:
+                if len(rule.output) > 1:
+                    if not rule.output[0].is_multiext:
+                        raise WorkflowError(
+                            "Rule is marked for between workflow caching but has multiple output files. "
+                            "This is only allowed if multiext() is used to declare them (see docs on between "
+                            "workflow caching).",
+                            rule=rule,
+                        )
                 if not self.enable_cache:
                     logger.warning(
                         "Workflow defines that rule {} is eligible for caching between workflows "

--- a/tests/test_cache_multioutput/Snakefile
+++ b/tests/test_cache_multioutput/Snakefile
@@ -1,0 +1,7 @@
+rule a:
+    output:
+        "1.txt",
+        "2.txt",
+    cache: True
+    shell:
+        "touch {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1397,3 +1397,7 @@ def test_modules_ruledeps_inheritance():
 @skip_on_windows
 def test_conda_named():
     run(dpath("test_conda_named"), use_conda=True)
+
+
+def test_cache_multioutput():
+    run(dpath("test_cache_multioutput"), shouldfail=True)


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
