### PR TITLE
fix: remove redundant print

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,3 @@ Finally, Snakemake workflows can entail a description of required software, whic
 **Homepage: https://snakemake.github.io**
 
 Copyright (c) 2012-2022 Johannes Köster <johannes.koester@uni-due.com> (see LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Finally, Snakemake workflows can entail a description of required software, whic
 **Homepage: https://snakemake.github.io**
 
 Copyright (c) 2012-2022 Johannes Köster <johannes.koester@uni-due.com> (see LICENSE)
+

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1390,7 +1390,7 @@ class DAG:
                 depending = list(self.depending[job])
                 # re-evaluate depending jobs, replace and update DAG
                 for j in depending:
-                    logger.info("Updating job {}.".format(j))
+                    logger.debug("Updating job {}.".format(j))
                     newjob = j.updated()
                     self.replace_job(j, newjob, recursive=False)
                     updated = True


### PR DESCRIPTION
### Description

When I re-start a workflow with checkpoints, I get spammed with an enormous amount of `updating job` prints. I think those prints are supposed to be hidden? The other updating job prints are logged under the debug logger:

https://github.com/snakemake/snakemake/blob/main/snakemake/dag.py#L1536

https://github.com/snakemake/snakemake/blob/main/snakemake/dag.py#L1618

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
