### PR TITLE
fix: small bug in snakemake.executors

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1020,11 +1020,11 @@ class GenericClusterExecutor(ClusterExecutor):
             while process.poll() is None and executor.wait:
                 buf = process.stdout.readline()
                 if buf:
-                    self.stdout.write(buf)
+                    sys.stdout.write(buf)
             # one final time ...
             buf = process.stdout.readline()
             if buf:
-                self.stdout.write(buf)
+                sys.stdout.write(buf)
 
         def wait(executor, process):
             while executor.wait:


### PR DESCRIPTION
### Description

Fixing an issue where actually sys.stdout should have been used.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
