### PR TITLE
add `oncompletion` handler

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1367,9 +1367,9 @@ With Snakemake 3.2.1, this is possible via the ``onsuccess`` and ``onerror`` key
         shell("mail -s "an error occurred" youremail@provider.com < {log}")
 
 The ``onsuccess`` handler is executed if the workflow finished without error. Otherwise, the ``onerror`` handler is executed.
-In both handlers, you have access to the variable ``log``, which contains the path to a logfile with the complete Snakemake output.
-Snakemake 3.6.0 adds an ``onstart`` handler, that will be executed before the workflow starts.
-Note that dry-runs do not trigger any of the handlers.
+The``onstart`` handler is executed before the workflow starts. The ``oncompletion`` handler is executed once the workflow is finished
+(with or without error). In all handlers, you have access to the variable ``log``, which contains the path to a logfile with the
+complete Snakemake output. Note that dry-runs do not trigger any of the handlers.
 
 
 Rule dependencies

--- a/misc/nano/syntax/snakemake.nanorc
+++ b/misc/nano/syntax/snakemake.nanorc
@@ -32,7 +32,7 @@ color green start=""""[^"]" end=""""" start="'''[^']" end="'''"
 color brightmagenta "#.*$"
 
 # Snakemake keywords
-color blue "\<(include|workdir|onsuccess|onerror|ruleorder|localrules|configfile|touch|protected|temp|input|output|params|message|threads|resources|version|run|shell|benchmark|snakefile|log)\>"
+color blue "\<(include|workdir|onstart|onsuccess|onerror|oncompletion|ruleorder|localrules|configfile|touch|protected|temp|input|output|params|message|threads|resources|version|run|shell|benchmark|snakefile|log)\>"
 
 # rule or subworkflow names
 color brightmagenta "(rule|subworkflow)\s*[A-Za-z_]*"

--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -61,6 +61,7 @@ syn keyword pythonStatement
       \ onerror
       \ onstart
       \ onsuccess
+      \ oncompletion
       \ output
       \ params
       \ priority

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2077,7 +2077,7 @@ def get_argument_parser(profile=None):
     group_behavior.add_argument(
         "--no-hooks",
         action="store_true",
-        help="Do not invoke onstart, onsuccess or onerror hooks after execution.",
+        help="Do not invoke onstart, onsuccess, onerror or oncompletion hooks after execution.",
     )
     group_behavior.add_argument(
         "--overwrite-shellcmd",

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -855,6 +855,11 @@ class OnStart(DecoratorKeywordState):
     args = ["log"]
 
 
+class OnCompletion(DecoratorKeywordState):
+    decorator = "oncompletion"
+    args = ["log"]
+
+
 # modules
 
 
@@ -1219,6 +1224,7 @@ class Python(TokenAutomaton):
         onsuccess=OnSuccess,
         onerror=OnError,
         onstart=OnStart,
+        oncompletion=OnCompletion,
         wildcard_constraints=GlobalWildcardConstraints,
         singularity=GlobalSingularity,
         container=GlobalContainer,

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -193,6 +193,7 @@ class Workflow:
         self._onsuccess = lambda log: None
         self._onerror = lambda log: None
         self._onstart = lambda log: None
+        self._oncompletion = lambda log: None
         self._wildcard_constraints = dict()
         self.debug = debug
         self.verbose = verbose
@@ -1094,10 +1095,12 @@ class Workflow:
                 logger.logfile_hint()
             if not dryrun and not no_hooks:
                 self._onsuccess(logger.get_logfile())
+                self._oncompletion(logger.get_logfile())
             return True
         else:
             if not dryrun and not no_hooks:
                 self._onerror(logger.get_logfile())
+                self._oncompletion(logger.get_logfile())
             logger.logfile_hint()
             return False
 
@@ -1219,6 +1222,10 @@ class Workflow:
     def onerror(self, func):
         """Register onerror function."""
         self._onerror = func
+
+    def oncompletion(self, func):
+        """Register oncompletion function."""
+        self._oncompletion = func
 
     def global_wildcard_constraints(self, **content):
         """Register global wildcard constraints."""


### PR DESCRIPTION
### Description

This adds a handler to execute code on completion with or without error. This
arose from a specific use-case described [here](https://stackoverflow.com/a/73215474/10693596), however
can be a useful feature for running post-workflow routines (e.g. cleaning cache directories).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
There are no tests for other handlers, so not sure what to add as a test.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
