### PR TITLE
fix: fix `--immediate-submit`

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1270,9 +1270,6 @@ class GenericClusterExecutor(ClusterExecutor):
         else:
 
             def job_status(job):
-                if self.workflow.immediate_submit:
-                    os.remove(active_job.jobscript)
-                    return success
                 if os.path.exists(active_job.jobfinished):
                     os.remove(active_job.jobfinished)
                     os.remove(active_job.jobscript)

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1270,6 +1270,9 @@ class GenericClusterExecutor(ClusterExecutor):
         else:
 
             def job_status(job):
+                if self.workflow.immediate_submit:
+                    os.remove(active_job.jobscript)
+                    return success
                 if os.path.exists(active_job.jobfinished):
                     os.remove(active_job.jobfinished)
                     os.remove(active_job.jobscript)

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -210,6 +210,7 @@ class JobScheduler:
                     keepincomplete=keepincomplete,
                 )
                 if workflow.immediate_submit:
+                    self._submit_callback = self._proceed
                     self.update_dynamic = False
                     self.print_progress = False
                     self.update_resources = False

--- a/tests/test_immediate_submit/README.md
+++ b/tests/test_immediate_submit/README.md
@@ -1,0 +1,5 @@
+```bash
+snakemake --profile slurm all
+touch output/output.touch
+```
+- only after create `output/output.touch`, snakemake can run as expected.

--- a/tests/test_immediate_submit/Snakefile
+++ b/tests/test_immediate_submit/Snakefile
@@ -1,0 +1,52 @@
+rule all:
+    input:
+        echo_helps=[f"output/{i}.touch" for i in ("a", "b")],
+    output:
+        "output/all"
+    resources:
+        partition="debug",
+        threads=1,
+    threads:
+        1
+    shell:
+        """
+        date +%F\ %T
+        ls {input} > {output}
+        """
+
+rule test_array:
+    input:
+        dirtouch="output/output.touch",
+    output:
+        echo_help="output/{i}.touch",
+    params:
+        watch="output"
+    threads: 40
+    params:
+        echo="{i}",
+    shell:
+        """
+        date +%F\ %T
+        sleep 3
+
+        ls -lrt {params.watch} > {output}
+        date +%F\ %T
+        """
+
+
+rule make_output:
+    output:
+        dirtouch="output/output.touch",
+    resources:
+        partition="debug",
+        threads=1,
+    threads:
+        1
+    shell:
+        """
+        date +%F\ %T
+        while [ ! -f {output.dirtouch} ]; do sleep 5; done
+
+        touch {output.dirtouch}
+        date +%F\ %T
+        """

--- a/tests/test_immediate_submit/expected-results/output/all
+++ b/tests/test_immediate_submit/expected-results/output/all
@@ -1,0 +1,2 @@
+output/a.touch
+output/b.touch

--- a/tests/test_immediate_submit/slurm/config.yaml
+++ b/tests/test_immediate_submit/slurm/config.yaml
@@ -1,0 +1,36 @@
+cluster:
+  mkdir -p logs/{rule} &&
+  bash slurm/get_jobid.sh
+  'logs/{rule}/{rule}-{wildcards}-%j'
+  '{dependencies}'
+  #  '--partition={resources.partition}
+  #  --ntasks-per-node={resources.threads}
+  #  --job-name=smk-{rule}-{wildcards}
+  #  --output=logs/{rule}/{rule}-{wildcards}-%j.out
+  #  --error=logs/{rule}/{rule}-{wildcards}-%j.err'
+default-resources:
+  - partition=cpu
+  - threads=40
+local-cores: 1
+jobs: 500
+keep-going: True
+rerun-incomplete: True
+printshellcmds: True
+scheduler: greedy
+immediate-submit: True
+notemp: True
+# jobscript: "slurm-jobscript.sh"
+
+# Example resource configuration
+# default-resources:
+#   - runtime=100
+#   - mem_mb=6000
+#   - disk_mb=1000000
+# # set-threads: map rule names to threads
+# set-threads:
+#   - single_core_rule=1
+#   - multi_core_rule=10
+# # set-resources: map rule names to resources in general
+# set-resources:
+#   - high_memory_rule:mem_mb=12000
+#   - long_running_rule:runtime=1200

--- a/tests/test_immediate_submit/slurm/config.yaml
+++ b/tests/test_immediate_submit/slurm/config.yaml
@@ -1,4 +1,4 @@
-cluster:
+cluster-sync:
   mkdir -p logs/{rule} &&
   bash slurm/get_jobid.sh
   'logs/{rule}/{rule}-{wildcards}-%j'

--- a/tests/test_immediate_submit/slurm/config.yaml
+++ b/tests/test_immediate_submit/slurm/config.yaml
@@ -1,4 +1,4 @@
-cluster-sync:
+cluster:
   mkdir -p logs/{rule} &&
   bash slurm/get_jobid.sh
   'logs/{rule}/{rule}-{wildcards}-%j'

--- a/tests/test_immediate_submit/slurm/get_jobid.sh
+++ b/tests/test_immediate_submit/slurm/get_jobid.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e && echo "$0 $*" >&2
+
+set -vx
+
+sbatch_params=$1
+dependencies=$2
+script=$3
+
+echo `bash slurm/sbatch.sh $sbatch_params $script "$dependencies"`

--- a/tests/test_immediate_submit/slurm/sbatch.sh
+++ b/tests/test_immediate_submit/slurm/sbatch.sh
@@ -6,7 +6,9 @@ set -vx
 sbatch_params=$1
 script=$2
 dependencies=$3
-flag=/tmp/dependencies-$(basename $script)-finish
+flag=tmp/slurm-signal/dependencies-$(basename $script)-finish
+
+mkdir -p tmp/slurm-signal
 
 echo "#!/bin/bash"                      > $flag.sh
 echo ''                                 >> $flag.sh

--- a/tests/test_immediate_submit/slurm/sbatch.sh
+++ b/tests/test_immediate_submit/slurm/sbatch.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e && echo "$0 $*" >&2
+
+set -vx
+
+sbatch_params=$1
+script=$2
+dependencies=$3
+flag=/tmp/dependencies-$(basename $script)-finish
+
+echo "#!/bin/bash"                      > $flag.sh
+echo ''                                 >> $flag.sh
+echo "for i in ${dependencies//,/ }"    >> $flag.sh
+echo 'do'                               >> $flag.sh
+echo '    while [ ! -f $i ]'            >> $flag.sh
+echo '    do'                           >> $flag.sh
+echo '        sleep 3'                  >> $flag.sh
+echo '    done'                         >> $flag.sh
+echo 'done'                             >> $flag.sh
+echo ''                                 >> $flag.sh
+cat $script                             >> $flag.sh
+echo ''                                 >> $flag.sh
+echo "touch $flag"                      >> $flag.sh
+
+nohup bash $flag.sh > $sbatch_params.log 2>&1 &
+
+echo $flag


### PR DESCRIPTION
### Description

parameter `--immediate-submit` is expected to [submit all jobs to the cluster instead of waiting for present input files](https://snakemake.readthedocs.io/en/stable/executing/cli.html?highlight=immediate#CLUSTER). However, as tested in the system, nothing changed compared to "run without this flag".

Detailed discussions can be found in #1865 and #1715. Briefly, it is caused by a hotfix for googlelifescience API handling.

### QC
* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] ~The documentation (`docs/`) is updated to reflect the changes~ or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
