### PR TITLE
fix: remove redundant dot in expand call in multiext documentation

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -233,7 +233,7 @@ The multiext function
         shell:
             ...
 
-The effect is the same as if you would write ``expand("some/plot.{ext}", ext=[".pdf", ".svg", ".png"])``, however, using a simpler syntax.
+The effect is the same as if you would write ``expand("some/plot{ext}", ext=[".pdf", ".svg", ".png"])``, however, using a simpler syntax.
 Moreover, defining output with ``multiext`` is the only way to use :ref:`between workflow caching <caching>` for rules with multiple output files.
 
 


### PR DESCRIPTION
### Description

This just removes a single period in the documentation section about the multiext function, so that this, with a redundant period:

```
expand("some/plot.{ext}", ext=[".pdf", ".svg", ".png"])
```

becomes this, matching the expected output:

```
expand("some/plot{ext}", ext=[".pdf", ".svg", ".png"])
```

Fixes #1012.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
