### PR TITLE
chore: add pyproject.toml to use setuptools features

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,8 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: |
           python -m pip install --upgrade pip
-          python setup.py sdist
+          pip install build
+          python -m build
 
       - name: Publish to PyPI
         if: ${{ steps.release.outputs.release_created }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,14 @@
-# -*- coding: UTF-8 -*-
-
-from __future__ import print_function
-
-__author__ = "Johannes Köster"
-__copyright__ = "Copyright 2022, Johannes Köster"
-__email__ = "johannes.koester@uni-due.de"
-__license__ = "MIT"
-
+import os
 import sys
-import versioneer
 
+from setuptools import setup
 
-if sys.version_info < (3, 7):
-    print("At least Python 3.7 is required for Snakemake.\n", file=sys.stderr)
-    exit(1)
+# ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(os.path.dirname(__file__))
 
-
-try:
-    from setuptools import setup
-except ImportError:
-    print("Please install setuptools before installing snakemake.", file=sys.stderr)
-    exit(1)
+import versioneer  # noqa: E402
 
 
 setup(
@@ -63,6 +51,7 @@ setup(
         ]
     },
     package_data={"": ["*.css", "*.sh", "*.html", "*.jinja2", "*.js", "*.svg"]},
+    python_requires=">=3.7",
     install_requires=[
         "wrapt",
         "requests",


### PR DESCRIPTION
### Description

This PR introduces a `pyproject.toml` file described by [PEP 518](https://peps.python.org/pep-0518/), and uses PyPA's [build](https://github.com/pypa/build) to check building the package (sdist and wheel files).

In addition, lots from `setup.py` is removed or simplified:

- E.g. first few lines are not needed for Python 3, which is UTF-8 by default and has a print function
- Dunders `__author__` etc are not normally used in this file
- Remove `setuptools` check, since this is a build requirement specified in the correct place (`pyproject.toml`)
- Remove Python version check, since this is done with setuptools' `python_requires`
- Note that lots of the static metadata from `setup.py` can be moved to either `setup.cfg` or `pyproject.toml`, but not done in this PR

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
