### PR TITLE
docs: update copyright year

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2019 Johannes Köster <johannes.koester@tu-dortmund.de>
+Copyright (c) 2012-2022 Johannes Köster <johannes.koester@tu-dortmund.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Finally, Snakemake workflows can entail a description of required software, whic
 
 **Homepage: https://snakemake.github.io**
 
-Copyright (c) 2012-2021 Johannes Köster <johannes.koester@uni-due.com> (see LICENSE)
+Copyright (c) 2012-2022 Johannes Köster <johannes.koester@uni-due.com> (see LICENSE)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,7 @@
 
 import sys
 import os
+from datetime import datetime
 
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -60,7 +61,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Snakemake'
-copyright = '2014-2021, Johannes Koester'
+date = datetime.now()
+copyright = '2014-{year}, Johannes Koester'.format(year=date.timetuple()[0])
 
 import snakemake
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
### Description
Set copyright year to 2022 in license file and readme. 
Update year automatically for online documentation.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
