### PR TITLE
fix: Correctly parse UserDicts in executors

### DIFF
--- a/snakemake/executors/common.py
+++ b/snakemake/executors/common.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 from snakemake.io import not_iterable
 
 
@@ -12,13 +13,12 @@ def format_cli_arg(flag, value, quote=True, skip=False):
 
 
 def format_cli_pos_arg(value, quote=True):
-    try:
+    if isinstance(value, (dict, UserDict)):
         return join_cli_args(repr(f"{key}={val}") for key, val in value.items())
-    except AttributeError:
-        if not_iterable(value):
-            return repr(value)
-        else:
-            return join_cli_args(repr(v) for v in value)
+    elif not_iterable(value):
+        return repr(value)
+    else:
+        return join_cli_args(repr(v) for v in value)
 
 
 def join_cli_args(args):

--- a/snakemake/executors/common.py
+++ b/snakemake/executors/common.py
@@ -12,12 +12,13 @@ def format_cli_arg(flag, value, quote=True, skip=False):
 
 
 def format_cli_pos_arg(value, quote=True):
-    if isinstance(value, dict):
+    try:
         return join_cli_args(repr(f"{key}={val}") for key, val in value.items())
-    elif not_iterable(value):
-        return repr(value)
-    else:
-        return join_cli_args(repr(v) for v in value)
+    except AttributeError:
+        if not_iterable(value):
+            return repr(value)
+        else:
+            return join_cli_args(repr(v) for v in value)
 
 
 def join_cli_args(args):

--- a/tests/common.py
+++ b/tests/common.py
@@ -21,7 +21,7 @@ import tarfile
 from snakemake import snakemake
 from snakemake.shell import shell
 from snakemake.common import ON_WINDOWS
-from snakemake.resources import DefaultResources, GroupResources
+from snakemake.resources import DefaultResources, GroupResources, ResourceScopes
 
 
 def dpath(path):
@@ -130,6 +130,7 @@ def run(
     container_image=os.environ.get("CONTAINER_IMAGE", "snakemake/snakemake:latest"),
     shellcmd=None,
     sigint_after=None,
+    overwrite_resource_scopes=None,
     **params,
 ):
     """
@@ -223,6 +224,11 @@ def run(
             targets=targets,
             conda_frontend=conda_frontend,
             container_image=container_image,
+            overwrite_resource_scopes=(
+                ResourceScopes(overwrite_resource_scopes)
+                if overwrite_resource_scopes is not None
+                else overwrite_resource_scopes
+            ),
             **params,
         )
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1062,7 +1062,7 @@ def test_resources_can_be_overwritten_as_global():
         nodes=5,
         cleanup=False,
         resources={"typo": 23, "fake_res": 200},
-        overwrite_resource_scopes={"fake_res": {"local"}},
+        overwrite_resource_scopes={"fake_res": "local"},
         group_components={0: 5, 1: 5},
         overwrite_groups={"a": 0, "a_1": 1, "b": 2, "c": 2},
         default_resources=DefaultResources(["mem_mb=0"]),
@@ -1072,6 +1072,23 @@ def test_resources_can_be_overwritten_as_global():
         lines = [l for l in f.readlines() if not l == "\n"]
     assert len(lines) == 1
     shutil.rmtree(tmp)
+
+
+@skip_on_windows
+def test_scopes_submitted_to_cluster(mocker):
+    from snakemake.executors import AbstractExecutor
+
+    spy = mocker.spy(AbstractExecutor, "get_resource_scopes_args")
+    run(
+        dpath("test_group_jobs_resources"),
+        cluster="./qsub",
+        # cluster_status="./status_failed",
+        overwrite_resource_scopes={"fake_res": "local"},
+        max_threads=1,
+        default_resources=DefaultResources(["mem_mb=0"]),
+    )
+
+    assert spy.spy_return == "--set-resource-scopes 'fake_res=local'"
 
 
 @skip_on_windows

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1053,7 +1053,7 @@ def test_new_resources_can_be_defined_as_local():
 
 @skip_on_windows
 def test_resources_can_be_overwritten_as_global():
-    # Test only works if both mem_mb and global_res are overwritten as local
+    # Test only works if fake_res overwritten as global
     tmp = run(
         dpath("test_group_jobs_resources"),
         cluster="./qsub",
@@ -1062,7 +1062,7 @@ def test_resources_can_be_overwritten_as_global():
         nodes=5,
         cleanup=False,
         resources={"typo": 23, "fake_res": 200},
-        overwrite_resource_scopes={"fake_res": "local"},
+        overwrite_resource_scopes={"fake_res": "global"},
         group_components={0: 5, 1: 5},
         overwrite_groups={"a": 0, "a_1": 1, "b": 2, "c": 2},
         default_resources=DefaultResources(["mem_mb=0"]),


### PR DESCRIPTION
ResourceScopes, a subclass of UserDict (not dict), was getting parsed as a regular iterator, not a dict, so only the keys were being passed on.

Resolves #1968

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
