### PR TITLE
fix: issue 1615 - Switch formatting condition for dictionary

### DIFF
--- a/snakemake/executors/common.py
+++ b/snakemake/executors/common.py
@@ -12,10 +12,10 @@ def format_cli_arg(flag, value, quote=True, skip=False):
 
 
 def format_cli_pos_arg(value, quote=True):
-    if not_iterable(value):
+    if isinstance(value, dict):
+        return join_cli_args(repr(f"{key}={val}") for key, val in value.items())
+    elif not_iterable(value):
         return repr(value)
-    elif isinstance(value, dict):
-        return join_cli_args(repr(f"{key}={val}") for key, val in value)
     else:
         return join_cli_args(repr(v) for v in value)
 


### PR DESCRIPTION
### Description
Fixes issue #1615 

A dictionary will return true when using _not_iterable_ from snakemake.io. The elif condition is never reached/true in the original code. Swapping them will cause dictionaries to be formatted as expected by snakemake.
### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

I'm not sure how to test this, or if i break any other functionality by changing this.