### PR TITLE
build: Fix conda dependency file for documentation build

### DIFF
--- a/doc-environment.yml
+++ b/doc-environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python >=3.5
+  - python >=3.7
   - datrie
   - wrapt
   - pyyaml
@@ -18,6 +18,7 @@ dependencies:
     - sphinxcontrib-napoleon
   - sphinx-argparse
   - sphinx_rtd_theme
-  - docutils==0.12
+  - docutils
   - recommonmark
   - commonmark
+  - myst-parser


### PR DESCRIPTION
Bumped Python to 3.7
Removed docutils constraint on version 0.12 (resulted in unresolved dependencies)
Added missing dependency myst-parser

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
