### PR TITLE
fix: don't raise WorkflowError when entry is empty

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -434,7 +434,7 @@ class Rule:
 
     def check_output_duplicates(self):
         """Check ``Namedlist`` for duplicate entries and raise a ``WorkflowError``
-        on problems.
+        on problems. Does not raise if the entry is empty.
         """
         seen = dict()
         idx = None
@@ -444,10 +444,10 @@ class Rule:
                     idx = 0
                 else:
                     idx += 1
-            if value in seen:
+            if value and value in seen:
                 raise WorkflowError(
                     "Duplicate output file pattern in rule {}. First two "
-                    "duplicate for entries {} and {}".format(
+                    "duplicate for entries {} and {}.".format(
                         self.name, seen[value], name or idx
                     )
                 )


### PR DESCRIPTION
Hi, this is in relation to #1367.

Summary of changes:
  - Modify function 'check_output_duplicates' to check for empty value
  - Complete docstring
  - Add period at the end of raise message

### Description

Fixes the aforementioned issue. I ran pytest (skipped `test_tibanna` which was failing due to lack of credentials) and all tests passed.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
