### PR TITLE
fix: allow report generation to handle pathlib objects

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -884,7 +884,7 @@ def get_wildcard_names(pattern):
 
 
 def contains_wildcard(path):
-    return _wildcard_regex.search(path) is not None
+    return _wildcard_regex.search(str(path)) is not None
 
 
 def contains_wildcard_constraints(pattern):


### PR DESCRIPTION
### Description

In #1869 I added the ability to use a `pathlib.Path` object in the `script` directive. When generating a report where a rule has a Path in the script directory, this function was causing snakemake to error as it assumes the path is a string. This PR makes it explicitly a string.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
