### PR TITLE
fix: only display a warning in case of non-strict channel priorities

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -751,11 +751,11 @@ class Conda:
             )
         )
         if res["get"].get("channel_priority") != "strict":
-            raise CreateCondaEnvironmentException(
+            logger.warning(
                 "Your conda installation is not configured to use strict channel priorities. "
                 "This is however crucial for having robust and correct environments (for details, "
                 "see https://conda-forge.org/docs/user/tipsandtricks.html). "
-                "Please configure strict priorities by executing 'conda config --set channel_priority strict'."
+                "Please consider to configure strict priorities by executing 'conda config --set channel_priority strict'."
             )
 
     def bin_path(self):


### PR DESCRIPTION
### Description

fixes #1751

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
