### PR TITLE
fix: ensures that REncoder also checks for numpy.bool_ in encode_value

### DIFF
--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -205,7 +205,7 @@ class REncoder:
                     return str(value)
                 elif isinstance(value, np.bool_):
                     return "true" if value else "false"
- 
+
             except ImportError:
                 pass
         raise ValueError("Unsupported value for conversion into R: {}".format(value))

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -180,6 +180,8 @@ class REncoder:
 
     @classmethod
     def encode_value(cls, value):
+        import numpy as np
+
         if value is None:
             return "NULL"
         elif isinstance(value, str):
@@ -188,7 +190,7 @@ class REncoder:
             return repr(str(value))
         elif isinstance(value, dict):
             return cls.encode_dict(value)
-        elif isinstance(value, bool):
+        elif isinstance(value, bool) or isinstance(value, np.bool_):
             return "TRUE" if value else "FALSE"
         elif isinstance(value, int) or isinstance(value, float):
             return str(value)
@@ -198,7 +200,6 @@ class REncoder:
         else:
             # Try to convert from numpy if numpy is present
             try:
-                import numpy as np
 
                 if isinstance(value, np.number):
                     return str(value)

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -264,6 +264,8 @@ class JuliaEncoder:
 
                 if isinstance(value, np.number):
                     return str(value)
+                elif isinstance(value, np.bool_):
+                    return "true" if value else "false"
             except ImportError:
                 pass
         raise ValueError(

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -180,7 +180,6 @@ class REncoder:
 
     @classmethod
     def encode_value(cls, value):
-        import numpy as np
 
         if value is None:
             return "NULL"
@@ -190,7 +189,7 @@ class REncoder:
             return repr(str(value))
         elif isinstance(value, dict):
             return cls.encode_dict(value)
-        elif isinstance(value, bool) or isinstance(value, np.bool_):
+        elif isinstance(value, bool):
             return "TRUE" if value else "FALSE"
         elif isinstance(value, int) or isinstance(value, float):
             return str(value)
@@ -200,9 +199,13 @@ class REncoder:
         else:
             # Try to convert from numpy if numpy is present
             try:
+                import numpy as np
 
                 if isinstance(value, np.number):
                     return str(value)
+                elif isinstance(value, np.bool_):
+                    return "true" if value else "false"
+ 
             except ImportError:
                 pass
         raise ValueError("Unsupported value for conversion into R: {}".format(value))
@@ -264,8 +267,6 @@ class JuliaEncoder:
 
                 if isinstance(value, np.number):
                     return str(value)
-                elif isinstance(value, np.bool_):
-                    return "true" if value else "false"
             except ImportError:
                 pass
         raise ValueError(

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -204,7 +204,7 @@ class REncoder:
                 if isinstance(value, np.number):
                     return str(value)
                 elif isinstance(value, np.bool_):
-                    return "true" if value else "false"
+                    return "TRUE" if value else "FALSE"
 
             except ImportError:
                 pass


### PR DESCRIPTION
### Description

Fixes #1045 which was caused when `np.bool_` type was used for boolean values and was slipping through the instance checking and raising an error. 


### QC


* [x ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
