### PR TITLE
fix: add lock free mechanism for avoiding race conditions when writing persistence information; consider corrupt metadata records as non-existent

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -441,7 +441,13 @@ class Persistence:
         # This avoids race-conditions while writing (e.g. on NFS when the main job
         # and the cluster node job propagate their content and the system has some
         # latency including non-atomic propagation processes).
-        with tempfile.NamedTemporaryFile(mode="w", dir=recdir, delete=False) as tmpfile:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            dir=recdir,
+            delete=False,
+            prefix=".",
+            suffix=os.path.basename(recpath),
+        ) as tmpfile:
             json.dump(json_value, tmpfile)
         os.rename(tmpfile.name, recpath)
 

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -469,7 +469,14 @@ class Persistence:
         if not self._exists_record(subject, id):
             return dict()
         with open(self._record_path(subject, id), "r") as f:
-            return json.load(f)
+            try:
+                return json.load(f)
+            except json.JSONDecodeError as e:
+                pass
+        # case: file is corrupted, delete it
+        logger.warning(f"Deleting corrupted metadata record.")
+        self._delete_record(subject, id)
+        return dict()
 
     def _exists_record(self, subject, id):
         return os.path.exists(self._record_path(subject, id))

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -445,7 +445,6 @@ class Persistence:
             mode="w",
             dir=recdir,
             delete=False,
-            prefix=".",
             suffix=os.path.basename(recpath),
         ) as tmpfile:
             json.dump(json_value, tmpfile)


### PR DESCRIPTION
### Description

fixes #1342

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
