### PR TITLE
fix: Handle temp files for all jobs in a group.

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1626,7 +1626,8 @@ class DAG:
                 self.create_conda_envs()
             potential_new_ready_jobs = True
 
-        self.handle_temp(job)
+        for job in jobs:
+            self.handle_temp(job)
 
         return potential_new_ready_jobs
 


### PR DESCRIPTION
### Description

As described in #1754 and demonstrated there with a minimal example, not all temp files are cleaned up when certain workflows containing "job groups" are run on the cluster. The issue does not occur when running the same workflow locally, in which case the group assignments are ignored, as the purpose of groups is to mark different jobs to be executed on the same cluster node.

This PR fixes the issue. See the problem analysis in [this comment](https://github.com/snakemake/snakemake/issues/1754#issuecomment-1192675070) for details. Essentially, the `job` argument to `dag.DAG.finish()` was being reused as a local variable inside the method. So when `job` was a group of jobs, it would only handle temp files for the last job in that group. We fix that by calling `handle_temp()` explicitly for each individual job.

As pointed out by @pvandyken in the discussion, `handle_temp()` would also know how to deal with job groups. So one could just avoid re-using `job` inside `finish()`. This might even be preferable, as it is cleaner, but would require more code changes.

Fixes #1754. Fixes #1732 as well, as that issue was superseded by the newer one providing a minimal example.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

Note: The problem only manifests itself when the test case (presented in issue #1754) is run on the cluster. I do not think the behavior can be tested with the current CI setup.