### PR TITLE
fix: move max_status_checks_per_second attribute setting before the wait thread of cluster backends is started to avoid missing attribute errors

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -680,6 +680,7 @@ class ClusterExecutor(RealExecutor):
             assume_shared_fs=assume_shared_fs,
             keepincomplete=keepincomplete,
         )
+        self.max_status_checks_per_second = max_status_checks_per_second
 
         if not self.assume_shared_fs:
             # use relative path to Snakefile
@@ -718,8 +719,6 @@ class ClusterExecutor(RealExecutor):
         self.disable_default_remote_provider_args = disable_default_remote_provider_args
         self.disable_default_resources_args = disable_default_resources_args
         self.disable_envvar_declarations = disable_envvar_declarations
-
-        self.max_status_checks_per_second = max_status_checks_per_second
 
         self.status_rate_limiter = RateLimiter(
             max_calls=self.max_status_checks_per_second, period=1


### PR DESCRIPTION

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
