### PR TITLE
chore: add container to vim syntax

### DIFF
--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -47,7 +47,7 @@ source $VIMRUNTIME/indent/python.vim
 syn keyword pythonStatement include workdir onsuccess onerror onstart
 syn keyword pythonStatement ruleorder localrules configfile group 
 syn keyword pythonStatement wrapper conda shadow
-syn keyword pythonStatement input output params wildcards priority message threads resources singularity wildcard_constraints
+syn keyword pythonStatement input output params wildcards priority message threads resources singularity wildcard_constraints container
 syn keyword pythonStatement version run shell benchmark snakefile log script
 syn keyword pythonStatement rule subworkflow checkpoint nextgroup=pythonFunction skipwhite
 syn keyword pythonBuiltinObj config checkpoints rules

--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -47,7 +47,8 @@ source $VIMRUNTIME/indent/python.vim
 syn keyword pythonStatement include workdir onsuccess onerror onstart
 syn keyword pythonStatement ruleorder localrules configfile group 
 syn keyword pythonStatement wrapper conda shadow
-syn keyword pythonStatement input output params wildcards priority message threads resources singularity wildcard_constraints container
+syn keyword pythonStatement input output params wildcards priority message
+syn keyword pythonStatement threads resources singularity container wildcard_constraints
 syn keyword pythonStatement version run shell benchmark snakefile log script
 syn keyword pythonStatement rule subworkflow checkpoint nextgroup=pythonFunction skipwhite
 syn keyword pythonBuiltinObj config checkpoints rules

--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -50,6 +50,7 @@ syn keyword pythonStatement wrapper conda shadow
 syn keyword pythonStatement input output params wildcards priority message
 syn keyword pythonStatement threads resources singularity container wildcard_constraints
 syn keyword pythonStatement version run shell benchmark snakefile log script
+syn keyword pythonStatement default_target template_engine
 syn keyword pythonStatement rule subworkflow checkpoint nextgroup=pythonFunction skipwhite
 syn keyword pythonBuiltinObj config checkpoints rules
 syn keyword pythonBuiltinFunc directory ancient pipe unpack expand temp touch protected


### PR DESCRIPTION
Add `container` to list of directives for syntax highlighting.

### Description

Added `container` directive to syntax highlighting.

### QC
<!-- Make sure that you can tick the boxes below. -->
NA, only affects vim file; tested locally.
* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
