### PR TITLE
fix: do not skip local conda env creation per se when having no shared FS, because it is still needed for local jobs. Instead, decide for each env whether it is needed locally or not.

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -965,11 +965,10 @@ class Workflow:
                 dryrun=dryrun or list_conda_envs, quiet=list_conda_envs
             )
         if self.use_conda:
-            if self.assume_shared_fs:
-                dag.create_conda_envs(
-                    dryrun=dryrun or list_conda_envs or conda_cleanup_envs,
-                    quiet=list_conda_envs,
-                )
+            dag.create_conda_envs(
+                dryrun=dryrun or list_conda_envs or conda_cleanup_envs,
+                quiet=list_conda_envs,
+            )
             if conda_create_envs_only:
                 return True
 

--- a/tests/test_tibanna/Snakefile
+++ b/tests/test_tibanna/Snakefile
@@ -9,73 +9,88 @@
 # Output of step2 is set remote.
 
 from snakemake.remote.S3 import RemoteProvider as S3RemoteProvider
+
 S3 = S3RemoteProvider()
 
-#envvars:
+# envvars:
 #    "TEST_ENVVAR1",
 #    "TEST_ENVVAR2"
 
+
+localrules:
+    all,
+
+
 rule all:
+    conda:
+        "env.yml"
     input:
-        final = S3.remote("snakemake-tibanna-test/1/final_message"),
+        final=S3.remote("snakemake-tibanna-test/1/final_message"),
         # final = "snakemake-tibanna-test/1/final_message"
-        final2 = S3.remote("snakemake-tibanna-test2/1/final_message")
+        final2=S3.remote("snakemake-tibanna-test2/1/final_message"),
+    shell:
+        "echo test"
 
 
 rule step1:
     conda:
         "env.yml"
-    group: "mygroup"
+    group:
+        "mygroup"
     input:
-        S3.remote("snakemake-tibanna-test/1/somefile")
+        S3.remote("snakemake-tibanna-test/1/somefile"),
     output:
-        message = "message1"
+        message="message1",
     shell:
         """
         echo {config[message]} > message1
         cat snakemake-tibanna-test/1/somefile >> message1
         """
 
+
 rule step1a:
     conda:
         "env.yml"
-    group: "mygroup"
+    group:
+        "mygroup"
     input:
-        message = "message1"
+        message="message1",
     output:
-        next_message = "next_message"
+        next_message="next_message",
     shell:
         """
         cat message1 message1 > next_message
         """
 
+
 rule step1b:
     conda:
         "env.yml"
     input:
-        S3.remote("snakemake-tibanna-test/1/somefile2")
+        S3.remote("snakemake-tibanna-test/1/somefile2"),
     output:
-        message = "message2"
+        message="message2",
     log:
-        "log.txt"
+        "log.txt",
     benchmark:
         "benchmark.txt"
     threads: 1
     resources:
-        mem_mb=1024
+        mem_mb=1024,
     shell:
         """
         echo "abcdefg" > message2
         cat snakemake-tibanna-test/1/somefile2 >> message2
         """
 
+
 rule step2:
     input:
-        message1 = "next_message",
-        message2 = "message2"
+        message1="next_message",
+        message2="message2",
     output:
-        final = S3.remote("snakemake-tibanna-test/1/final_message"),
+        final=S3.remote("snakemake-tibanna-test/1/final_message"),
         # final = "snakemake-tibanna-test/1/final_message"
-        final2 = S3.remote("snakemake-tibanna-test2/1/final_message")
+        final2=S3.remote("snakemake-tibanna-test2/1/final_message"),
     script:
         "scripts/step2.py"


### PR DESCRIPTION
### Description

fixes #1442

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
