### PR TITLE
feat: Proper recursive naming of rules and construction of prefixes in nested modules

### DIFF
--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -185,7 +185,11 @@ class WorkflowModifier:
         self.rule_exclude_list = rule_exclude_list
         self.ruleinfo_overwrite = ruleinfo_overwrite
         self.allow_rule_overwrite = allow_rule_overwrite
+
+        self.replace_prefix = replace_prefix
+        self.prefix = prefix
         self.path_modifier = PathModifier(replace_prefix, prefix, workflow)
+
         self.replace_wrapper_tag = replace_wrapper_tag
         self.namespace = namespace
 
@@ -209,10 +213,34 @@ class WorkflowModifier:
             return pattern.sub(self.replace_wrapper_tag + "/", wrapper_uri)
 
     def __enter__(self):
+        # replace flat rule naming by deep rule naming
+        self._flat_rulename_modifier = self.rulename_modifier
+        if self.workflow.modifier_stack[-1].rulename_modifier is not None:
+            parent_modifier = self.workflow.modifier_stack[-1]
+            self.rulename_modifier = lambda n: parent_modifier.rulename_modifier(
+                    self._flat_rulename_modifier(n))
+
+        # replace flat prefix by deep prefix
+        self._flat_path_modifier = self.path_modifier
+        if self.workflow.modifier_stack[-1].path_modifier.prefix is not None:
+            parent_prefix = self.workflow.modifier_stack[-1].path_modifier.prefix
+            # replace flat path modifier by deep path modifier
+            if self._flat_path_modifier.prefix is not None:
+                full_prefix = parent_prefix + self._flat_path_modifier.prefix
+            else:
+                full_prefix = parent_prefix
+        else:
+            full_prefix = self._flat_path_modifier.prefix
+
+        self.path_modifier = PathModifier(self.replace_prefix,
+                                          full_prefix, self.workflow)
+
         # put this modifier on the stack, it becomes the currently valid modifier
         self.workflow.modifier_stack.append(self)
 
     def __exit__(self, type, value, traceback):
+        self.rulename_modifier = self._flat_rulename_modifier
+        self.path_modifier = self._flat_path_modifier
         # remove this modifier from the stack
         self.workflow.modifier_stack.pop()
         if self.namespace:


### PR DESCRIPTION
### Description

This PR suggests a quick and dirty modification to achieve recursive renaming of rules and prefixing of paths in nested modules, addressing https://github.com/snakemake/snakemake/issues/2084, or the earlier https://github.com/snakemake/snakemake/issues/1626 .

I expect this to break stuff. But it does what I need it to do.

After applying the modification, I realized that another PR with the same aim exists already, https://github.com/snakemake/snakemake/pull/1625 . I am suggesting this PR anyway, since the other has not been discussed yet neither, and the implementations differ.

Will fill in samples and tests when able to find some time.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
