### PR TITLE
fix: Consider source cache when setting search path for python scripts. This allows to import from Python modules next to scripts while deploying the workflow as a snakemake module, even from remote locations.

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -157,6 +157,7 @@ class PythonJupyterNotebook(JupyterNotebook):
 
         return PythonScript.generate_preamble(
             self.path,
+            self.cache_path,
             self.source,
             self.basedir,
             self.input,
@@ -291,11 +292,12 @@ def notebook(
             )
 
     if not draft:
-        path, source, language, is_local = get_source(
+        path, source, language, is_local, cache_path = get_source(
             path, SourceCache(runtime_sourcecache_path), basedir, wildcards, params
         )
     else:
         source = None
+        cache_path = None
         is_local = True
         path = infer_source_file(path)
 
@@ -303,6 +305,7 @@ def notebook(
 
     executor = exec_class(
         path,
+        cache_path,
         source,
         basedir,
         input,

--- a/snakemake/report/data/packages.py
+++ b/snakemake/report/data/packages.py
@@ -28,10 +28,10 @@ def get_packages():
                 url="https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2",
             ),
             "react": Package(
-                version="17",
+                version="18",
                 license_url="https://raw.githubusercontent.com/facebook/react/main/LICENSE",
-                main="https://unpkg.com/react@17/umd/react.development.js",
-                dom="https://unpkg.com/react-dom@17/umd/react-dom.development.js",
+                main="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js",
+                dom="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js",
             ),
             "vega": Package(
                 version="5.21",

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -390,6 +390,7 @@ class ScriptBase(ABC):
     def __init__(
         self,
         path,
+        cache_path,
         source,
         basedir,
         input_,
@@ -414,6 +415,7 @@ class ScriptBase(ABC):
         is_local,
     ):
         self.path = path
+        self.cache_path = cache_path
         self.source = source
 
         self.basedir = basedir
@@ -506,6 +508,7 @@ class PythonScript(ScriptBase):
     @staticmethod
     def generate_preamble(
         path,
+        cache_path,
         source,
         basedir,
         input_,
@@ -550,6 +553,12 @@ class PythonScript(ScriptBase):
         if container_img is not None:
             searchpath = singularity.SNAKEMAKE_MOUNTPOINT
         searchpath = repr(searchpath)
+
+        # Add the cache path to the search path so that other cached source files in the same dir
+        # can be imported.
+        cache_searchpath = os.path.dirname(cache_path)
+        if cache_searchpath:
+            searchpath += ", " + repr(cache_searchpath)
         # For local scripts, add their location to the path in case they use path-based imports
         if is_local:
             searchpath += ", " + repr(path.get_basedir().get_path_or_uri())
@@ -581,6 +590,7 @@ class PythonScript(ScriptBase):
 
         return PythonScript.generate_preamble(
             self.path,
+            self.cache_path,
             self.source,
             self.basedir,
             self.input,
@@ -1431,7 +1441,7 @@ def get_source(
 
     is_local = isinstance(source_file, LocalSourceFile)
 
-    return source_file, source, language, is_local
+    return source_file, source, language, is_local, sourcecache.get_path(source_file)
 
 
 def get_language(source_file, source):
@@ -1501,7 +1511,7 @@ def script(
     if isinstance(path, Path):
         path = str(path)
 
-    path, source, language, is_local = get_source(
+    path, source, language, is_local, cache_path = get_source(
         path, SourceCache(runtime_sourcecache_path), basedir, wildcards, params
     )
 
@@ -1520,6 +1530,7 @@ def script(
 
     executor = exec_class(
         path,
+        cache_path,
         source,
         basedir,
         input,

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -7,6 +7,7 @@ import inspect
 import itertools
 import os
 from collections.abc import Iterable
+import typing
 
 from snakemake import sourcecache
 from snakemake.sourcecache import (
@@ -390,7 +391,7 @@ class ScriptBase(ABC):
     def __init__(
         self,
         path,
-        cache_path,
+        cache_path: typing.Optional[str],
         source,
         basedir,
         input_,
@@ -508,7 +509,7 @@ class PythonScript(ScriptBase):
     @staticmethod
     def generate_preamble(
         path,
-        cache_path,
+        cache_path: typing.Optional[str],
         source,
         basedir,
         input_,
@@ -556,9 +557,10 @@ class PythonScript(ScriptBase):
 
         # Add the cache path to the search path so that other cached source files in the same dir
         # can be imported.
-        cache_searchpath = os.path.dirname(cache_path)
-        if cache_searchpath:
-            searchpath += ", " + repr(cache_searchpath)
+        if cache_path:
+            cache_searchpath = os.path.dirname(cache_path)
+            if cache_searchpath:
+                searchpath += ", " + repr(cache_searchpath)
         # For local scripts, add their location to the path in case they use path-based imports
         if is_local:
             searchpath += ", " + repr(path.get_basedir().get_path_or_uri())

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -361,7 +361,7 @@ class SourceCache:
             return False
         return True
 
-    def get_path(self, source_file, mode="r"):
+    def get_path(self, source_file):
         cache_entry = self._cache(source_file)
         return str(cache_entry)
 


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
