### PR TITLE
feat: add  keyword to gridftp remote provide to specify the number or disable usage of multiple data stream

### DIFF
--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -602,7 +602,7 @@ In general, if you are able to use the `gfal-*` commands directly, Snakemake sup
 
     from snakemake.remote import gfal
 
-    gfal = gfal.RemoteProvider(retry=5)
+    gfal = gfal.RemoteProvider()
 
     rule a:
         input:
@@ -614,8 +614,6 @@ In general, if you are able to use the `gfal-*` commands directly, Snakemake sup
 
 Authentication has to be setup in the system, e.g. via certificates in the ``.globus`` directory.
 Usually, this is already the case and no action has to be taken.
-The keyword argument to the remote provider allows to set the number of retries (10 per default) in case of failed commands (the GRID is usually relatively unreliable).
-The latter may be unsupported depending on the system configuration.
 
 Note that GFAL support used together with the flags ``--no-shared-fs`` and ``--default-remote-provider`` enables you
 to transparently use Snakemake in a grid computing environment without a shared network filesystem.
@@ -633,7 +631,7 @@ This provider only supports the GridFTP protocol. Internally, it uses the `globu
 
     from snakemake.remote import gridftp
 
-    gridftp = gridftp.RemoteProvider(retry=5)
+    gridftp = gridftp.RemoteProvider(streams=4)
 
     rule a:
         input:
@@ -645,8 +643,7 @@ This provider only supports the GridFTP protocol. Internally, it uses the `globu
 
 Authentication has to be setup in the system, e.g. via certificates in the ``.globus`` directory.
 Usually, this is already the case and no action has to be taken.
-The keyword argument to the remote provider allows to set the number of retries (10 per default) in case of failed commands (the GRID is usually relatively unreliable).
-The latter may be unsupported depending on the system configuration.
+The keyword argument to the remote provider allows to set the number of parallel streams used for file tranfers(4 per default). When ``streams``is set to 1 or smaller, the files are trasfered in a serial way. Paralell stream may be unsupported depending on the system configuration.
 
 Note that GridFTP support used together with the flags ``--no-shared-fs`` and ``--default-remote-provider`` enables you
 to transparently use Snakemake in a grid computing environment without a shared network filesystem.

--- a/snakemake/remote/gridftp.py
+++ b/snakemake/remote/gridftp.py
@@ -34,7 +34,7 @@ class RemoteProvider(gfal.RemoteProvider):
 
 class RemoteObject(gfal.RemoteObject):
     def _globus(self, *args):
-        cmd = ["globus-url-copy"] + list(args)
+        cmd = ["globus-url-copy"] + self._parallelstreams() + list(args)
         try:
             logger.debug(" ".join(cmd))
             return sp.run(
@@ -56,9 +56,7 @@ class RemoteObject(gfal.RemoteObject):
             source = self.remote_file()
             target = "file://" + os.path.abspath(self.local_file())
 
-            self._globus(
-                "-parallel", "4", "-create-dest", "-recurse", "-dp", source, target
-            )
+            self._globus("-create-dest", "-recurse", "-dp", source, target)
 
             os_sync()
             return self.local_file()
@@ -72,6 +70,14 @@ class RemoteObject(gfal.RemoteObject):
             # first delete file, such that globus does not fail
             self._gfal("rm", target)
 
-        self._globus(
-            "-parallel", "4", "-create-dest", "-recurse", "-dp", source, target
-        )
+            self._globus("-create-dest", "-recurse", "-dp", source, target)
+
+    def _parallelstreams(self):
+        n_streams = 4
+        if "streams" in self.kwargs:
+            n_streams = int(self.kwargs["streams"])
+
+        elif "streams" in self.provider.kwargs:
+            n_streams = int(self.provider.kwargs["streams"])
+
+        return [] if n_streams <= 1 else ["-parallel", str(n_streams)]


### PR DESCRIPTION

### Description
- add a keyword(`streams`)to GridFTP remote provides to specify the number or disable the usage of multiple data streams. This can be handy when the system does not support multiple streams. The keyword can be set in the provider and remote object(remote object is prioritized).
- Also removes some outdated info about the retry keyword for the gfal and GridFTP provider

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.

* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
