### PR TITLE
fix: convert conda env to string before checks

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1483,6 +1483,9 @@ class Workflow:
                         rule=rule,
                     )
 
+                if isinstance(ruleinfo.conda_env, Path):
+                    ruleinfo.conda_env = str(ruleinfo.conda_env)
+
                 if (
                     ruleinfo.conda_env is not None
                     and is_conda_env_file(ruleinfo.conda_env)

--- a/tests/test_conda/Snakefile
+++ b/tests/test_conda/Snakefile
@@ -1,4 +1,5 @@
 shell.executable("bash")
+conda_env = Path("test-env.yaml")
 
 rule all:
     input:
@@ -19,6 +20,6 @@ rule b:
     output:
         "test{i}.out2"
     conda:
-        "test-env.yaml"
+        conda_env
     shell:
         "Tm -h > {output} || true"


### PR DESCRIPTION
### Description

PR to resolve #798. Convert pathlib to string before running checks on conda_env.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
