### PR TITLE
snakemake.vim: add envmodules keyword

### DIFF
--- a/misc/vim/syntax/snakemake.vim
+++ b/misc/vim/syntax/snakemake.vim
@@ -51,6 +51,7 @@ syn keyword pythonStatement
       \ configfile
       \ container
       \ default_target
+      \ envmodules
       \ group
       \ include
       \ input


### PR DESCRIPTION
### Description

<!--Add envmodules keyword to vim syntax-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
