### PR TITLE
fix: json validation error with markdown cells

### DIFF
--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -117,6 +117,8 @@ class JupyterNotebook(ScriptBase):
                 for cell in nb["cells"]:
                     if "outputs" in cell:
                         cell["outputs"] = []
+                    if "execution_count" in cell:
+                        cell["execution_count"] = None
 
                 nbformat.write(nb, self.local_path)
 

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -115,7 +115,8 @@ class JupyterNotebook(ScriptBase):
 
                 # clean up all outputs
                 for cell in nb["cells"]:
-                    cell["outputs"] = []
+                    if "outputs" in cell:
+                        cell["outputs"] = []
 
                 nbformat.write(nb, self.local_path)
 


### PR DESCRIPTION
### Description

This should fix #718. The cleanup routine after editing a notebook would add the `"outputs"` attribute to all cells in the notebook, which would cause the JSON validation of nbconvert to fail for cells where no output is expected.

I've also added a cleanup of the `"execution_count"` property, which should make SCM management of the notebook easier (execution count of cells is prompt to frequent changes in interactive sessions). I can remove it if that change is superfluous.

Finally, I think #1032 can be safely closed, I have not encountered it with recent versions of snakemake.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
