### PR TITLE
fix: parsing error when last line is comment

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -142,6 +142,8 @@ class KeywordState(TokenAutomaton):
         return self.__class__.__name__.lower()[len(self.prefix) :]
 
     def end(self):
+        # Add newline to prevent https://github.com/snakemake/snakemake/issues/1943
+        yield "\n"
         yield ")"
 
     def decorate_end(self, token):

--- a/tests/test_parsing_terminal_comment_following_statement/Snakefile
+++ b/tests/test_parsing_terminal_comment_following_statement/Snakefile
@@ -1,0 +1,3 @@
+rule all:
+    output: touch('done')
+#include: "tmp/t2.smk" $ snakemake -s merge.smk -j 1 -p

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1554,6 +1554,10 @@ def test_scatter_gather():
 # SLURM tests go here, after successfull tests
 
 
+def test_parsing_terminal_comment_following_statement():
+    run(dpath("test_parsing_terminal_comment_following_statement"))
+
+
 @skip_on_windows
 def test_github_issue640():
     run(


### PR DESCRIPTION
This occurred when a file-terminating comment was followed a keyword, as the closing parentheses would be put on the same line as the comment and not seen by the parser, leading to a syntax error.

Fix by adding a newline before the closing parentheses. Adds a test case based on the original report.

Resolves #1943


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
