### PR TITLE
fix: proper error message in case of missing git when checking for source files

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -392,7 +392,8 @@ class Workflow:
                 )
             else:
                 raise WorkflowError(
-                    "Error executing git:\n{}".format(e.stderr.decode())
+                    "Error executing git (Snakemake requires git to be installed for "
+                    "remote execution without shared filesystem):\n" + e.stderr.decode()
                 )
 
         return files


### PR DESCRIPTION
### Description

fixes #234

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
