### PR TITLE
fix: mtime inventory for google storage was accidentally setting a float instead of a proper mtime object

### DIFF
--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -171,7 +171,7 @@ class RemoteObject(AbstractRemoteObject):
         iterate over the entire bucket once (and then not need to again).
         This includes:
          - cache.exist_remote
-         - cache_mtime
+         - cache.mtime
          - cache.size
         """
         if cache.remaining_wait_time <= 0:
@@ -184,7 +184,7 @@ class RemoteObject(AbstractRemoteObject):
             # By way of being listed, it exists. mtime is a datetime object
             name = "{}/{}".format(blob.bucket.name, blob.name)
             cache.exists_remote[name] = True
-            cache.mtime[name] = blob.updated.timestamp()
+            cache.mtime[name] = snakemake.io.Mtime(remote=blob.updated.timestamp())
             cache.size[name] = blob.size
 
         cache.remaining_wait_time -= time.time() - start_time


### PR DESCRIPTION
### Description

fixes issue #1482

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
