### PR TITLE
fix: fix issue when generating unit tests for rules with directory output

### DIFF
--- a/snakemake/unit_tests/__init__.py
+++ b/snakemake/unit_tests/__init__.py
@@ -54,6 +54,15 @@ def generate(dag, path, deploy=["conda", "singularity"], configfiles=None):
         )
 
     for rulename, jobs in groupby(dag.jobs, key=lambda job: job.rule.name):
+        jobs = list(jobs)
+        if jobs[0].rule.norun:
+            logger.info(
+                "Skipping rule {} because it does not execute anything.".format(
+                    rulename
+                )
+            )
+            continue
+
         testpath = path / "test_{}.py".format(rulename)
 
         if testpath.exists():
@@ -79,12 +88,11 @@ def generate(dag, path, deploy=["conda", "singularity"], configfiles=None):
                         if parent.is_absolute():
                             root = str(f.parents[len(f.parents) - 1])
                             parent = str(parent)[len(root) :]
-                            print(parent)
                         target = path / rulename / content_type / parent
-                        os.makedirs(target, exist_ok=True)
                         if f.is_dir():
-                            shutil.copytree(f, target)
+                            shutil.copytree(f, target / f.name)
                         else:
+                            os.makedirs(target, exist_ok=True)
                             shutil.copy(f, target)
                     if not files:
                         os.makedirs(path / rulename / content_type, exist_ok=True)

--- a/snakemake/unit_tests/templates/ruletest.py.jinja2
+++ b/snakemake/unit_tests/templates/ruletest.py.jinja2
@@ -30,7 +30,7 @@ def test_{{ ruletest.name }}():
             "-m",
             "snakemake", 
             "{{ ruletest.target }}",
-            "-F", 
+            "-f", 
             "-j1",
             "--keep-target-files",
             {% if configfiles %}

--- a/tests/test_github_issue1384/Snakefile
+++ b/tests/test_github_issue1384/Snakefile
@@ -1,0 +1,20 @@
+rule all:
+    input:
+        "results/checksum.txt"
+
+rule foo:
+    output:
+        directory("results/dir")
+    shell:
+        """
+        mkdir results/dir
+        echo hi >> results/dir/something
+        """
+
+rule bar:
+    input:
+        rules.foo.output
+    output:
+        "results/checksum.txt"
+    shell:
+        "ls {input}/* >> {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1421,7 +1421,7 @@ def test_github_issue1384():
         shell(
             """
             cd {tmpdir}
-            snakemake --generate-unit-tests
+            python -m snakemake --generate-unit-tests
             pytest -v .tests/unit
             """
         )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1412,3 +1412,18 @@ def test_default_target():
 
 def test_cache_multioutput():
     run(dpath("test_cache_multioutput"), shouldfail=True)
+
+
+@skip_on_windows
+def test_github_issue1384():
+    try:
+        tmpdir = run(dpath("test_github_issue1384"), cleanup=False)
+        shell(
+            """
+            cd {tmpdir}
+            snakemake --generate-unit-tests
+            pytest -v .tests/unit
+            """
+        )
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
### Description

fixes #1384

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
