### PR TITLE
fix: k8s container volume mounts as list

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1853,10 +1853,8 @@ class KubernetesExecutor(ClusterExecutor):
         container.args = ["-c", exec_job]
         container.working_dir = "/workdir"
         container.volume_mounts = [
-            kubernetes.client.V1VolumeMount(name="workdir", mount_path="/workdir")
-        ]
-        container.volume_mounts = [
-            kubernetes.client.V1VolumeMount(name="source", mount_path="/source")
+            kubernetes.client.V1VolumeMount(name="workdir", mount_path="/workdir"),
+            kubernetes.client.V1VolumeMount(name="source", mount_path="/source"),
         ]
 
         node_selector = {}


### PR DESCRIPTION
As described in the body of PR https://github.com/snakemake/snakemake/pull/1858, there's a typo whereby the property `container.volume_mounts` is overwritten, rather than appended to.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. (this is allegedly tested as part of the k8s tests).
* [ ] ~The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).~
