### PR TITLE
fix: fixed bug in needrun computation of jobs downsteam of checkpoints

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1157,7 +1157,6 @@ class DAG:
                     # depending jobs of jobs that are needrun as a prior
                     # can be skipped
                     continue
-
                 if update_needrun(job):
                     queue.append(job)
                     masked.update(self.bfs(self.depending, job))
@@ -1530,6 +1529,8 @@ class DAG:
                     self.replace_job(j, newjob, recursive=False)
                     updated = True
         if updated:
+            # reset job reasons to ensure that they are properly re-evaluated
+            self._reason.clear()
             self.postprocess()
         return updated
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1529,8 +1529,6 @@ class DAG:
                     self.replace_job(j, newjob, recursive=False)
                     updated = True
         if updated:
-            # reset job reasons to ensure that they are properly re-evaluated
-            self._reason.clear()
             self.postprocess()
         return updated
 
@@ -1704,10 +1702,11 @@ class DAG:
             if not depending and recursive:
                 self.delete_job(job_)
         del self.dependencies[job]
+        if job in self._reason:
+            del self._reason[job]
         if job in self._needrun:
             self._len -= 1
             self._needrun.remove(job)
-            del self._reason[job]
         if job in self._finished:
             self._finished.remove(job)
         if job in self._dynamic:


### PR DESCRIPTION
### Description

Fixes an issue where checkpoints trigger unnecessary reruns of downstream functions that has been introduced with the provenance based rerun triggers of Snakemake 7.8.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
