### PR TITLE
fix: obtaining conda prefix from older Python versions

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -564,7 +564,9 @@ class Conda:
 
             if prefix_path is None or container_img is not None:
                 self.prefix_path = json.loads(
-                    shell.check_output(self._get_cmd("conda info --json"))
+                    shell.check_output(
+                        self._get_cmd("conda info --json"), universal_newlines=True
+                    )
                 )["conda_prefix"]
             else:
                 self.prefix_path = prefix_path


### PR DESCRIPTION
### Description

fixes #237

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
