### PR TITLE
fix: propagate attempt count from group to subjobs

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2525,8 +2525,8 @@ class DAG:
 
             for group in pipe_groups.values():
                 sorted_layer.extend(
-                    chain(
-                        *toposort(
+                    chain.from_iterable(
+                        toposort(
                             {
                                 job: {
                                     dep

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1560,6 +1560,8 @@ class GroupJob(AbstractJob):
     def attempt(self, attempt):
         # reset resources
         self._resources = None
+        for job in self.jobs:
+            job.attempt = attempt
         self._attempt = attempt
 
     @property

--- a/tests/test_group_jobs_attempts/Snakefile
+++ b/tests/test_group_jobs_attempts/Snakefile
@@ -1,0 +1,17 @@
+rule a:
+    output: "a"
+    resources: mem_mb = lambda w, attempt: attempt*1000
+    group: "mygroup"
+    shell: '''
+    if [ {resources.mem_mb} == 2000 ]; then
+        touch {output}
+    fi
+    '''
+
+# rule b:
+#     input: rules.a.output
+#     output: "b_{number}"
+#     group: "mygroup"
+#     shell: '''
+#     touch -m {output}
+#     '''

--- a/tests/test_group_jobs_attempts/qsub
+++ b/tests/test_group_jobs_attempts/qsub
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo `date` >> qsub.log
+tail -n1 $1 >> qsub.log
+# simulate printing of job id by a random number
+echo $RANDOM
+sh $1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -930,6 +930,11 @@ def test_group_jobs():
     run(dpath("test_group_jobs"), cluster="./qsub")
 
 
+@skip_on_windows
+def test_group_jobs_attempts():
+    run(dpath("test_group_jobs_attempts"), cluster="./qsub", restart_times=2)
+
+
 def assert_resources(resources: dict, **expected_resources):
     assert {res: resources[res] for res in expected_resources} == expected_resources
 


### PR DESCRIPTION
Attempts was getting updated on the group job, but not getting updated on the group job's member jobs. This prevented the member job resources calculations from being updated, preventing the correct functioning of resource lambdas in the group job context.

This propagates the update to the members and adds a test

Resolves #2045

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
