### PR TITLE
feat: first try to match output files against input files while persisting wildcard values from the consuming job. This can dramatically reduce ambiuity problems. Thanks to @descostesn!

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -37,6 +37,7 @@ from snakemake.common import (
     MIN_PY_VERSION,
     get_appdirs,
     dict_to_key_value_args,
+    parse_key_value_arg,
 )
 from snakemake.resources import ResourceScopes, parse_resources, DefaultResources
 

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -223,7 +223,7 @@ def snakemake(
         config (dict):              override values for workflow config
         workdir (str):              path to the working directory (default None)
         targets (list):             list of targets, e.g. rule or file names (default None)
-        target_jobs (dict):         dict of rulename vs dict of wildcard values pairs for for directly targeting specific jobs (default None)
+        target_jobs (dict):         list of snakemake.target_jobs.TargetSpec objects directly targeting specific jobs (default None)
         dryrun (bool):              only dry-run the workflow (default False)
         touch (bool):               only touch all output files if present (default False)
         forcetargets (bool):        force given targets to be re-created (default False)

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -33,6 +33,14 @@ NOTHING_TO_BE_DONE_MSG = (
 ON_WINDOWS = platform.system() == "Windows"
 
 
+def parse_key_value_arg(arg, errmsg):
+    try:
+        key, val = arg.split("=", 1)
+    except ValueError:
+        raise ValueError(errmsg + " Unparseable value: %r." % arg)
+    return key, val
+
+
 def dict_to_key_value_args(some_dict: dict, quote_str: bool = True):
     items = []
     for key, value in some_dict.items():

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -37,7 +37,7 @@ def parse_key_value_arg(arg, errmsg):
     try:
         key, val = arg.split("=", 1)
     except ValueError:
-        raise ValueError(errmsg + " Unparseable value: %r." % arg)
+        raise ValueError(errmsg + f" (Unparseable value: {repr(arg)})")
     return key, val
 
 

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -33,6 +33,16 @@ NOTHING_TO_BE_DONE_MSG = (
 ON_WINDOWS = platform.system() == "Windows"
 
 
+def dict_to_key_value_args(some_dict: dict, quote_str: bool = True):
+    items = []
+    for key, value in some_dict.items():
+        encoded = (
+            "'{}'".format(value) if quote_str and isinstance(value, str) else value
+        )
+        items.append("{}={}".format(key, encoded))
+    return items
+
+
 def async_run(coroutine):
     """Attaches to running event loop or creates a new one to execute a
     coroutine.

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -129,6 +129,7 @@ class DAG:
         self.targetfiles = targetfiles
         self.targetrules = targetrules
         self.target_jobs_def = target_jobs_def
+        self.target_jobs_rules = {spec.rulename for spec in target_jobs_def} if target_jobs_def else set()
         self.priorityfiles = priorityfiles
         self.priorityrules = priorityrules
         self.targetjobs = set()
@@ -204,12 +205,12 @@ class DAG:
             self.targetjobs.add(job)
 
         if self.target_jobs_def:
-            for rulename, wildcards_dict in self.target_jobs_def.items():
+            for spec in self.target_jobs_def:
                 job = self.update(
                     [
                         self.new_job(
-                            self.workflow.get_rule(rulename),
-                            wildcards_dict=wildcards_dict,
+                            self.workflow.get_rule(spec.rulename),
+                            wildcards_dict=spec.wildcards_dict,
                         )
                     ],
                     progress=progress,
@@ -1097,7 +1098,7 @@ class DAG:
                         files = set(job.products(include_logfiles=False))
                     elif (
                         self.target_jobs_def is not None
-                        and job.rule.name in self.target_jobs_def
+                        and job.rule.name in self.target_jobs_rules
                     ):
                         files = set(job.products(include_logfiles=False))
                     else:

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -196,7 +196,7 @@ class DAG:
 
         for file in self.targetfiles:
             job = self.update(
-                self.file2jobs(file, wildcards_dict=self.target_wildcards),
+                self.file2jobs(file),
                 file=file,
                 progress=progress,
                 create_inventory=True,

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -97,7 +97,7 @@ class DAG:
         dryrun=False,
         targetfiles=None,
         targetrules=None,
-        target_wildcards=None,
+        target_jobs_def=None,
         forceall=False,
         forcerules=None,
         forcefiles=None,
@@ -128,7 +128,7 @@ class DAG:
         self.ignore_ambiguity = ignore_ambiguity
         self.targetfiles = targetfiles
         self.targetrules = targetrules
-        self.target_wildcards = target_wildcards
+        self.target_jobs_def = target_jobs_def
         self.priorityfiles = priorityfiles
         self.priorityrules = priorityrules
         self.targetjobs = set()
@@ -202,6 +202,20 @@ class DAG:
                 create_inventory=True,
             )
             self.targetjobs.add(job)
+
+        if self.target_jobs_def:
+            for rulename, wildcards_dict in self.target_jobs_def.items():
+                job = self.update(
+                    [
+                        self.new_job(
+                            self.workflow.get_rule(rulename),
+                            wildcards_dict=wildcards_dict,
+                        )
+                    ],
+                    progress=progress,
+                    create_inventory=True,
+                )
+                self.targetjobs.add(job)
 
         self.cleanup()
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1097,7 +1097,10 @@ class DAG:
                         files = set(job.output)
                         if job.benchmark:
                             files.add(job.benchmark)
-                    elif job.rule.name in self.target_jobs_def:
+                    elif (
+                        self.target_jobs_def is not None
+                        and job.rule.name in self.target_jobs_def
+                    ):
                         files = set(job.output)
                     else:
                         files = set(chain(*self.depending[job].values()))

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -129,7 +129,9 @@ class DAG:
         self.targetfiles = targetfiles
         self.targetrules = targetrules
         self.target_jobs_def = target_jobs_def
-        self.target_jobs_rules = {spec.rulename for spec in target_jobs_def} if target_jobs_def else set()
+        self.target_jobs_rules = (
+            {spec.rulename for spec in target_jobs_def} if target_jobs_def else set()
+        )
         self.priorityfiles = priorityfiles
         self.priorityrules = priorityrules
         self.targetjobs = set()

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -23,8 +23,6 @@ import threading
 from functools import partial
 from itertools import chain
 from collections import namedtuple
-from snakemake.executors.common import format_cli_arg, format_cli_pos_arg, join_cli_args
-from snakemake.io import _IOFile
 import random
 import base64
 import uuid
@@ -52,7 +50,10 @@ from snakemake.common import (
     get_container_image,
     get_uuid,
     lazy_property,
+    dict_to_key_value_args,
 )
+from snakemake.executors.common import format_cli_arg, format_cli_pos_arg, join_cli_args
+from snakemake.io import _IOFile
 
 
 # TODO move each executor into a separate submodule
@@ -357,6 +358,11 @@ class RealExecutor(AbstractExecutor):
         return join_cli_args(
             [
                 format_cli_pos_arg(kwargs.get("target", self.get_job_targets(job))),
+                format_cli_arg(
+                    "--target-wildcards",
+                    job.wildcards_dict,
+                    skip=not job.wildcards_dict,
+                ),
                 # Restrict considered rules for faster DAG computation.
                 # This does not work for updated jobs because they need
                 # to be updated in the spawned process as well.

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -360,7 +360,7 @@ class RealExecutor(AbstractExecutor):
             [
                 format_cli_arg(
                     "--target-jobs",
-                    encode_target_jobs_cli_args(job.get_target_dict()),
+                    encode_target_jobs_cli_args(job.get_target_spec()),
                 ),
                 # Restrict considered rules for faster DAG computation.
                 # This does not work for updated jobs because they need

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -203,6 +203,7 @@ class _IOFile(str):
         "_file",
         "rule",
         "_regex",
+        "_wildcard_constraints",
     ]
 
     def __new__(cls, file):
@@ -222,6 +223,7 @@ class _IOFile(str):
         obj._file = file
         obj.rule = None
         obj._regex = None
+        obj._wildcard_constraints = None
 
         if obj.is_remote:
             obj.remote_object._iofile = obj
@@ -756,6 +758,11 @@ class _IOFile(str):
             self._regex = re.compile(regex(self.file))
         return self._regex
 
+    def wildcard_constraints(self):
+        if self._wildcard_constraints is None:
+            self._wildcard_constraints = get_wildcard_constraints(self.file)
+        return self._wildcard_constraints
+
     def constant_prefix(self):
         first_wildcard = _wildcard_regex.search(self.file)
         if first_wildcard:
@@ -917,6 +924,14 @@ def remove(file, remove_non_empty_dir=False):
             os.remove(file)
         except FileNotFoundError:
             pass
+
+
+def get_wildcard_constraints(pattern):
+    constraints = {}
+    for match in _wildcard_regex.finditer(pattern):
+        if match.group("constraint"):
+            constraints[match.group("name")] = re.compile(match.group("constraint"))
+    return constraints
 
 
 def regex(filepattern):

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -27,6 +27,7 @@ from snakemake.io import (
     wait_for_files,
 )
 from snakemake.resources import GroupResources
+from snakemake.target_jobs import TargetSpec
 from snakemake.utils import format, listfiles
 from snakemake.exceptions import RuleException, ProtectedOutputException, WorkflowError
 
@@ -84,7 +85,7 @@ class AbstractJob:
     def reset_params_and_resources(self):
         raise NotImplementedError()
 
-    def get_target_dict(self):
+    def get_target_spec(self):
         raise NotImplementedError()
 
     def products(self):
@@ -320,8 +321,8 @@ class Job(AbstractJob):
                         yield f
         # TODO also handle remote file case here.
 
-    def get_target_dict(self):
-        return {self.rule.name: self.wildcards_dict}
+    def get_target_spec(self):
+        return [TargetSpec(self.rule.name, self.wildcards_dict)]
 
     @property
     def threads(self):
@@ -1509,8 +1510,8 @@ class GroupJob(AbstractJob):
     def threads(self):
         return self.resources["_cores"]
 
-    def get_target_dict(self):
-        return {job.rule.name: job.wildcards_dict for job in self.jobs}
+    def get_target_spec(self):
+        return [TargetSpec(job.rule.name, job.wildcards_dict) for job in self.jobs]
 
     @property
     def attempt(self):

--- a/snakemake/output_index.py
+++ b/snakemake/output_index.py
@@ -11,10 +11,10 @@ class OutputIndex:
         import datrie
 
         def prefixes(rule):
-            return (str(o.constant_prefix()) for o in rule.products)
+            return (str(o.constant_prefix()) for o in rule.products())
 
         def reverse_suffixes(rule):
-            return (str(o.constant_suffix())[::-1] for o in rule.products)
+            return (str(o.constant_suffix())[::-1] for o in rule.products())
 
         def calc_trie(subpatterns):
             t = datrie.Trie("".join(p for rule in rules for p in subpatterns(rule)))

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+
+from snakemake.common import parse_key_value_arg
+
+
+def parse_target_jobs_cli_args(args):
+    errmsg = "Invalid target wildcards definition: entries have to be defined as WILDCARD=VALUE pairs"
+    if args.target_jobs is not None:
+        target_jobs = defaultdict(dict)
+        for entry in args.target_wildcards:
+            rulename, wildcards = entry.split(":")
+            for entry in wildcards.split(","):
+                wildcard, value = parse_key_value_arg(entry, errmsg=errmsg)
+                target_jobs[rulename][wildcard] = value
+        return target_jobs
+
+
+def encode_target_jobs_cli_args(target_jobs):
+    items = []
+    for rulename, wildcards in target_jobs.items():
+        wildcards = ",".join(f"{key}={value}" for key, value in wildcards.items())
+        items.append(f"{rulename}:{wildcards}")
+    return items

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -13,9 +13,13 @@ def parse_target_jobs_cli_args(args):
         for entry in args.target_jobs:
             rulename, wildcards = entry.split(":", 1)
             if wildcards:
+
                 def parse_wildcard(entry):
                     return parse_key_value_arg(entry, errmsg)
-                wildcards = dict(parse_wildcard(entry) for entry in wildcards.split(","))
+
+                wildcards = dict(
+                    parse_wildcard(entry) for entry in wildcards.split(",")
+                )
                 target_jobs.append(TargetSpec(rulename, wildcards))
             else:
                 target_jobs.append(TargetSpec(rulename, dict()))
@@ -25,6 +29,8 @@ def parse_target_jobs_cli_args(args):
 def encode_target_jobs_cli_args(target_jobs: list[TargetSpec]) -> list[str]:
     items = []
     for spec in target_jobs:
-        wildcards = ",".join(f"{key}={value}" for key, value in spec.wildcards_dict.items())
+        wildcards = ",".join(
+            f"{key}={value}" for key, value in spec.wildcards_dict.items()
+        )
         items.append(f"{spec.rulename}:{wildcards}")
     return items

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -8,10 +8,13 @@ def parse_target_jobs_cli_args(args):
     if args.target_jobs is not None:
         target_jobs = defaultdict(dict)
         for entry in args.target_jobs:
-            rulename, wildcards = entry.split(":")
-            for entry in wildcards.split(","):
-                wildcard, value = parse_key_value_arg(entry, errmsg=errmsg)
-                target_jobs[rulename][wildcard] = value
+            rulename, wildcards = entry.split(":", 1)
+            if wildcards:
+                for entry in wildcards.split(","):
+                    wildcard, value = parse_key_value_arg(entry, errmsg=errmsg)
+                    target_jobs[rulename][wildcard] = value
+            else:
+                target_jobs[rulename] = {}
         return target_jobs
 
 

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -27,7 +27,9 @@ def parse_target_jobs_cli_args(args):
         return target_jobs
 
 
-def encode_target_jobs_cli_args(target_jobs: typing.List[TargetSpec]) -> typing.List[str]:
+def encode_target_jobs_cli_args(
+    target_jobs: typing.List[TargetSpec],
+) -> typing.List[str]:
     items = []
     for spec in target_jobs:
         wildcards = ",".join(

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -1,4 +1,5 @@
-from collections import defaultdict, namedtuple
+from collections import namedtuple
+import typing
 
 from snakemake.common import parse_key_value_arg
 
@@ -26,7 +27,7 @@ def parse_target_jobs_cli_args(args):
         return target_jobs
 
 
-def encode_target_jobs_cli_args(target_jobs: list[TargetSpec]) -> list[str]:
+def encode_target_jobs_cli_args(target_jobs: typing.List[TargetSpec]) -> typing.List[str]:
     items = []
     for spec in target_jobs:
         wildcards = ",".join(

--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -7,7 +7,7 @@ def parse_target_jobs_cli_args(args):
     errmsg = "Invalid target wildcards definition: entries have to be defined as WILDCARD=VALUE pairs"
     if args.target_jobs is not None:
         target_jobs = defaultdict(dict)
-        for entry in args.target_wildcards:
+        for entry in args.target_jobs:
             rulename, wildcards = entry.split(":")
             for entry in wildcards.split(","):
                 wildcard, value = parse_key_value_arg(entry, errmsg=errmsg)

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -494,6 +494,7 @@ class Workflow:
     def execute(
         self,
         targets=None,
+        target_wildcards=None,
         dryrun=False,
         generate_unit_tests=None,
         touch=False,
@@ -604,6 +605,11 @@ class Workflow:
                 )
                 return map(relpath, filterfalse(self.is_rule, items))
 
+        if targets and target_wildcards and len(targets) != 1:
+            raise WorkflowError(
+                "Only one target allowed when specifying --target-wildcards."
+            )
+
         if not targets:
             targets = (
                 [self.default_target] if self.default_target is not None else list()
@@ -663,6 +669,7 @@ class Workflow:
             dryrun=dryrun,
             targetfiles=targetfiles,
             targetrules=targetrules,
+            target_wildcards=target_wildcards,
             # when cleaning up conda, we should enforce all possible jobs
             # since their envs shall not be deleted
             forceall=forceall or conda_cleanup_envs,

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -494,7 +494,7 @@ class Workflow:
     def execute(
         self,
         targets=None,
-        target_wildcards=None,
+        target_jobs=None,
         dryrun=False,
         generate_unit_tests=None,
         touch=False,
@@ -605,12 +605,7 @@ class Workflow:
                 )
                 return map(relpath, filterfalse(self.is_rule, items))
 
-        if targets and target_wildcards and len(targets) != 1:
-            raise WorkflowError(
-                "Only one target allowed when specifying --target-wildcards."
-            )
-
-        if not targets:
+        if not targets and not target_jobs:
             targets = (
                 [self.default_target] if self.default_target is not None else list()
             )
@@ -669,7 +664,7 @@ class Workflow:
             dryrun=dryrun,
             targetfiles=targetfiles,
             targetrules=targetrules,
-            target_wildcards=target_wildcards,
+            target_jobs_def=target_jobs,
             # when cleaning up conda, we should enforce all possible jobs
             # since their envs shall not be deleted
             forceall=forceall or conda_cleanup_envs,

--- a/tests/test_match_by_wildcard_names/Snakefile
+++ b/tests/test_match_by_wildcard_names/Snakefile
@@ -1,0 +1,22 @@
+rule all:
+    input:
+        expand("test.{sample}.{read}.fq", sample=["a"], read=["r1"]),
+
+
+rule a:
+    input:
+        "foo.{sample}{read}.fq",
+    output:
+        "test.{sample}.{read}.fq",
+    shell:
+        "touch {output}"
+
+
+rule b:
+    output:
+        "foo.{sample}{read}.fq",
+    run:
+        if "r" in wildcards.sample:
+            raise ValueError("sample name contains 'r'")
+        with open(output[0], "w") as f:
+            f.write("foo")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1987,3 +1987,8 @@ def test_conda_python_script():
 @skip_on_windows
 def test_github_issue1818():
     run(dpath("test_github_issue1818"), rerun_triggers="input")
+
+
+@skip_on_windows  # not platform dependent
+def test_match_by_wildcard_names():
+    run(dpath("test_match_by_wildcard_names"))


### PR DESCRIPTION
Only fall back to generic regex based matching if the wildcard based approach does not work. This is inspired by a chat with @descostesn.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
