### PR TITLE
fix: pass triggers and resources to subworkflow

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -833,6 +833,7 @@ class Workflow:
                         targets=subworkflow_targets,
                         cores=self._cores,
                         nodes=self.nodes,
+                        resources=self.global_resources,
                         configfiles=[subworkflow.configfile]
                         if subworkflow.configfile
                         else None,

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -838,6 +838,7 @@ class Workflow:
                         if subworkflow.configfile
                         else None,
                         updated_files=updated,
+                        rerun_triggers=self.rerun_triggers,
                     ):
                         return False
                     dag.updated_subworkflow_files.update(


### PR DESCRIPTION
### Description

**Passes rerun-triggers to subworkflow.** Also passes resources.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
