### PR TITLE
fix: conda create --no-shortcuts absent on Linux/MacOS (regression from #1046)

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -492,7 +492,7 @@ class Env:
                             "conda",
                             "create",
                             "--quiet",
-                            "--no-shortcuts",
+                            "--no-shortcuts" if ON_WINDOWS else "",
                             "--yes",
                             "--prefix '{}'".format(env_path),
                         ]


### PR DESCRIPTION
`conda create --no-shortcuts` is only valid on windows. The option does not exist on other OSes. This fixes the regression introduced in #1046

See https://github.com/conda/conda/blob/32b958df05e5fab04254ed2af9044ea99f5f13f1/conda/cli/conda_argparse.py#L1827-L1837