### PR TITLE
fix: more robust place for runtime source file cache

### DIFF
--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -284,8 +284,11 @@ class SourceCache:
         )
         os.makedirs(self.cache, exist_ok=True)
         if runtime_cache_path is None:
+            runtime_cache_parent = self.cache / "runtime-cache"
+            os.makedirs(runtime_cache_parent)
             self.runtime_cache = tempfile.TemporaryDirectory(
-                suffix="snakemake-runtime-source-cache"
+                suffix="snakemake-runtime-source-cache",
+                dir=runtime_cache_parent,
             )
             self._runtime_cache_path = None
         else:

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -285,7 +285,7 @@ class SourceCache:
         os.makedirs(self.cache, exist_ok=True)
         if runtime_cache_path is None:
             runtime_cache_parent = self.cache / "runtime-cache"
-            os.makedirs(runtime_cache_parent)
+            os.makedirs(runtime_cache_parent, exist_ok=True)
             self.runtime_cache = tempfile.TemporaryDirectory(
                 suffix="snakemake-runtime-source-cache",
                 dir=runtime_cache_parent,


### PR DESCRIPTION
### Description

Fixes #1435. The temp folder chosen before could lead to unexpected behavior in clusters where the temp folder changes across nodes. Further it could  have caused issues where the folder is not writable.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
