### PR TITLE
refactor: Replace “retry” dependency with “reretry”

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "tabulate",
         "yte >=1.0,<2.0",
         "jinja2 >=3.0,<4.0",
-        "retry",
+        "reretry",
     ],
     extras_require={
         "reports": ["jinja2", "pygments"],

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 import shutil
 
 from wrapt import ObjectProxy
-from retry import retry
+from reretry import retry
 
 try:
     from connection_pool import ConnectionPool

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -406,7 +406,7 @@ class SourceCache:
             os.utime(cache_entry, times=(mtime, mtime))
 
     def _open_local_or_remote(self, source_file, mode, encoding=None):
-        from retry.api import retry_call
+        from reretry.api import retry_call
 
         if source_file.is_local:
             return self._open(source_file, mode, encoding=encoding)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -62,5 +62,5 @@ dependencies:
   - smart_open
   - filelock
   - tabulate
-  - retry
+  - reretry
   - graphviz


### PR DESCRIPTION
This implements the suggestion in https://github.com/snakemake/snakemake/issues/1776.

### Description

<!--Add a description of your PR here-->
Replaces the `retry` dependency with the compatible maintained fork `reretry`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

*The dependency is drop-in compatible, so existing tests and documentation should not need to be changed.*