### PR TITLE
fix: multiext prefix computation in case it is used within a module that defines an additional prefix

### DIFF
--- a/snakemake/path_modifier.py
+++ b/snakemake/path_modifier.py
@@ -47,6 +47,10 @@ class PathModifier:
             if not hasattr(modified_path, "flags"):
                 modified_path = AnnotatedString(modified_path)
             modified_path.flags.update(path.flags)
+            if is_flagged(modified_path, "multiext"):
+                modified_path.flags["multiext"] = self.apply_default_remote(
+                    self.replace_prefix(modified_path.flags["multiext"], property)
+                )
         # Flag the path as modified and return.
         modified_path = flag(modified_path, PATH_MODIFIER_FLAG, self)
         return modified_path


### PR DESCRIPTION


### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
