### PR TITLE
Indicate a file of conflict when locking workflow fails

### DIFF
--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -550,16 +550,17 @@ class CacheMissException(Exception):
 
 
 class LockException(WorkflowError):
-    def __init__(self):
+    def __init__(self, conflict_filename):
         super().__init__(
             "Error: Directory cannot be locked. Please make "
             "sure that no other Snakemake process is trying to create "
             "the same files in the following directory:\n{}\n"
+            "File(s) of conflict include:\n{}\n"
             "If you are sure that no other "
             "instances of snakemake are running on this directory, "
             "the remaining lock was likely caused by a kill signal or "
             "a power loss. It can be removed with "
-            "the --unlock argument.".format(os.getcwd())
+            "the --unlock argument.".format(os.getcwd(), conflict_filename)
         )
 
 


### PR DESCRIPTION
### Description

With this change, the user will helpfully be notified of at least one file leading to conflict and preventing the working directory from being locked. In cases of large workflows with a large number of input and output files, this makes debugging locking issues much easier.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
