### PR TITLE
docs: fix broken link in executor_tutorial/tutorial.rst

### DIFF
--- a/docs/executor_tutorial/tutorial.rst
+++ b/docs/executor_tutorial/tutorial.rst
@@ -4,7 +4,7 @@
 Snakemake Executor Tutorials
 ============================
 
-.. _cloud executors: https://snakemake.readthedocs.io/en/stable/executing/cluster-cloud.html
+.. _cloud executors: https://snakemake.readthedocs.io/en/stable/executing/cloud.html
 .. _tutorial: https://snakemake.readthedocs.io/en/stable/tutorial/tutorial.html
 
 This set of tutorials are intended to introduce you to executing `cloud executors`_.


### PR DESCRIPTION
### Description

Minor documentation fix. Link was broken in 9b012394eb793a38a4c0752766f3da991a255674

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
