### PR TITLE
fix: declare associative arrays in bash scripts

### DIFF
--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -351,7 +351,7 @@ class BashEncoder:
                 main_aa[var] = val
 
         arrays.append(f"{self.prefix}={self.dict_to_aa(main_aa)}")
-        return "\n".join(arrays)
+        return "\n".join([f"declare -A {aa}" for aa in arrays])
 
     @staticmethod
     def dict_to_aa(d: dict) -> str:


### PR DESCRIPTION
### Description

This PR adds a hotfix for bash scripts. I don't know if this is a Bash version issue or not, but when I tried to run a bash script on v4.4.20 (I tested the implementation of bash scripts with v5.1.16) the named variabes were playing up.

Here is an example to illustrate the problem (I've removed `snakemake_config` for brevity)

```bash
#!/usr/bin/env bash

snakemake_input=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/filtered/illumina/PRJEB25972/SAMEA1101594/ERR2510324/ERR2510324.filtered.fq.gz" [reads]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/filtered/illumina/PRJEB25972/SAMEA1101594/ERR2510324/ERR2510324.filtered.fq.gz" [1]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/download/illumina/run_info.tsv" [run_info]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/download/illumina/run_info.tsv" [2]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/tbprofiler/.db.built" [db]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/tbprofiler/.db.built" )
snakemake_output=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324/results/ERR2510324.results.json" [report]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324/results/ERR2510324.results.json" )
snakemake_params=( [0]="--txt --no_trim -p ERR2510324" [opts]="--txt --no_trim -p ERR2510324" [1]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324" [outdir]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324" )
snakemake_wildcards=( [0]="illumina" [tech]="illumina" [1]="PRJEB25972" [proj]="PRJEB25972" [2]="SAMEA1101594" [sample]="SAMEA1101594" [3]="ERR2510324" [run]="ERR2510324" )
snakemake_resources=( [0]="1" [_cores]="1" [1]="1" [_nodes]="1" [2]="1000" [mem_mb]="1000" [3]="1000" [disk_mb]="1000" [4]="/hps/scratch/lsf_tmpdir/hl-codon-113-02" [tmpdir]="/hps/scratch/lsf_tmpdir/hl-codon-113-02" )
snakemake_log=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/logs/rules/tbprofiler_predict/illumina/PRJEB25972/SAMEA1101594/ERR2510324.log" )

set -euxo pipefail

# shellcheck disable=SC2154
exec 2> "${snakemake_log[0]}" # send all stderr from this script to the log file

# shellcheck disable=SC2154
reads="${snakemake_input[reads]}"
```

when this script was executed, it was failing with `/hps/nobackup/iqbal/mbhall/drprg/paper/.snakemake/scripts/tmpbf4avsq5.tbprofiler_predict.sh: line 16: reads: unbound variable`.

But when I explicitly declare the snakemake variables as associative arrays (`declare -A`), the script ran fine.

```bash
#!/usr/bin/env bash

declare -A snakemake_input=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/filtered/illumina/PRJEB25972/SAMEA1101594/ERR2510324/ERR2510324.filtered.fq.gz" [reads]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/filtered/illumina/PRJEB25972/SAMEA1101594/ERR2510324/ERR2510324.filtered.fq.gz" [1]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/download/illumina/run_info.tsv" [run_info]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/download/illumina/run_info.tsv" [2]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/tbprofiler/.db.built" [db]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/tbprofiler/.db.built" )
declare -A snakemake_output=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324/results/ERR2510324.results.json" [report]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324/results/ERR2510324.results.json" )
declare -A snakemake_params=( [0]="--txt --no_trim -p ERR2510324" [opts]="--txt --no_trim -p ERR2510324" [1]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324" [outdir]="/hps/nobackup/iqbal/mbhall/drprg/paper/results/amr_predictions/tbprofiler/illumina/PRJEB25972/SAMEA1101594/ERR2510324" )
declare -A snakemake_wildcards=( [0]="illumina" [tech]="illumina" [1]="PRJEB25972" [proj]="PRJEB25972" [2]="SAMEA1101594" [sample]="SAMEA1101594" [3]="ERR2510324" [run]="ERR2510324" )
declare -A snakemake_resources=( [0]="1" [_cores]="1" [1]="1" [_nodes]="1" [2]="1000" [mem_mb]="1000" [3]="1000" [disk_mb]="1000" [4]="/hps/scratch/lsf_tmpdir/hl-codon-113-02" [tmpdir]="/hps/scratch/lsf_tmpdir/hl-codon-113-02" )
declare -A snakemake_log=( [0]="/hps/nobackup/iqbal/mbhall/drprg/paper/logs/rules/tbprofiler_predict/illumina/PRJEB25972/SAMEA1101594/ERR2510324.log" )

set -euxo pipefail

# shellcheck disable=SC2154
exec 2> "${snakemake_log[0]}" # send all stderr from this script to the log file

# shellcheck disable=SC2154
reads="${snakemake_input[reads]}"
```

I'm not quite sure what the root cause of the problem is, but declaring the snakemake variables fixes the problem so that seems sufficient I guess?

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
