### PR TITLE
fix: fix singularity logging messages causing conda fail

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -624,6 +624,7 @@ class Conda:
         try:
             version = shell.check_output(
                 self._get_cmd("conda --version"),
+                stderr=subprocess.PIPE,
                 universal_newlines=True,
             )
             version_matches = re.findall("\d+.\d+.\d+", version)
@@ -641,7 +642,7 @@ class Conda:
                 )
         except subprocess.CalledProcessError as e:
             raise CreateCondaEnvironmentException(
-                "Unable to check conda version:\n" + e.output.decode()
+                "Unable to check conda version:\n" + e.stderr.decode()
             )
 
     def bin_path(self):

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -635,8 +635,7 @@ class Conda:
                         version.splitlines(),
                     )
                 )
-
-            version = version.split()[1]
+            version = re.findall('\d+.\d+.\d+', version)[0]
             if StrictVersion(version) < StrictVersion("4.2"):
                 raise CreateCondaEnvironmentException(
                     "Conda must be version 4.2 or later, found version {}.".format(

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -624,18 +624,15 @@ class Conda:
         try:
             version = shell.check_output(
                 self._get_cmd("conda --version"),
-                stderr=subprocess.STDOUT,
                 universal_newlines=True,
             )
-            if self.container_img:
-                version = "\n".join(
-                    filter(
-                        lambda line: not line.startswith("WARNING:")
-                        and not line.startswith("ERROR:"),
-                        version.splitlines(),
-                    )
+            version_matches = re.findall("\d+.\d+.\d+", version)
+            if len(version_matches) != 1:
+                raise WorkflowError(
+                    f"Unable to determine conda version. 'conda --version' returned {version}"
                 )
-            version = re.findall('\d+.\d+.\d+', version)[0]
+            else:
+                version = version_matches[0]
             if StrictVersion(version) < StrictVersion("4.2"):
                 raise CreateCondaEnvironmentException(
                     "Conda must be version 4.2 or later, found version {}.".format(


### PR DESCRIPTION
### Description

This modification aims to fix issue #749 and #520. I use the resolution coming from the issue #520.
As a reminder, the problem is that Singularity's logging messages interfere with the verification of the conda version that is done. This solution of @mariafiruleva seems to solve the problem and does not present any side effects

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
