### PR TITLE
perf: Average NamedList __getitem__ performance improvement

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1610,11 +1610,10 @@ class Namedlist(list):
         return self.__dict__.get(key, default_value)
 
     def __getitem__(self, key):
-        try:
+        if isinstance(key, str):
+            return getattr(self, key)
+        else:
             return super().__getitem__(key)
-        except TypeError:
-            pass
-        return getattr(self, key)
 
     def __hash__(self):
         return hash(tuple(self))


### PR DESCRIPTION
### Description

Previous NamedList performance is optimized for integer/slice (list) access, but very slow when using string indices. 
With this change, both types of access are approximately equally fast and average performance (assuming equal number if integer and string accesses) is improved.

**Note:** If you assume that integer/slice (list) access is the norm and named access is rare (less than 7 times as frequent as list accesses), then please ignore this pull request. In my workflow, named accesses are much more frequent, so this change lead to a major performance improvement.

#### Performance improvment 

Performance comparison below are from accessing a named list with 1e4 list components and 1e4 named components, attempting 1e4 accesses on my system. Multiple attempts on a different system confirmed similar numbers.

Original implementation:
Integer accesses: 2.65s
String (named) accesses: 7.79s
Total: 10.44s

Implementation in this pull request:
Integer accesses: 3.26s
String (named) accesses: 3.07s
Total: 6.33s

Therefore, the changes in this pull request constitute

* approximately 20% performance reduction when doing list access
* approximately 150% performance improvement when doing named access
* approximately 65% performance improvement average, assuming list and named accesses are used with the same frequency
* approximately 0% effect on performance when list accesses occur about 7 times as frequent as named accesses


#### Effects on behavior

The only behavior change is that the TypeError when a wrong index type is provided will now be the TypeError thrown by the list implementation of `__getitem__`.

Original implementation:

    In: named_list[2.5]
    TypeError: getattr(): attribute name must be string

Implementation in this pull request:

    In: named_list[2.5]
    TypeError: list indices must be integers or slices, not float

    

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case: **Should be covered by existing tests**
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake): **The only behavior change (listed above) concerns undocumented behavior**
