### PR TITLE
fix: Postprocess job groups in toposorted order for correct touch times

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1461,7 +1461,9 @@ class GroupJob(AbstractJob):
             job.cleanup()
 
     def postprocess(self, error=False, **kwargs):
-        for job in self.jobs:
+        # Iterate over jobs in toposorted order (see self.__iter__) to
+        # ensure that outputs are touched in correct order.
+        for job in self:
             job.postprocess(error=error, **kwargs)
         # remove all pipe and service outputs since all jobs of this group are done and the
         # outputs are no longer needed

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1463,8 +1463,12 @@ class GroupJob(AbstractJob):
     def postprocess(self, error=False, **kwargs):
         # Iterate over jobs in toposorted order (see self.__iter__) to
         # ensure that outputs are touched in correct order.
-        for job in self:
-            job.postprocess(error=error, **kwargs)
+        for level in self.toposorted:
+            for job in level:
+                # postprocessing involves touching output files (to ensure that
+                # modification times are always correct. This has to happen in
+                # topological order, such that they are not mixed up.
+                job.postprocess(error=error, **kwargs)
         # remove all pipe and service outputs since all jobs of this group are done and the
         # outputs are no longer needed
         for job in self.jobs:


### PR DESCRIPTION
### Description

If I understand the mechanics correctly, jobs in job groups executed on clusters get "postprocessed", and as part of this their output files are touched. However, the order in which this happened was not necessarily a topological order, meaning that output files of dependent rules could be touched in the "wrong" order. See https://github.com/snakemake/snakemake/issues/789

This simple change just ensures that jobs are post-processed in topological order, which should solve the above issue.

If desirable, I could also writing a test for the above behaviour to catch potential future issues.

### QC
* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
