### PR TITLE
fix: set number of cores for GenericClusterExecutor and DRMAAExecutor to cores rather than None (i.e. all)

### DIFF
--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -199,7 +199,7 @@ class JobScheduler:
                 self._executor = constructor(
                     workflow,
                     dag,
-                    None,
+                    cores,
                     submitcmd=(cluster or cluster_sync),
                     cluster_config=cluster_config,
                     jobname=jobname,
@@ -218,7 +218,7 @@ class JobScheduler:
                 self._executor = DRMAAExecutor(
                     workflow,
                     dag,
-                    None,
+                    cores,
                     drmaa_args=drmaa,
                     drmaa_log_dir=drmaa_log_dir,
                     jobname=jobname,


### PR DESCRIPTION
set number of cores for GenericClusterExecutor and DRMAAExecutor to cores rather than None (which defaults to all)

### Description

This pull request passes the --cores parameter to the GenericClusterExecutor and DRMAAExecutor to address #1178. This behavior makes them consistent with the TibannaExecutor and GoogleLifeSciencesExecutor, although it is left to @johanneskoester to decide whether this is the correct behavior in general. Please note that the `--cores=N` spawned snakemake processes on the node continue to be set to `--cores all`, which I'm also not sure is intended.  

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ x ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
