### PR TITLE
fix: Fix handling of --jobs in no-exec state

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -23,7 +23,12 @@ from snakemake.target_jobs import parse_target_jobs_cli_args
 
 from snakemake.workflow import Workflow
 from snakemake.dag import Batch
-from snakemake.exceptions import ResourceScopesException, print_exception, WorkflowError
+from snakemake.exceptions import (
+    CliException,
+    ResourceScopesException,
+    print_exception,
+    WorkflowError,
+)
 from snakemake.logging import setup_logger, logger, SlackLogger, WMSLogger
 from snakemake.io import load_configfile, wait_for_files
 from snakemake.shell import shell
@@ -1020,6 +1025,60 @@ def parse_config(args):
             assert v is not None
             update_config(config, {key: v})
     return config
+
+
+def parse_cores(cores, allow_none=False):
+    if cores is None:
+        if allow_none:
+            return cores
+        raise CliException(
+            "Error: you need to specify the maximum number of CPU cores to "
+            "be used at the same time. If you want to use N cores, say --cores N "
+            "or -cN. For all cores on your system (be sure that this is "
+            "appropriate) use --cores all. For no parallelization use --cores 1 or "
+            "-c1."
+        )
+    if cores == "all":
+        return available_cpu_count()
+    try:
+        return int(cores)
+    except ValueError:
+        raise CliException(
+            "Error parsing number of cores (--cores, -c, -j): must be integer, "
+            "empty, or 'all'."
+        )
+
+
+def parse_jobs(jobs, allow_none=False):
+    if jobs is None:
+        if allow_none:
+            return jobs
+        raise CliException(
+            "Error: you need to specify the maximum number of jobs to "
+            "be queued or executed at the same time with --jobs or -j.",
+        )
+    if jobs == "unlimited":
+        return sys.maxsize
+    try:
+        return int(jobs)
+    except ValueError:
+        raise CliException(
+            "Error parsing number of jobs (--jobs, -j): must be integer.",
+        )
+
+
+def parse_cores_jobs(cores, jobs, no_exec, non_local_exec, dryrun):
+    if no_exec or dryrun:
+        cores = parse_cores(cores, allow_none=True) or 1
+        jobs = parse_jobs(jobs, allow_none=True) or 1
+    elif non_local_exec:
+        cores = parse_cores(cores, allow_none=True)
+        jobs = parse_jobs(jobs)
+    else:
+        cores = parse_cores(cores or jobs)
+        jobs = None
+
+    return cores, jobs
 
 
 def get_profile_file(profile, file, return_default=False):
@@ -2663,65 +2722,16 @@ def main(argv=None):
         or args.unlock
         or args.cleanup_metadata
     )
-    local_exec = not (no_exec or non_local_exec)
 
-    def parse_cores(cores):
-        if cores == "all":
-            return available_cpu_count()
-        else:
-            try:
-                return int(cores)
-            except ValueError:
-                print(
-                    "Error parsing number of cores (--cores, -c, -j): must be integer, empty, or 'all'.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-    if args.cores is not None:
-        args.cores = parse_cores(args.cores)
-        if local_exec:
-            # avoid people accidentally setting jobs as well
-            args.jobs = None
-    else:
-        if no_exec:
-            args.cores = 1
-        elif local_exec:
-            if args.jobs is not None:
-                args.cores = parse_cores(args.jobs)
-                args.jobs = None
-            elif args.dryrun:
-                # dryrun with single core if nothing specified
-                args.cores = 1
-            else:
-                print(
-                    "Error: you need to specify the maximum number of CPU cores to "
-                    "be used at the same time. If you want to use N cores, say --cores N or "
-                    "-cN. For all cores on your system (be sure that this is appropriate) "
-                    "use --cores all. For no parallelization use --cores 1 or -c1.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-    if non_local_exec:
-        if args.jobs is None:
-            print(
-                "Error: you need to specify the maximum number of jobs to "
-                "be queued or executed at the same time with --jobs or -j.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        elif args.jobs == "unlimited":
-            args.jobs = sys.maxsize
-        else:
-            try:
-                args.jobs = int(args.jobs)
-            except ValueError:
-                print(
-                    "Error parsing number of jobs (--jobs, -j): must be integer.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+    try:
+        cores, jobs = parse_cores_jobs(
+            args.cores, args.jobs, no_exec, non_local_exec, args.dryrun
+        )
+        args.cores = cores
+        args.jobs = jobs
+    except CliException as err:
+        print(err.msg, sys.stderr)
+        sys.exit(1)
 
     if args.drmaa_log_dir is not None:
         if not os.path.isabs(args.drmaa_log_dir):

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -568,3 +568,9 @@ class ResourceScopesException(Exception):
         super().__init__(msg, invalid_resources)
         self.msg = msg
         self.invalid_resources = invalid_resources
+
+
+class CliException(Exception):
+    def __init__(self, msg):
+        super().__init__(msg)
+        self.msg = msg


### PR DESCRIPTION
When running in any no-exec mode (e.g. `--dag`, `--report`), `--jobs` was getting left as a string, leading to workflow errors.

This PR takes the opportunity to refactor the jobs and cores parsing code, which was very convoluted. Parsing is split into three basic possibilities: `no_exec` mode, `non_local_exec` mode, and `local_mode`. `jobs` and `cores` are both set appropriately given the context.

A test is provided to test the new parsing function.

Resolves #1589


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
