### PR TITLE
fix: in google live science backend, save multiple logs per rule name and overwrite existing logs

### DIFF
--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -725,7 +725,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         commands = [
             "/bin/bash",
             "-c",
-            "wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s/%s"
+            "wget -O /gls.py https://raw.githubusercontent.com/cademirch/snakemake/1485-save-multiple-gsl-logs/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s/jobid_%s"
             % (self.bucket.name, self.gs_logs, job.name, job.jobid),
         ]
 

--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -725,7 +725,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         commands = [
             "/bin/bash",
             "-c",
-            "wget -O /gls.py https://raw.githubusercontent.com/cademirch/snakemake/1485-save-multiple-gsl-logs/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s/jobid_%s"
+            "wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s/jobid_%s"
             % (self.bucket.name, self.gs_logs, job.name, job.jobid),
         ]
 

--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -721,13 +721,12 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         """generate an action to save the pipeline logs to storage."""
         # script should be changed to this when added to version control!
         # https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py
-
         # Save logs from /google/logs/output to source/logs in bucket
         commands = [
             "/bin/bash",
             "-c",
-            "wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s"
-            % (self.bucket.name, self.gs_logs, job.name),
+            "wget -O /gls.py https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py && chmod +x /gls.py && source activate snakemake || true && python /gls.py save %s /google/logs %s/%s/%s"
+            % (self.bucket.name, self.gs_logs, job.name, job.jobid),
         ]
 
         # Always run the action to generate log output
@@ -738,6 +737,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
             "labels": self._generate_pipeline_labels(job),
             "alwaysRun": True,
         }
+
         return action
 
     def _generate_job_action(self, job):

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -56,7 +56,8 @@ def save_files(bucket_name, source_path, destination_path):
         print(
             "{filename} -> {full_path}".format(filename=filename, full_path=full_path)
         )
-
+        if os.path.basename(filename) in ["output", "stderr", "stdout"]:
+            filename += ".txt"
         # Get the blob
         blob = bucket.blob(storage_path)
         print("Uploading %s to %s" % (filename, full_path))

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -49,7 +49,6 @@ def save_files(bucket_name, source_path, destination_path):
 
         # The relative path of the filename from the source path
         relative_path = filename.replace(source_path, "", 1).strip("/")
-        print(f"{filename=}, {type(filename)=}")
         # The path in storage includes relative path from destination_path
         storage_path = os.path.join(destination_path, relative_path)
         full_path = os.path.join(bucket_name, storage_path)

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -56,8 +56,8 @@ def save_files(bucket_name, source_path, destination_path):
         print(
             "{filename} -> {full_path}".format(filename=filename, full_path=full_path)
         )
-        if os.path.basename(filename) in ["output", "stderr", "stdout"]:
-            filename += ".txt"
+        if os.path.basename(filename.name) in ["output", "stderr", "stdout"]:
+            filename.name += ".txt"
         # Get the blob
         blob = bucket.blob(storage_path)
         print("Uploading %s to %s" % (filename, full_path))

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -49,19 +49,16 @@ def save_files(bucket_name, source_path, destination_path):
 
         # The relative path of the filename from the source path
         relative_path = filename.replace(source_path, "", 1).strip("/")
-
+        print(f"{filename=}, {type(filename)=}")
         # The path in storage includes relative path from destination_path
         storage_path = os.path.join(destination_path, relative_path)
         full_path = os.path.join(bucket_name, storage_path)
         print(
             "{filename} -> {full_path}".format(filename=filename, full_path=full_path)
         )
-        if os.path.basename(filename.name) in ["output", "stderr", "stdout"]:
-            filename.name += ".txt"
-        # Get the blob
         blob = bucket.blob(storage_path)
         print("Uploading %s to %s" % (filename, full_path))
-        blob.upload_from_filename(filename)
+        blob.upload_from_filename(filename, content_type=".txt")
 
 
 def get_source_files(source_path):

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -59,9 +59,8 @@ def save_files(bucket_name, source_path, destination_path):
 
         # Get the blob
         blob = bucket.blob(storage_path)
-        if not blob.exists():
-            print("Uploading %s to %s" % (filename, full_path))
-            blob.upload_from_filename(filename)
+        print("Uploading %s to %s" % (filename, full_path))
+        blob.upload_from_filename(filename)
 
 
 def get_source_files(source_path):


### PR DESCRIPTION
### Description
This makes slight changes to the google_lifesciences_helper.py script to make GSL logs more helpful. These changes make GSL logs overwritten if present, saved per job_id to allow separation between multiple instances of the same rule, and have a .txt type so that they can be viewed easily in the browser.

See also #1485 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
