### PR TITLE
fix: throw error message in case of target rule that depends on a pipe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### [7.3.3](https://www.github.com/snakemake/snakemake/compare/v7.3.2...v7.3.3) (2022-03-28)
+
+
+### Bug Fixes
+
+* better error message in case of failing to create conda env ([#1526](https://www.github.com/snakemake/snakemake/issues/1526)) ([e7a461c](https://www.github.com/snakemake/snakemake/commit/e7a461ce7b5626e603784da27aa4c87649f5edec))
+* fix singularity logging messages causing conda fail ([#1523](https://www.github.com/snakemake/snakemake/issues/1523)) ([7797595](https://www.github.com/snakemake/snakemake/commit/77975952ce7df346729f76a767ad4f475b385306))
+* more robust handling of incompletely evaluated parameters (any interaction with them will result in a string <TBD> now). ([#1525](https://www.github.com/snakemake/snakemake/issues/1525)) ([3d4c768](https://www.github.com/snakemake/snakemake/commit/3d4c768aafbdca67a9032ad9e3b73449a1fadb0d))
+
+
+### Documentation
+
+* details on benchmarked results ([64fea09](https://www.github.com/snakemake/snakemake/commit/64fea0921f6a35dbea96435debb114012603ffc2))
+
 ### [7.3.2](https://www.github.com/snakemake/snakemake/compare/v7.3.1...v7.3.2) (2022-03-25)
 
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1308,6 +1308,12 @@ class DAG:
                             "a dead lock.".format(f),
                             rule=job.rule,
                         )
+                    elif is_pipe and depending[0].is_norun:
+                        raise WorkflowError(
+                            f"Output file {f} is marked as pipe but is requested by a rule that "
+                            "does not execute anything. This is not allowed because it would lead "
+                            "to a dead lock."
+                        )
 
                     for dep in depending:
                         if dep.is_run:

--- a/tests/test_pipe_depend/Snakefile
+++ b/tests/test_pipe_depend/Snakefile
@@ -1,0 +1,11 @@
+rule all:
+    input:
+        "test.txt"
+
+
+rule a:
+    output:
+        pipe("test.txt")
+    shell:
+        "echo test > {output}"
+

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1567,9 +1567,11 @@ def test_incomplete_params():
     run(dpath("test_incomplete_params"), dryrun=True, printshellcmds=True)
 
 
+@skip_on_windows  # no pipe support on windows
 def test_pipe_depend():
     run(dpath("test_pipe_depend"), shouldfail=True)
 
 
+@skip_on_windows  # no pipe support on windows
 def test_pipe_depend_target_file():
     run(dpath("test_pipe_depend"), targets=["test.txt"], shouldfail=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1565,3 +1565,11 @@ def test_service_jobs():
 
 def test_incomplete_params():
     run(dpath("test_incomplete_params"), dryrun=True, printshellcmds=True)
+
+
+def test_pipe_depend():
+    run(dpath("test_pipe_depend"), shouldfail=True)
+
+
+def test_pipe_depend_target_file():
+    run(dpath("test_pipe_depend"), targets=["test.txt"], shouldfail=True)


### PR DESCRIPTION
### Description

fixes #190

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
