### PR TITLE
fix: Add back logging of run directives

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1,3 +1,4 @@
+all
 __author__ = "Johannes Köster"
 __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
@@ -494,7 +495,7 @@ class CPUExecutor(RealExecutor):
         return ""
 
     def get_job_args(self, job, **kwargs):
-        return f"{super().get_job_args(job, **kwargs)} --quiet all"
+        return f"{super().get_job_args(job, **kwargs)} --quiet"
 
     def run(self, job, callback=None, submit_callback=None, error_callback=None):
         super()._run(job)

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -1,4 +1,3 @@
-all
 __author__ = "Johannes Köster"
 __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"


### PR DESCRIPTION
### Description

Fix #1698 exception tracebacks in run: blocks are sent to /dev/null, making rules hard to debug

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


I have created a text based on #1881 but I don't see how I can test that the error message is printed out correctly to a log. 
