### PR TITLE
docs: small tweaks to flux documentation

### DIFF
--- a/docs/executor_tutorial/flux.rst
+++ b/docs/executor_tutorial/flux.rst
@@ -14,10 +14,11 @@ Setup
 
 To go through this tutorial, you need the following software installed:
 
-* Docker
+- Docker
 
-The (`Flux-framework <https://flux-framework.org/>`_) is a flexible resource scheduler that can work on both high performance computing systems and cloud (e.g., Kubernetes).
-Since it is more modern (e.g., has an official Python API) we define it under a cloud resource. For this example, we will show you how to set up a "single node" local flux container to interact with snakemake. You can use the Dockerfile in ``examples/flux`` that will provide a container with flux and snakemake        
+
+`Flux-framework <https://flux-framework.org/>`_ is a flexible resource scheduler that can work on both high performance computing systems and cloud (e.g., Kubernetes).
+Since it is more modern (e.g., has an official Python API) we define it under a cloud resource. For this example, we will show you how to set up a "single node" local flux container to interact with snakemake. You can use the `Dockerfile in examples/flux <https://github.com/snakemake/snakemake/blob/main/examples/flux/Dockerfile>`_ that will provide a container with flux and snakemake        
 Note that we install from source and bind to ``/home/fluxuser/snakemake`` with the intention of being able to develop (if desired).
 First, build the container:
 
@@ -56,8 +57,8 @@ support ``mem_mb`` or ``disk_mb``.
 
          
 
-Step 1: Run Snakemake
-:::::::::::::::::::::
+Run Snakemake
+:::::::::::::
 
 Now let's run Snakemake with the Flux executor. There is an example ``Snakefile``
 in the flux examples folder that will show running a "Hello World!" example,
@@ -77,7 +78,7 @@ Here is how to run the workflow:
 
 The flags above refer to:
 
- - `--flux`: tell Snakemake to use the flux executor
+ - ``--flux``: tell Snakemake to use the flux executor
 
 
 Once you submit the job, you'll immediately see the familiar Snakemake console output.


### PR DESCRIPTION
After seeing it live - here are some small tweaks to make it better!

- We do not have more than one step, so it does not make sense to include Step 1.
- The spacing on the first bulleted list is off because I think I used `*` instead of `-`.
- I added an actual link to the Dockerfile in examples.
- The flag in the list was missing the correct quotes
- The first sentence will read/ look better just as "Flux Framework" as part of the sentence instead of in parentheses.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
