### PR TITLE
fix: allow to use {wildcards} for group jobs in cluster config

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1450,8 +1450,18 @@ class GroupJob(AbstractJob):
     def is_local(self):
         return all(job.is_local for job in self.jobs)
 
+    def merged_wildcards(self):
+        merged_wildcards = Wildcards(toclone=self.jobs[0].wildcards)
+        for job in self.jobs[1:]:
+            for name, value in job.wildcards.items():
+                if name not in merged_wildcards.keys():
+                    merged_wildcards.append(value)
+                    merged_wildcards._set_name(name)
+        return merged_wildcards
+
     def format_wildcards(self, string, **variables):
         """Format a string with variables from the job."""
+
         _variables = dict()
         _variables.update(self.dag.workflow.globals)
         _variables.update(
@@ -1459,6 +1469,7 @@ class GroupJob(AbstractJob):
                 input=self.input,
                 output=self.output,
                 threads=self.threads,
+                wildcards=self.merged_wildcards(),
                 jobid=self.jobid,
                 name=self.name,
                 rule="GROUP",

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1451,12 +1451,13 @@ class GroupJob(AbstractJob):
         return all(job.is_local for job in self.jobs)
 
     def merged_wildcards(self):
-        merged_wildcards = Wildcards(toclone=self.jobs[0].wildcards)
-        for job in self.jobs[1:]:
+        jobs = iter(self.jobs)
+        merged_wildcards = Wildcards(toclone=next(jobs).wildcards)
+        for job in jobs:
             for name, value in job.wildcards.items():
                 if name not in merged_wildcards.keys():
                     merged_wildcards.append(value)
-                    merged_wildcards._set_name(name)
+                    merged_wildcards._add_name(name)
         return merged_wildcards
 
     def format_wildcards(self, string, **variables):


### PR DESCRIPTION
### Description

fixes #1406

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
