### PR TITLE
fix: CondaEnvFileSpec lose the rule object to create new IOFile object

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -699,6 +699,7 @@ class CondaEnvSpec(ABC):
 
 class CondaEnvFileSpec(CondaEnvSpec):
     def __init__(self, filepath: str, rule=None):
+        self.rule = rule
         if isinstance(filepath, _IOFile):
             self.file = filepath
         else:
@@ -709,7 +710,7 @@ class CondaEnvFileSpec(CondaEnvSpec):
         if is_local_file(filepath):
             # Normalize 'file:///my/path.yml' to '/my/path.yml'
             filepath = parse_uri(filepath).uri_path
-        return CondaEnvFileSpec(filepath)
+        return CondaEnvFileSpec(filepath, self.rule)
 
     def check(self):
         self.file.check()


### PR DESCRIPTION
### Description

Hello !
This PR is a bugfix for the bug that broke the tests for snakemake-wrappers like this one https://github.com/snakemake/snakemake-wrappers/pull/449.
The implementation with `CondaEnvFileSpec` seems to lose the rule object needed to create new IOFile object.
I am not sure but my bugfix may lead to memory leak.
Another solution is to pass the rule object when the `apply_wildcards` is called.
Cheers
Dimitri

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
