### PR TITLE
fix: update for minimum of Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
 )

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -21,7 +21,7 @@ __version__ = get_versions()["version"]
 del get_versions
 
 
-MIN_PY_VERSION = (3, 5)
+MIN_PY_VERSION = (3, 7)
 DYNAMIC_FILL = "__snakemake_dynamic__"
 SNAKEMAKE_SEARCHPATH = str(Path(__file__).parent.parent.parent)
 UUID_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://snakemake.readthedocs.io")
@@ -32,30 +32,19 @@ NOTHING_TO_BE_DONE_MSG = (
 ON_WINDOWS = platform.system() == "Windows"
 
 
-if sys.version_info < (3, 7):
-
-    def async_run(coroutine):
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(coroutine)
-
-else:
-
-    def async_run(coroutine):
-        """Attaches to running event loop or creates a new one to execute a
-        coroutine.
-
-        .. seealso::
-
-             https://github.com/snakemake/snakemake/issues/1105
-             https://stackoverflow.com/a/65696398
-
-        """
-        try:
-            _ = asyncio.get_running_loop()
-        except RuntimeError:
-            asyncio.run(coroutine)
-        else:
-            asyncio.create_task(coroutine)
+def async_run(coroutine):
+    """Attaches to running event loop or creates a new one to execute a
+    coroutine.
+    .. seealso::
+         https://github.com/snakemake/snakemake/issues/1105
+         https://stackoverflow.com/a/65696398
+    """
+    try:
+        _ = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(coroutine)
+    else:
+        asyncio.create_task(coroutine)
 
 
 # A string that prints as TBD

--- a/tests/testapi.py
+++ b/tests/testapi.py
@@ -53,10 +53,7 @@ def test_run_script_directive_async():
         async_run(dummy_task())
         test_run_script_directive()
 
-    if sys.version_info < (3, 7):
-        async_run(main())
-    else:
-        asyncio.run(main())
+    asyncio.run(main())
 
 
 def test_dicts_in_config():


### PR DESCRIPTION
### Description

**tl;dr** As of fd5daaeff070f9987dba411a0f5262c533a2f666, snakemake requires Python 3.7. This PR updates any reference to previous versions

I came to the GitHub repo to determine the minimum required Python version to run Snakemake, and I quickly got confused. The README displays Python 3.5:

![Screen Shot 2022-03-22 at 2 48 08 PM](https://user-images.githubusercontent.com/1608317/159553958-0c64cbd2-6241-4ec6-9306-321c2e56bc44.png)

But `setup.py` clearly requires Python 3.7+

https://github.com/snakemake/snakemake/blob/5f7170e095a961ce11ac87467a20879dc4f220f4/setup.py#L14-L16

I was going to simply update the metadata

https://github.com/snakemake/snakemake/blob/5f7170e095a961ce11ac87467a20879dc4f220f4/setup.py#L109

But I saw in commit 0357911cc919a1289004bad9144e75d2880665c7 that the minimum required version is specified in multiple other places. This PR is my attempt to update the code and tests to remove any reference to Python versions < 3.7.

A few other notes:

* In searching old Issues, I found #910. Now that Python 3.5 is no longer supported, I think it can be closed
* I didn't update any of the tutorials in the documentation since technically a user could install older versions of Snakemake and Python

### QC
<!-- Make sure that you can tick the boxes below. -->

I don't think this PR requires additional tests or documentation. Please let me know if there is more you'd like me to do.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
