### PR TITLE
fix: request disk_mb resource from k8s

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1911,6 +1911,7 @@ class KubernetesExecutor(ClusterExecutor):
             container.env.append(envvar)
 
         # request resources
+        logger.debug(f"job resources:  {dict(job.resources)}")
         container.resources = kubernetes.client.V1ResourceRequirements()
         container.resources.requests = {}
         container.resources.requests["cpu"] = job.resources["_cores"]
@@ -1918,6 +1919,11 @@ class KubernetesExecutor(ClusterExecutor):
             container.resources.requests["memory"] = "{}M".format(
                 job.resources["mem_mb"]
             )
+        if "disk_mb" in job.resources.keys():
+            disk_mb = int(job.resources.get("disk_mb", 1024))
+            container.resources.requests["ephemeral-storage"] = f"{disk_mb}M"
+
+        logger.debug(f"k8s pod resources: {container.resources.requests}")
 
         # capabilities
         if job.needs_singularity and self.workflow.use_singularity:

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -17,7 +17,7 @@ def kubernetes_cluster():
             try:
                 shell(
                     """
-                    gcloud container clusters create {self.cluster} --num-nodes 3 --scopes storage-rw --zone us-central1-a --machine-type n1-standard-2
+                    gcloud container clusters create {self.cluster} --num-nodes 3 --scopes storage-rw --zone us-central1-a --machine-type n1-standard-2 --ephemeral-storage local-ssd-count=1
                     gcloud container clusters get-credentials {self.cluster} --zone us-central1-a
                     gsutil mb gs://{self.bucket_name}
                     """

--- a/tests/test_kubernetes/Snakefile
+++ b/tests/test_kubernetes/Snakefile
@@ -20,11 +20,13 @@ rule copy:
         "landsat-data.txt",
     resources:
         mem_mb=100,
+        disk_mb=301000
     run:
-        # we could test volume size like this but it is currently unclear what f1-micro instances provide as boot disk size
-        # stats = os.statvfs('.')
-        # volume_gib = stats.f_bsize * stats.f_blocks / 1.074e9
-        # assert volume_gib > 90
+        # Nominally, we have attached a 375GB SSD to our underlying cluster node, and requested 301GB above.
+        stats = os.statvfs('.')
+        volume_gb = stats.f_bsize * stats.f_blocks / 1.0e9
+        assert volume_gb >= 300
+
         shell("cp {input} {output}")
 
 


### PR DESCRIPTION
### Description

k8s supports adding ephemeral storage (e.g. node-local SSDs) to the working directory of the container. However, the size of this working directory isn't configured. This PR maps the `disk_mb` resource to the `ephemeral-storage` k8s Allocatable.

As an aside, while reviewing this PR, I think I have found a small issue: during the container init code, we are setting the `container.volume.mounts` property twice with single-entry lists, rather than once with a list of two mounts as their API seems to want. Is my reading correct, and this is a bug? If so, I'll quickly fix it.  https://github.com/snakemake/snakemake/blob/a1e49b6f290daeb2012575ab3a85ca72cfe42747/snakemake/executors/__init__.py#L1855-L1860

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. 
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **My (@kdm9) reading of the docs implied this already happened, but I can add a more explicit statement if need be**
