### PR TITLE
fix: allow script directive to take pathlib Path

### DIFF
--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -1498,6 +1498,8 @@ def script(
     """
     Load a script from the given basedir + path and execute it.
     """
+    if isinstance(path, Path):
+        path = str(path)
 
     path, source, language, is_local = get_source(
         path, SourceCache(runtime_sourcecache_path), basedir, wildcards, params

--- a/tests/test_script/Snakefile
+++ b/tests/test_script/Snakefile
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 
 configfile: "config.yaml"
 
@@ -28,7 +30,7 @@ rule:
     output:
         "test.in"
     script:
-        "scripts/test.py"
+        Path("scripts/test.py")
 
 rule:
     output:


### PR DESCRIPTION
### Description

This PR allows the `script` directive to accept a `pathlib.Path` object.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
