### PR TITLE
fix: forwarding --keep-incomplete to cluster executor

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -314,6 +314,7 @@ class RealExecutor(AbstractExecutor):
                 "--no-hooks",
                 "--nolock",
                 "--ignore-incomplete",
+                format_cli_arg("--keep-incomplete", self.keepincomplete),
                 w2a("rerun_triggers"),
                 w2a("cleanup_scripts", flag="--skip-script-cleanup"),
                 w2a("shadow_prefix"),


### PR DESCRIPTION
### Description

The option `--keep-incomplete` was not correctly forwarded in the case of cluster execution, causing jobs to clean up output files in case of failure, despite the main snakemake process being called with `--keep-incomplete`. Below is a MWE:

```snakefile
rule test:
    output:
        "file.out"
    shell:
        "touch {output[0]}"
```
Run with `snakemake -j1 --cluster "bash -x" --keep-incomplete file.out` to see that `--keep-incomplete` is absent from the `snakemake` call in the generated jobscript.

I've looked at adding a regression test, but I'm not sure how to do that in the snakemake tests, which is why the box below is unchecked. Any advice is appreciated.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
