### PR TITLE
fix: more robust encoding of params in persistent metadata storage. This way, pandas parameters do not lead to spurious rerun triggers.

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -36,6 +36,7 @@ class Persistence:
 
         try:
             import pandas as pd
+
             self._serialize_param = self._serialize_param_pandas
         except ImportError:
             self._serialize_param = self._serialize_param_builtin
@@ -440,20 +441,40 @@ class Persistence:
         return sorted(job.log)
 
     def _serialize_param_builtin(self, param):
-        if isinstance(param, (int, float, bool, str, complex, range, list, tuple, dict, set, frozenset, bytes, bytearray)):
+        if isinstance(
+            param,
+            (
+                int,
+                float,
+                bool,
+                str,
+                complex,
+                range,
+                list,
+                tuple,
+                dict,
+                set,
+                frozenset,
+                bytes,
+                bytearray,
+            ),
+        ):
             return repr(param)
         else:
             return None
 
     def _serialize_param_pandas(self, param):
         import pandas as pd
+
         if isinstance(param, (pd.DataFrame, pd.Series, pd.Index)):
             return repr(pd.util.hash_pandas_object(param).tolist())
         return self._serialize_param_builtin(param)
 
     @lru_cache()
     def _params(self, job):
-        return sorted(filter(lambda p: p is not None, map(self._serialize_param, job.params)))
+        return sorted(
+            filter(lambda p: p is not None, map(self._serialize_param, job.params))
+        )
 
     @lru_cache()
     def _output(self, job):


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
