### PR TITLE
perf: cached os.pathconf() call in _record_path()

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -33,6 +33,7 @@ class Persistence:
         shadow_prefix=None,
         warn_only=False,
     ):
+        self._max_len = None
         self.path = os.path.abspath(".snakemake")
         if not os.path.exists(self.path):
             os.mkdir(self.path)
@@ -514,9 +515,14 @@ class Persistence:
                     print(*files, sep="\n", file=lock)
                 return
 
+    def _fetch_max_len(self, subject):
+        if self._max_len is None:
+            self._max_len = os.pathconf(subject, "PC_NAME_MAX")
+        return self._max_len
+
     def _record_path(self, subject, id):
         max_len = (
-            os.pathconf(subject, "PC_NAME_MAX") if os.name == "posix" else 255
+            self._fetch_max_len(subject) if os.name == "posix" else 255
         )  # maximum NTFS and FAT32 filename length
         if max_len == 0:
             max_len = 255


### PR DESCRIPTION
### Description

The value of `os.pathconf(self._incomplete_path, "PC_NAME_MAX")` is cached in an attribute `Persistence._max_len` -- this avoids repeatedly querying the operating system for the same configuration information every time `marked_incomplete()` is called on a file/job output. (Note: this will dramatically speed up Snakemake DAG building on compute clusters where `os.pathconf()` is slow to return and the number of files checked for incompleteness is very large.)

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
