### PR TITLE
fix: Comparison of rules and non-rule instances

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -1219,7 +1219,10 @@ class Rule:
         return self.name.__hash__()
 
     def __eq__(self, other):
-        return self.name == other.name and self.output == other.output
+        if type(other) is type(self):
+            return self.name == other.name and self.output == other.output
+        else:
+            return False
 
 
 class Ruleorder:

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -1219,7 +1219,7 @@ class Rule:
         return self.name.__hash__()
 
     def __eq__(self, other):
-        if type(other) is type(self):
+        if isinstance(other, Rule):
             return self.name == other.name and self.output == other.output
         else:
             return False


### PR DESCRIPTION
### Description

Fixes #1891 and #1892. The issue is that the [`__eq__` method of `Rule`](https://github.com/snakemake/snakemake/blob/274d613fd27b632d5bbe4c6fe55a82262d6b2dec/snakemake/rules.py#L1221) implicitly expects `other` to be an instance of `Rule` as well. Thus, any comparison of a `Rule` instance to any non-`Rule` object leads to an `AttributeError`. This is a more general fix than #1893.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
