### PR TITLE
feat: Add support for tokens in the XRootD interface

### DIFF
--- a/docs/snakefiles/remote_files.rst
+++ b/docs/snakefiles/remote_files.rst
@@ -510,6 +510,14 @@ This flag can be overridden on a file by file basis as described in the S3 remot
         shell:
             'xrdcp {input[0]} {output[0]}'
 
+In order to access the files using autorization tokens, the "url_decorator" parameter can be used to append the necessary string to the URL e.g.
+
+.. code-block:: python
+
+    from snakemake.remote.XRootD import RemoteProvider as XRootDRemoteProvider
+    XRootD = XRootDRemoteProvider(stay_on_remote=True, url_decorator=lambda x: x + "?xrd.wantprot=unix&authz=XXXXXX")
+    
+
 GenBank / NCBI Entrez
 =====================
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1503,7 +1503,12 @@ class Namedlist(list):
             if custom_map is not None:
                 self.extend(map(custom_map, toclone))
             elif plainstr:
-                self.extend(map(str, toclone))
+                self.extend(
+                    x.remote_object.to_plainstr()
+                    if isinstance(x, _IOFile) and x.remote_object is not None
+                    else str(x)
+                    for x in toclone
+                )
             elif strip_constraints:
                 self.extend(map(strip_wildcard_constraints, toclone))
             else:

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -217,6 +217,12 @@ class AbstractRemoteObject:
     def remote_file(self):
         return self.protocol + self.local_file()
 
+    def to_plainstr(self):
+        if self.stay_on_remote:
+            return str(self.remote_file())
+        else:
+            return str(self.local_file())
+
     @abstractmethod
     def close(self):
         pass


### PR DESCRIPTION
### Description

Support for tokens in the interface with XRootD.
As the tokens used by EOS at CERN are URL parameters, this PR allows adding them when needed (an extra "decorator" parameter has been introduced) 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).