### PR TITLE
fix: set channel priority in container system wide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV SHELL /bin/bash
 RUN install_packages wget curl bzip2 ca-certificates gnupg2 squashfs-tools git
 RUN /bin/bash -c "curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh > mambaforge.sh && \
     bash mambaforge.sh -b -p /opt/conda && \
-    conda config --set channel_priority strict && \
+    conda config --system --set channel_priority strict && \
     rm mambaforge.sh"
 RUN /bin/bash -c "mamba create -q -y -c conda-forge -c bioconda -n snakemake snakemake snakemake-minimal --only-deps && \
     source activate snakemake && \


### PR DESCRIPTION
### Description

Otherwise, setting the docker home directory would lead to channel priority not being considered properly.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
