### PR TITLE
fix: Replaced pathlib relative_to with os.relpath

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -306,7 +306,7 @@ class Env:
             )
         logger.info(
             "Running post-deploy script {}...".format(
-                Path(deploy_file).relative_to(os.getcwd())
+                os.path.relpath(path = deploy_file, start = os.getcwd())
             )
         )
         conda = Conda(self._container_img)

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -306,7 +306,7 @@ class Env:
             )
         logger.info(
             "Running post-deploy script {}...".format(
-                os.path.relpath(path = deploy_file, start = os.getcwd())
+                os.path.relpath(path=deploy_file, start=os.getcwd())
             )
         )
         conda = Conda(self._container_img)


### PR DESCRIPTION
### Description

Fixes #1496

I changed the print output when using a post-deploy script to use `os.relpath` instead of `pathlib.Path.relative_to` since 
the pathlib variant fails when the conda-env is outside of the .snakemake directory. 

So I think existing test cases should cover it (Also since a conda environment would have to be created outside of the working directory I have no clue how one would write a test case for this.)


### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
