### PR TITLE
fix: skip type checks of missing dir in touch mode

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -594,12 +594,20 @@ class DAG:
                     jobid=self.jobid(job),
                 )
 
-        # Ensure that outputs are of the correct type (those flagged with directory()
-        # are directories and not files and vice versa). We can't check for remote objects.
+        def correctly_flagged_with_dir(f):
+            """Check that files flagged as directories are in fact directories
+
+            In ambiguous cases, such as when f is remote, or f doesn't exist and
+            ignore_missing_output is true, always return True
+            """
+            if f.remote_object:
+                return True
+            if ignore_missing_output and not os.path.exists(f):
+                return True
+            return not (f.is_directory ^ os.path.isdir(f))
+
         for f in expanded_output:
-            if (f.is_directory and not f.remote_object and not os.path.isdir(f)) or (
-                not f.remote_object and os.path.isdir(f) and not f.is_directory
-            ):
+            if not correctly_flagged_with_dir(f):
                 raise ImproperOutputException(job, [f])
 
         # Handle ensure flags

--- a/tests/test_touch_with_directories/Snakefile
+++ b/tests/test_touch_with_directories/Snakefile
@@ -1,2 +1,6 @@
+# need a dummy file in expected-results in order to commit it to git
+with open("out", 'w'):
+    pass
+
 rule a:
     output: directory('output/'),

--- a/tests/test_touch_with_directories/Snakefile
+++ b/tests/test_touch_with_directories/Snakefile
@@ -1,0 +1,2 @@
+rule a:
+    output: directory('output/'),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -323,6 +323,10 @@ def test_touch():
     run(dpath("test_touch"))
 
 
+def test_touch_flag_with_directories():
+    run(dpath("test_touch_with_directories"), touch=True)
+
+
 def test_config():
     run(dpath("test_config"))
 


### PR DESCRIPTION
When using the --touch flag, missing files are disregarded by dag.check_and_touch_output. This same function also checks that directory outputs are correctly labelled with `directory()` and vice-versa. This test was failing when the file was missing.

This patch skips the test when the file is missing.

Resolves #211


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
