### PR TITLE
fix: issue #1882 WorkflowError: Metadata can't be created as it already exists (Windows)

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -459,7 +459,7 @@ class Persistence:
             suffix=f".{os.path.basename(recpath)[:8]}",
         ) as tmpfile:
             json.dump(json_value, tmpfile)
-        os.rename(tmpfile.name, recpath)
+        os.replace(tmpfile.name, recpath)
 
     def _delete_record(self, subject, id):
         try:

--- a/tests/test_github_issue1882/Snakefile
+++ b/tests/test_github_issue1882/Snakefile
@@ -1,0 +1,5 @@
+rule all:
+    output:
+        "foo.txt"
+    run:
+        with open('foo.txt', 'w') as f: pass

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2001,7 +2001,10 @@ def test_github_issue929():
     # Huge thanks to Ronald Lehnigk for pointing me to the issue!
     run(dpath("test_github_issue929"), targets=["childrule_2"])
 
+
 def test_github_issue1882():
-    tmpdir = run(dpath("test_github_issue1882"), cleanup=False)
-    run(tmpdir, forceall=True)
-    shutil.rmtree(tmpdir)
+    try:
+        tmpdir = run(dpath("test_github_issue1882"), cleanup=False)
+        run(tmpdir, forceall=True)
+    finally:
+        shutil.rmtree(tmpdir)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2000,3 +2000,8 @@ def test_github_issue929():
     # and pointing to the problem in the code!
     # Huge thanks to Ronald Lehnigk for pointing me to the issue!
     run(dpath("test_github_issue929"), targets=["childrule_2"])
+
+def test_github_issue1882():
+    tmpdir = run(dpath("test_github_issue1882"), cleanup=False)
+    run(tmpdir, forceall=True)
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
### Description

Fixes issue #1882: WorkflowError: Metadata can't be created as it already exists (Windows)

The underlying cause of the problem is that `os.rename` was used to overwrite the target file. Unfortunately, it has a different behavior under Unix/Linux (overwrites target) and Windows (fails). `os.replace` is an alternative to `os.rename` that simulates the  Unix behavior.

The required change is extremely small (commit 4ad1ab1) and I have also added a test case covering it (commit e12955f).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
