### PR TITLE
fix: skip global report caption when using a module

### DIFF
--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -69,7 +69,13 @@ class ModuleInfo:
         self.replace_prefix = replace_prefix
         self.prefix = prefix
 
-    def use_rules(self, rules=None, name_modifier=None, ruleinfo=None):
+    def use_rules(
+        self,
+        rules=None,
+        name_modifier=None,
+        ruleinfo=None,
+        skip_global_report_caption=False,
+    ):
         snakefile = self.get_snakefile()
         with WorkflowModifier(
             self.workflow,
@@ -77,7 +83,7 @@ class ModuleInfo:
             base_snakefile=snakefile,
             skip_configfile=self.config is not None,
             skip_validation=self.skip_validation,
-            skip_global_report_caption=True,
+            skip_global_report_caption=skip_global_report_caption,
             rule_whitelist=self.get_rule_whitelist(rules),
             rulename_modifier=get_name_modifier_func(rules, name_modifier),
             ruleinfo_overwrite=ruleinfo,

--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -77,6 +77,7 @@ class ModuleInfo:
             base_snakefile=snakefile,
             skip_configfile=self.config is not None,
             skip_validation=self.skip_validation,
+            skip_global_report_caption=True,
             rule_whitelist=self.get_rule_whitelist(rules),
             rulename_modifier=get_name_modifier_func(rules, name_modifier),
             ruleinfo_overwrite=ruleinfo,
@@ -129,6 +130,7 @@ class WorkflowModifier:
         base_snakefile=None,
         skip_configfile=False,
         skip_validation=False,
+        skip_global_report_caption=False,
         rulename_modifier=None,
         rule_whitelist=None,
         ruleinfo_overwrite=None,
@@ -150,6 +152,7 @@ class WorkflowModifier:
         self.skip_configfile = skip_configfile
         self.rulename_modifier = rulename_modifier
         self.skip_validation = skip_validation
+        self.skip_global_report_caption = skip_global_report_caption
         self.rule_whitelist = rule_whitelist
         self.ruleinfo_overwrite = ruleinfo_overwrite
         self.allow_rule_overwrite = allow_rule_overwrite

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -506,7 +506,10 @@ class FileRecord:
                 )
             except Exception as e:
                 raise WorkflowError(
-                    "Error loading caption file of output marked for report.", e
+                    "Error loading caption file {} of output marked for report.".format(
+                        self.raw_caption.get_path_or_uri()
+                    ),
+                    e,
                 )
 
     @property
@@ -602,7 +605,7 @@ def get_resource_as_string(url):
 
 def auto_report(dag, path, stylesheet=None):
     try:
-        from jinja2 import Template, Environment, PackageLoader
+        from jinja2 import Template, Environment, PackageLoader, UndefinedError
     except ImportError as e:
         raise WorkflowError(
             "Python package jinja2 must be installed to create reports."
@@ -848,12 +851,20 @@ def auto_report(dag, path, stylesheet=None):
                 config = dag.workflow.config
 
             text = f.read() + rst_links
-            text = publish_parts(
-                env.from_string(text).render(
-                    snakemake=Snakemake, categories=results, files=files
-                ),
-                writer_name="html",
-            )["body"]
+            try:
+                text = publish_parts(
+                    env.from_string(text).render(
+                        snakemake=Snakemake, categories=results, files=files
+                    ),
+                    writer_name="html",
+                )["body"]
+            except UndefinedError as e:
+                raise WorkflowError(
+                    "Error rendering global report caption {}:".format(
+                        dag.workflow.report_text.get_path_or_uri()
+                    ),
+                    e,
+                )
 
     # record time
     now = "{} {}".format(datetime.datetime.now().ctime(), time.tzname[0])

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1289,7 +1289,8 @@ class Workflow:
 
     def report(self, path):
         """Define a global report description in .rst format."""
-        self.report_text = self.current_basedir.join(path)
+        if not self.modifier.skip_global_report_caption:
+            self.report_text = self.current_basedir.join(path)
 
     @property
     def config(self):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1844,6 +1844,8 @@ class Workflow:
                     rules,
                     name_modifier,
                     ruleinfo=None if callable(maybe_ruleinfo) else maybe_ruleinfo,
+                    skip_global_report_caption=self.report_text
+                    is not None,  # do not overwrite existing report text via module
                 )
             else:
                 # local inheritance


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
