### PR TITLE
fix: set mtime for cached source files [WIP]

### DIFF
--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -60,6 +60,10 @@ class SourceFile(ABC):
             path = path.get_path_or_uri()
         return self.__class__(smart_join(self.get_path_or_uri(), path))
 
+    @abstractmethod
+    def mtime(self):
+        ...  # TODO implement for all classes below
+
     def __hash__(self):
         return self.get_path_or_uri().__hash__()
 
@@ -344,6 +348,9 @@ class SourceCache:
             cache_entry, "wb"
         ) as cache_source:
             cache_source.write(source.read())
+
+        mtime = source_file.mtime()
+        os.utime(cache_entry, times=(mtime, mtime))
 
     def _open(self, path_or_uri, mode):
         from smart_open import open

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -362,13 +362,12 @@ class SourceCache:
             cache_source.write(source.read())
 
         mtime = source_file.mtime()
-        if mtime is None:
-            logger.debug(
-                f"Setting mtime of cached source file {source_file} to 0 as no "
-                "mtime could be determined from provider."
-            )
-            mtime = 0  # start of epoch, guaranteed older than anything else
-        os.utime(cache_entry, times=(mtime, mtime))
+        if mtime is not None:
+            # Set to mtime of original file
+            # In case we don't have that mtime, it is fine
+            # to just keep the time at the time of caching
+            # as mtime.
+            os.utime(cache_entry, times=(mtime, mtime))
 
     def _open(self, path_or_uri, mode):
         from smart_open import open

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -61,7 +61,6 @@ class SourceFile(ABC):
             path = path.get_path_or_uri()
         return self.__class__(smart_join(self.get_path_or_uri(), path))
 
-    @abstractmethod
     def mtime(self):
         """If possible, return mtime of the file. Otherwise, return None."""
         return None

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -237,9 +237,13 @@ class GithubFile(HostingProviderFile):
         import requests
 
         url = f"https://api.github.com/repos/{self.repo}/commits?path={self.path}&page=1&per_page=1"
-        return datetime.fromisoformat(
-            requests.get(url).json()[0]["commit"]["committer"]["date"]
-        ).timestamp()
+        mtime = requests.get(url).json()[0]["commit"]["committer"]["date"]
+        assert mtime.endswith(
+            "Z"
+        ), "bug: expected suffix Z on Github provided time stamp"
+        # assume UTC and make it understandable to fromisoformat
+        mtime = mtime[:-1] + "+00:00"
+        return datetime.fromisoformat(mtime).timestamp()
 
 
 class GitlabFile(HostingProviderFile):

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -238,7 +238,7 @@ class GithubFile(HostingProviderFile):
 
         url = f"https://api.github.com/repos/{self.repo}/commits?path={self.path}&page=1&per_page=1"
         return datetime.fromisoformat(
-            requests.get(url).json()["commit"]["committer"]["date"]
+            requests.get(url).json()[0]["commit"]["committer"]["date"]
         ).timestamp()
 
 

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -11,7 +11,7 @@ from snakemake import utils
 import tempfile
 import io
 from abc import ABC, abstractmethod
-import datetime
+from datetime import datetime
 
 
 from snakemake.common import (

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -364,6 +364,10 @@ class SourceCache:
 
         mtime = source_file.mtime()
         if mtime is None:
+            logger.debug(
+                f"Setting mtime of cached source file {source_file} to 0 as no "
+                "mtime could be determined from provider."
+            )
             mtime = 0  # start of epoch, guaranteed older than anything else
         os.utime(cache_entry, times=(mtime, mtime))
 


### PR DESCRIPTION
### Description

Needs an mtime implementation for all kinds of source files.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
