### PR TITLE
fix: limit filename length of temporary files generated by the persistence backend (metadata, incomplete markers, etc.)

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -445,7 +445,11 @@ class Persistence:
             mode="w",
             dir=recdir,
             delete=False,
-            suffix=os.path.basename(recpath),
+            # Add short prefix to final filename for better debugging.
+            # This may not be the full one, because that may be too long
+            # for the filesystem in combination with the prefix from the temp
+            # file.
+            suffix=f".{os.path.basename(recpath)[:8]}",
         ) as tmpfile:
             json.dump(json_value, tmpfile)
         os.rename(tmpfile.name, recpath)


### PR DESCRIPTION
### Description

fixes #1771

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
