### PR TITLE
fix: reduce resource requirements for kubernetes tests

### DIFF
--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -4,6 +4,8 @@ import uuid
 
 sys.path.insert(0, os.path.dirname(__file__))
 
+from snakemake.resources import DefaultResources
+
 from common import *
 
 
@@ -46,6 +48,7 @@ def kubernetes_cluster():
                     default_remote_provider="GS",
                     default_remote_prefix=self.bucket_name,
                     no_tmpdir=True,
+                    default_resources=DefaultResources(["mem_mb=1000", "disk_mb=50"]), # ensure that we don't get charged too much
                     **kwargs
                 )
             except Exception as e:

--- a/tests/test_kubernetes/Snakefile
+++ b/tests/test_kubernetes/Snakefile
@@ -20,12 +20,12 @@ rule copy:
         "landsat-data.txt",
     resources:
         mem_mb=100,
-        disk_mb=301000
+        disk_mb=301,
     run:
-        # Nominally, we have attached a 375GB SSD to our underlying cluster node, and requested 301GB above.
-        stats = os.statvfs('.')
+        # Check whether there is enough storage attached
+        stats = os.statvfs(".")
         volume_gb = stats.f_bsize * stats.f_blocks / 1.0e9
-        assert volume_gb >= 300
+        assert volume_gb >= 0.3, "Volume size is too small: {}GB".format(volume_gb)
 
         shell("cp {input} {output}")
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
