### PR TITLE
Small changes to make docs checkpoint example functional

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1978,7 +1978,7 @@ Consider the following example where an arbitrary number of files is generated b
 
   # input function for rule aggregate, return paths to all files produced by the checkpoint 'somestep'
   def aggregate_input(wildcards):
-      checkpoint_output = checkpoints.export_sequences.get(**wildcards).output[0]
+      checkpoint_output = checkpoints.somestep.get(**wildcards).output[0]
       return expand("my_directory/{i}.txt",
                     i=glob_wildcards(os.path.join(checkpoint_output, "{i}.txt")).i)
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1987,7 +1987,7 @@ Consider the following example where an arbitrary number of files is generated b
       input:
           aggregate_input
       output:
-          "aggegated.txt"
+          "aggregated.txt"
       shell:
           "cat {input} > {output}"
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1961,35 +1961,38 @@ Consider the following example where an arbitrary number of files is generated b
 .. code-block:: python
 
   # a target rule to define the desired final output
-  rule all:
-      input:
-          "aggregated.txt"
+    rule all:
+        input:
+            "aggregated.txt"
 
 
-  # the checkpoint that shall trigger re-evaluation of the DAG
-  # an number of file is created in a defined directory
-  checkpoint somestep:
-      output:
-          directory("my_directory/")
-      shell:
-          "mkdir my_directory/;"
-          "for i in 1 2 3; do touch $i.txt; done"
+    # the checkpoint that shall trigger re-evaluation of the DAG
+    # an number of file is created in a defined directory
+    checkpoint somestep:
+        output:
+            directory("my_directory/")
+        shell:'''
+        mkdir my_directory/
+        cd my_directory
+        for i in 1 2 3; do touch $i.txt; done
+        '''
 
 
-  # input function for rule aggregate, return paths to all files produced by the checkpoint 'somestep'
-  def aggregate_input(wildcards):
-      checkpoint_output = checkpoints.somestep.get(**wildcards).output[0]
-      return expand("my_directory/{i}.txt",
+
+    # input function for rule aggregate, return paths to all files produced by the checkpoint 'somestep'
+    def aggregate_input(wildcards):
+        checkpoint_output = checkpoints.somestep.get(**wildcards).output[0]
+        return expand("my_directory/{i}.txt",
                     i=glob_wildcards(os.path.join(checkpoint_output, "{i}.txt")).i)
 
 
-  rule aggregate:
-      input:
-          aggregate_input
-      output:
-          "aggregated.txt"
-      shell:
-          "cat {input} > {output}"
+    rule aggregate:
+        input:
+            aggregate_input
+        output:
+            "aggregated.txt"
+        shell:
+            "cat {input} > {output}"
 
 Because the number of output files is unknown beforehand, the checkpoint only defines an output :ref:`directory <snakefiles-directory_output>`.
 This time, instead of explicitly writing


### PR DESCRIPTION
### Description

This is a small PR to correct a few small errors in the documentation code example for using checkpoints when an arbitrary number of files is generated from a rule. This is under the [Data-dependent conditional execution](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) section. 

Previously if you attempted to run this block you would get errors because the checkpoint rule is called `somestep` while the call to `checkpoints` uses `export_sequences` and rule all specified
`aggregated.txt` as the input but rule aggregate produced `aggegated.txt` as the output.

This codeblock is now run-able from my machine. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
