### PR TITLE
fix: Snakemake deletes shared output directory for parallel jobs when one job fails

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -195,7 +195,13 @@ class Job(AbstractJob):
         )
 
         self.output, output_mapping = self.rule.expand_output(self.wildcards_dict)
-        self._place_holders = set(os.path.join(os.path.dirname(outfile), '.' + str(self.rule) + '.' + str(self.wildcards.__hash__())) for outfile in self.output)
+        self._place_holders = set(
+            os.path.join(
+                os.path.dirname(outfile),
+                "." + str(self.rule) + "." + str(self.wildcards.__hash__()),
+            )
+            for outfile in self.output
+        )
         # other properties are lazy to be able to use additional parameters and check already existing files
         self._params = None
         self._log = None


### PR DESCRIPTION


### Description

This PR fixes issue #1261 by creating empty "place holder" dirs in output directories for each job. These emty directoies are removed upon completion of a job, sccessfully or not. 

I can make a test for this change if we think this is a resonable fix.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
