### PR TITLE
fix: ensure that rule name string instead of object is passed to tabulate package

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2393,7 +2393,7 @@ class DAG:
             min_threads[job.rule] = min(min_threads[job.rule], job.threads)
         rows = [
             {
-                "job": rule,
+                "job": rule.name,
                 "count": count,
                 "min threads": min_threads[rule],
                 "max threads": max_threads[rule],


### PR DESCRIPTION
* fixes #1892
* fixes #1891

Thanks to @ftabaro for pointing me to the problem and providing an initial solution (https://github.com/snakemake/snakemake/pull/1893).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
