### PR TITLE
fix: show input files on job error

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1057,6 +1057,7 @@ class Job(AbstractJob):
         logger.job_error(
             name=self.rule.name,
             jobid=self.dag.jobid(self),
+            input=list(format_files(self, self.input, self.dynamic_output)),
             output=list(format_files(self, self.output, self.dynamic_output)),
             log=list(self.log),
             conda_env=self.conda_env.address if self.conda_env else None,

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -512,6 +512,8 @@ class Logger:
             def job_error():
                 yield indent("Error in rule {}:".format(msg["name"]))
                 yield indent("    jobid: {}".format(msg["jobid"]))
+                if msg["input"]:
+                    yield indent("    input: {}".format(", ".join(msg["input"])))
                 if msg["output"]:
                     yield indent("    output: {}".format(", ".join(msg["output"])))
                 if msg["log"]:


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
