### PR TITLE
fix: provide details on error when failing to evaluate default resources

### DIFF
--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -66,11 +66,12 @@ class DefaultResources:
                         ):
                             # Missing input files are handled by the caller
                             raise WorkflowError(
-                                "Failed to evaluate DefaultResources value "
+                                "Failed to evaluate default resources value "
                                 "'{}'.\n"
                                 "    String arguments may need additional "
                                 "quoting. Ex: --default-resources "
-                                "\"tmpdir='/home/user/tmp'\".".format(val)
+                                "\"tmpdir='/home/user/tmp'\".".format(val),
+                                e,
                             )
                         raise e
                     return value


### PR DESCRIPTION
### Description

See title

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
