### PR TITLE
fix: correctly parse empty values in config cli

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -1009,6 +1009,9 @@ def parse_config(args):
                     "Invalid config definition: Config entry must start with a valid identifier."
                 )
             v = None
+            if val == "":
+                update_config(config, {key: v})
+                continue
             for parser in parsers:
                 try:
                     v = parser(val)


### PR DESCRIPTION
Config values such as `--config arg=` were getting parsed as `None` by the `yaml_base_load` parser and failing the subsequent assertion `assert v is not None`. Instead, check first if val is a blank string.

This fix assumes we want blank strings to be a valid option for `--config` args, which seems reasonable to me. Otherwise, we need to explicitly check for blank strings and throw a better error.

Resolves #1903

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
