### PR TITLE
fix: use short argument name for `--chdir` for compatibility with Slurm <=v17

### DIFF
--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -253,6 +253,8 @@ class SlurmExecutor(ClusterExecutor):
 
         exec_job = self.format_job_exec(job)
         # ensure that workdir is set correctly
+        # use short argument as this is the same in all slurm versions
+        # (see https://github.com/snakemake/snakemake/issues/2014)
         call += f" -D {self.workflow.workdir_init}"
         # and finally the job to execute with all the snakemake parameters
         call += f" --wrap={repr(exec_job)}"

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -253,7 +253,7 @@ class SlurmExecutor(ClusterExecutor):
 
         exec_job = self.format_job_exec(job)
         # ensure that workdir is set correctly
-        call += f" --chdir={self.workflow.workdir_init}"
+        call += f" -D {self.workflow.workdir_init}"
         # and finally the job to execute with all the snakemake parameters
         call += f" --wrap={repr(exec_job)}"
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

This would fix #2014 since the short argument is the same (`-D`) even if the long argument changed from `--workdir` to `--chdir` after Slurm 17:

https://slurm.schedmd.com/archive/slurm-17.02.0/sbatch.html
https://slurm.schedmd.com/sbatch.html