### PR TITLE
fix: Adding file system based locks for meta data (#1342)

### DIFF
--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -292,6 +292,15 @@ The line will subsequently be available in the calls to ``--cluster``, ``--clust
 In the case of a REST server, you can use this to return the port that the server is listening on and credentials.
 When the Snakemake process terminates, the sidecar process will be terminated as well.
 
+File System Based Locks on Clusters
+:::::::::::::::::::::::::::::::::::
+
+Snakemake uses so-called "metadata" file for storing information about the current status of the workflow.
+When using cluster execution, multiple processes may write to the same file as the main Snakemake process is not able to lock access.
+To prevent this, Snakemake will create files ending in ``.lock`` to each meta data files.
+This increases IOPS (I/O operations per second) load on the file system but this cannot be prevented.
+To explicitely disable the use of such lock files pass ``--cluster-no-fs-locks`` to your ``snakemake`` invocation.
+
 Constraining wildcards
 ::::::::::::::::::::::
 

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "yte >=1.0,<2.0",
         "jinja2 >=3.0,<4.0",
         "retry",
+        "fasteners >=0.17.3,<0.18",
     ],
     extras_require={
         "reports": ["jinja2", "pygments"],

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -640,6 +640,7 @@ class Workflow:
         export_cwl=False,
         batch=None,
         keepincomplete=False,
+        cluster_fs_lock=True,
     ):
 
         self.check_localrules()
@@ -764,6 +765,7 @@ class Workflow:
             or list_untracked
             or delete_all_output
             or delete_temp_output,
+            cluster_fs_lock=cluster_fs_lock,
         )
 
         if self.mode in [Mode.subprocess, Mode.cluster]:

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -63,3 +63,4 @@ dependencies:
   - tabulate
   - retry
   - graphviz
+  - fasteners


### PR DESCRIPTION
### Description

The locks are based on the fasteners package and will be enabled
automatically in cluster mode. API users can explicitely enable and
disable them and CLI users can disable them explicitely. This prevents
multiple processes from writing to the same metadata file and thus
damaging the file as described by multiple cluster execution users in
issue #1342.

**Note** and question to @johanneskoester: It might have been possible to use a single lock file which reduces the number of small files in the metadata directory. I don't have a sufficient insight in the `Persistence` code so this would be up to you. We would only require a small change to use a static path for the lock but the path to the file inside of the `.snakemake` directory must be well chosen.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
