### PR TITLE
fix: provide proper error when using immediate submit in combination with checkpoint jobs.

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2120,7 +2120,8 @@ def get_argument_parser(profile=None):
         "$ snakemake --cluster 'sbatch --dependency {dependencies}.\n"
         "Assuming that your submit script (here sbatch) outputs the "
         "generated job id to the first stdout line, {dependencies} will "
-        "be filled with space separated job ids this job depends on.",
+        "be filled with space separated job ids this job depends on. "
+        "Does not work for workflows that contain checkpoint rules.",
     )
     group_cluster.add_argument(
         "--jobscript",

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -873,6 +873,14 @@ class Workflow:
                 )
                 return False
 
+        if immediate_submit and any(dag.checkpoint_jobs):
+            logger.error(
+                "Immediate submit mode (--immediate-submit) may not be used for workflows "
+                "with checkpoint jobs, as the dependencies cannot be determined before "
+                "execution in such cases."
+            )
+            return False
+
         updated_files.extend(f for job in dag.needrun_jobs for f in job.output)
 
         if generate_unit_tests:


### PR DESCRIPTION
### Description

fixes #1208

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
