### PR TITLE
fix: quote workdir in job exec prefix to allow to spaces in the workdir

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -979,6 +979,7 @@ class GenericClusterExecutor(ClusterExecutor):
 
     def get_job_exec_prefix(self, job):
         if self.assume_shared_fs:
+            # quoting the workdir since it may contain spaces
             return f"cd {repr(self.workflow.workdir_init)}"
         else:
             return ""


### PR DESCRIPTION
### Description

fixes #1546

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
