### PR TITLE
fix: do not require --cores or --jobs to be set when --cleanup-metadata is used.

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2512,6 +2512,7 @@ def main(argv=None):
         or args.gui
         or args.archive
         or args.unlock
+        or args.cleanup_metadata
     )
     local_exec = not (no_exec or non_local_exec)
 


### PR DESCRIPTION
### Description

Before, Snakemake was complaining that cores or jobs aren't defined, but --cleanup-metadata just deletes the metadata and does not execute anything.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
