### PR TITLE
docs: Fix typo in SLURM help text

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2152,7 +2152,7 @@ def get_argument_parser(profile=None):
         action="store_true",
         help=(
             "Execute snakemake rules as SLURM batch jobs according"
-            " to their 'resources' definition. SLRUM resources as "
+            " to their 'resources' definition. SLURM resources as "
             " 'partition', 'ntasks', 'cpus', etc. need to be defined"
             " per rule within the 'resources' definition. Note, that"
             " memory can only be defined as 'mem_mb' or 'mem_mb_per_cpu'"


### PR DESCRIPTION
### Description

I noticed this typo in the documentation, but could only find the text in the actual source code. I assume something is copying help text into the docs, but if it's hiding somewhere else, please let me know.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
