### PR TITLE
Add Filelist cache for azure blob storage

### DIFF
--- a/snakemake/remote/AzBlob.py
+++ b/snakemake/remote/AzBlob.py
@@ -162,8 +162,6 @@ class RemoteObject(AbstractRemoteRetryObject):
 
 
 # Actual Azure specific functions, adapted from S3.py
-
-
 class AzureStorageHelper(object):
     def __init__(self, *args, **kwargs):
         if "stay_on_remote" in kwargs:
@@ -188,10 +186,37 @@ class AzureStorageHelper(object):
         # BlobServiceClient deal with the ambiguity
         self.blob_service_client = BlobServiceClient(**kwargs)
 
+        self._use_cache = "AZ_USE_CACHE" in os.environ
+        self._gen_cache()
+
     def container_exists(self, container_name):
+        return container_name in self._cache
         return any(
             True for _ in self.blob_service_client.list_containers(container_name)
         )
+
+    def _gen_cache(self):
+        if not self._use_cache:
+           self._cache = None
+           return
+
+        print("CREATING AZURE CACHE")
+        self._cache = {}
+        num_files   = 0
+        sum_size    = 0
+        for container_properties in self.blob_service_client.list_containers():
+            container_name = container_properties.name
+            c = self.blob_service_client.get_container_client(container_name)
+            container_files = {}
+            for b in c.list_blobs():
+                blob_name           = b.name
+                blob_last_modified  = b.last_modified
+                blob_size           = b.size
+                num_files          += 1
+                sum_size           += blob_size
+                container_files[blob_name] = (blob_last_modified, blob_size)
+            self._cache[container_name] = container_files
+        print(f"AZURE CACHE CREATED. {num_files:7,d} files. {sum_size//(1024*1024):16,d} Mb")
 
     def upload_to_azure_storage(
         self,
@@ -331,6 +356,10 @@ class AzureStorageHelper(object):
             container_name
         ), 'container_name must be specified (did you try to write to "root" or forgot to set --default-remote-prefix?)'
         assert blob_name, "blob_name must be specified"
+
+        if self._use_cache:
+            return container_name in self._cache and blob_name in self._cache[container_name]
+
         cc = self.blob_service_client.get_container_client(container_name)
         return any(True for _ in cc.list_blobs(name_starts_with=blob_name))
 
@@ -347,6 +376,11 @@ class AzureStorageHelper(object):
         assert container_name, "container_name must be specified"
         assert blob_name, "blob_name must be specified"
 
+        if self._use_cache:
+            assert container_name in self._cache
+            assert blob_name in self._cache[container_name]
+            return self._cache[container_name][blob_name][1] // 1024
+
         b = self.blob_service_client.get_blob_client(container_name, blob_name)
         return b.get_blob_properties().size // 1024
 
@@ -362,6 +396,12 @@ class AzureStorageHelper(object):
         """
         assert container_name, "container_name must be specified"
         assert blob_name, "blob_name must be specified"
+
+        if self._use_cache:
+            assert container_name in self._cache
+            assert blob_name in self._cache[container_name]
+            return self._cache[container_name][blob_name][0].timestamp()
+
         b = self.blob_service_client.get_blob_client(container_name, blob_name)
         return b.get_blob_properties().last_modified.timestamp()
 
@@ -375,5 +415,10 @@ class AzureStorageHelper(object):
             list of blobs
         """
         assert container_name, "container_name must be specified"
+
+        if self._use_cache:
+            assert container_name in self._cache
+            return tuple(self._cache[container_name].keys())
+
         c = self.blob_service_client.get_container_client(container_name)
         return [b.name for b in c.list_blobs()]


### PR DESCRIPTION
Add Filelist cache for azure blob storage when AZ_USE_CACHE environment variable is enabled.

Then listing thousands of files, snakemake makes thousands of HTTP requests to Azure storage. This change list all files once and query this dictionary instead of making HTTP requests.

Although this is not advised when actively creating files, this speeds up dry-runs and graph creation.

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
