### PR TITLE
Fix regression bug when using wrapper-prefix

### DIFF
--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -136,7 +136,7 @@ class LocalGitFile(SourceFile):
         self.path = path
 
     def get_path_or_uri(self):
-        return "git+{}/{}@{}".format(self.repo_path, self.path, self.ref)
+        return "file://{}/{}".format(self.repo_path, self.path)
 
     def join(self, path):
         return LocalGitFile(


### PR DESCRIPTION
### Description

Since a few months, we sticked to version 6.7 due to a regression bug when using 
--wrapper-prefix option. Here is a quick fix that should solve the issue in version 7.2.1+9

With version 7.2.1, this kind of run using snakemake 

    snakemake -s test.rules --wrapper-prefix git+file:///home/user/local_wrappers 

currently fails. The error is related to the fact that 
    
    TypeError in line XX of test.rules:
    expected str, got NoneType

an is probably related to this PR: https://github.com/snakemake/snakemake/pull/1182

This happen in modules wrapper.py  where and sourcecache.py in LocalGitFile

Indeed the function find_extension of wrappers.py return None (hence the error here above) because the LocalGitFile.get_path_or_uri does not return a valid file. 

This may be due the fact that git+ is not recognised by smart_open as a valid protocol.

Therefore, I switched from git+ to file://  

This fixes the issue and allows us to use --wrapper-prefix again.

I see two issues here:
1. I had to remove the **@** referring to the branch
2. using file: does seem strange since the class is called LocalGitFile

There are maybe some side effects here and I do not know the snakemake code base enough so please take care if merging the PR but that will be super useful to have this feature back to the next snakemake release !






### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
