### PR TITLE
fix: fix None type error when invoking Workflow object manually

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -204,7 +204,9 @@ class Workflow:
         self.attempt = attempt
         self.default_remote_provider = default_remote_provider
         self.default_remote_prefix = default_remote_prefix
-        self.configfiles = [] if overwrite_configfiles is None else list(overwrite_configfiles)
+        self.configfiles = (
+            [] if overwrite_configfiles is None else list(overwrite_configfiles)
+        )
         self.run_local = run_local
         self.report_text = None
         self.conda_cleanup_pkgs = conda_cleanup_pkgs

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -204,7 +204,7 @@ class Workflow:
         self.attempt = attempt
         self.default_remote_provider = default_remote_provider
         self.default_remote_prefix = default_remote_prefix
-        self.configfiles = list(overwrite_configfiles) or []
+        self.configfiles = [] if overwrite_configfiles is None else list(overwrite_configfiles)
         self.run_local = run_local
         self.report_text = None
         self.conda_cleanup_pkgs = conda_cleanup_pkgs


### PR DESCRIPTION
### Description

After updating snakemake to its current version, the following code fails with `TypeError: 'NoneType' object is not iterable`:
```python
workflow = Workflow(snakefile=snakefile)
```
This PR attempts to fix that issue.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
