### PR TITLE
add '--show-failed-logs` to executor args

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -318,6 +318,7 @@ class RealExecutor(AbstractExecutor):
                 "--no-hooks",
                 "--nolock",
                 "--ignore-incomplete",
+                "--show-failed-logs",
                 format_cli_arg("--keep-incomplete", self.keepincomplete),
                 w2a("rerun_triggers"),
                 w2a("cleanup_scripts", flag="--skip-script-cleanup"),


### PR DESCRIPTION
### Description

See #1992 

Adds `--show-failed-logs` to Snakemake call in cloud containers. This is a workaround to capture the stderr/stdout that is redirected to a rule log file which is not saved when a job fails on GLS. 

@johanneskoester would appreciate your feedback/discussion.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
