### PR TITLE
fix: make `--show-failed-logs` handle empty log files

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -474,9 +474,13 @@ class Logger:
                 except FileNotFoundError:
                     yield f"Logfile {f} not found."
                     return
-                logfile_header = f"Logfile {f}:"
-                yield logfile_header
                 lines = content.splitlines()
+                logfile_header = f"Logfile {f}:"
+                if not lines:
+                    logfile_header += " empty file"
+                    yield logfile_header
+                    return
+                yield logfile_header
                 max_len = max(max(len(l) for l in lines), len(logfile_header))
                 yield "=" * max_len
                 yield from lines


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

Fixes #2023 