### PR TITLE
fix: change source cache entries to keep the original name and folder structure, such that imports from e.g. scripts also work with remote modules (if specified as additional input files with workflow.source_path)

### DIFF
--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -12,6 +12,7 @@ from snakemake import utils
 import tempfile
 import io
 from abc import ABC, abstractmethod
+from urllib.parse import unquote
 
 from snakemake.common import (
     ON_WINDOWS,
@@ -44,7 +45,7 @@ class SourceFile(ABC):
     
     def get_cache_path(self):
         uri = parse_uri(self.get_path_or_uri())
-        return os.path.join(uri.scheme, uri.uri_path.lstrip("/"))
+        return os.path.join(uri.scheme, unquote(uri.uri_path.lstrip("/")))
 
     def get_basedir(self):
         path = os.path.dirname(self.get_path_or_uri())

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -42,7 +42,7 @@ class SourceFile(ABC):
     @abstractmethod
     def is_persistently_cacheable(self):
         ...
-    
+
     def get_cache_path(self):
         uri = parse_uri(self.get_path_or_uri())
         return os.path.join(uri.scheme, unquote(uri.uri_path.lstrip("/")))


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
