### PR TITLE
Adding option to redirect shell stdout and stderr to log files

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1682,7 +1682,7 @@ class Log(Namedlist):
             dirname = os.path.dirname(path)
             if any(dirname) and not os.path.exists(dirname):
                 os.makedirs(dirname)
-        return {name: open(value, "w") for name, value in _streams.items()}
+        return {name: open(value, "a") for name, value in _streams.items()}
 
 
 def _load_configfile(configpath_or_obj, filetype="Config"):

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -3,9 +3,11 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import _io
 import collections
 from hashlib import sha256
 import os
+import sys
 import shutil
 from pathlib import Path
 import re
@@ -31,6 +33,12 @@ from snakemake.exceptions import (
 from snakemake.logging import logger
 from inspect import isfunction, ismethod
 from snakemake.common import DYNAMIC_FILL, ON_WINDOWS, async_run
+
+STDOUT = sys.stdout
+if not isinstance(sys.stdout, _io.TextIOWrapper):
+    # workaround for nosetest since it overwrites sys.stdout
+    # in a strange way that does not work with Popen
+    STDOUT = None
 
 
 class Mtime:
@@ -1667,22 +1675,43 @@ class LogStreamError(AttributeError):
 
 
 class Log(Namedlist):
-    def streams(self):
+    def streams(self, capture_stdout=False):
         _streams = {
-            name: str(value)
+            name: value
             for name, value in self.items()
             if name in ("std", "stderr", "stdout")
         }
+
+        for name, value in _streams.items():
+            if isinstance(value, tuple) or isinstance(value, list) or isinstance(value, dict):
+                raise LogStreamError(
+                    "Log stream called '{}' has more than one entry.".format(name)
+                )
+            _streams[name] = str(value)
+
         if "std" in _streams and ("stderr" in _streams or "stdout" in _streams):
             raise LogStreamError("Can't combine std stream with stdout/stderr.")
-        if any(path for path in _streams.values() if " " in path):
-            raise LogStreamError("Std output stream has more than one entry.")
 
         for path in _streams.values():
             dirname = os.path.dirname(path)
             if any(dirname) and not os.path.exists(dirname):
                 os.makedirs(dirname)
-        return {name: open(value, "a") for name, value in _streams.items()}
+
+        if capture_stdout:
+            _streams.pop("stdout", None)
+        if "std" in _streams:
+            stream = open(_streams["std"], "a")
+            _streams = {"stdout": stream, "stderr": stream}
+        else:
+            _streams = {
+                name: open(value, "a") for name, value in _streams.items()
+            }
+        if capture_stdout:
+            _streams["stdout"] = sp.PIPE
+        elif "stdout" not in _streams:
+            _streams["stdout"] = STDOUT
+
+        return _streams
 
 
 def _load_configfile(configpath_or_obj, filetype="Config"):

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -291,7 +291,7 @@ class shell:
 
         ret = None
         if iterable:
-            return cls.iter_stdout(proc, cmd, tmpdir)
+            return cls.iter_stdout(proc, cmd, tmpdir, output_streams)
         if read:
             ret = proc.stdout.read()
         if bench_record is not None:
@@ -318,12 +318,15 @@ class shell:
         return ret
 
     @staticmethod
-    def iter_stdout(proc, cmd, tmpdir):
+    def iter_stdout(proc, cmd, tmpdir, output_streams):
         for l in proc.stdout:
             yield l[:-1]
         retcode = proc.wait()
         if tmpdir:
             shutil.rmtree(tmpdir)
+        for stream in output_streams.values():
+            if stream != sp.STDOUT:
+                stream.close()
         if retcode:
             raise sp.CalledProcessError(retcode, cmd)
 

--- a/tests/test_output_redirection/Snakefile
+++ b/tests/test_output_redirection/Snakefile
@@ -45,7 +45,9 @@ rule redirect_output_no_overwrite1:
         echo 1 >> /dev/stdout
         """
 
-rule redirect_output_no_overwrite2:
+rule redirect_output_no_overwrite:
+    input:
+        "no_overwrite1.txt"
     output:
         "no_overwrite2.txt"
     log:
@@ -55,13 +57,6 @@ rule redirect_output_no_overwrite2:
         touch {output}
         echo 2 >> /dev/stdout
         """
-
-rule redirect_output_no_overwrite:
-    output:
-        touch("no_overwrite.txt")
-    input:
-        "no_overwrite1.txt",
-        "no_overwrite2.txt"
 
 rule redirect_output_multiple_std:
     output:

--- a/tests/test_output_redirection/Snakefile
+++ b/tests/test_output_redirection/Snakefile
@@ -1,28 +1,89 @@
-
 rule redirect_output:
     output: "output.txt"
+    log:
+        stdout="output.log",
+        stderr="output.err"
+    shell:
+        """
+        touch {output}
+        echo stdout log >> /dev/stdout
+        echo stderr log >> /dev/stderr
+        """
 
-    log: stdout="output.log", stderr="output.err"
-    shell: """touch {output}
-      echo stdout log >> /dev/stdout
-      echo stderr log >> /dev/stderr
-      """
+rule redirect_output_combined:
+    output:
+        "combined.txt"
+    log:
+        std="combined.log"
+    shell: 
+        """
+        touch {output}
+        echo stdout log >> /dev/stdout
+        echo stderr log >> /dev/stderr
+        """
 
+rule redirect_output_manual_pipe:
+    output:
+        "manual_pipe.txt"
+    log:
+        stdout="manual_pipe.log"
+    shell:
+        """
+        touch {output}
+        echo stdout log >> /dev/stdout
+        echo stdout log piped >> {log.stdout}
+        """
 
-rule redirect_output_combine:
-    output: "combined.txt"
+rule redirect_output_no_overwrite1:
+    output:
+        "no_overwrite1.txt"
+    log:
+        stdout="no_overwrite.log"
+    shell:
+        """
+        touch {output}
+        echo 1 >> /dev/stdout
+        """
 
-    log: std="output.log"
-    shell: """touch {output}
-      echo stdout log >> /dev/stdout
-      echo stderr log >> /dev/stderr
-      """
+rule redirect_output_no_overwrite2:
+    output:
+        "no_overwrite2.txt"
+    log:
+        stdout="no_overwrite.log"
+    shell:
+        """
+        touch {output}
+        echo 2 >> /dev/stdout
+        """
 
+rule redirect_output_no_overwrite:
+    output:
+        touch("no_overwrite.txt")
+    input:
+        "no_overwrite1.txt",
+        "no_overwrite2.txt"
 
-rule two_stdouts:
-    output: "two_stdouts.txt"
-    log: std=["output.log", "other.log"]
-    shell: """touch {output}
-      echo stdout log >> /dev/stdout
-      echo stderr log >> /dev/stderr
-      """
+rule redirect_output_multiple_std:
+    output:
+        "multiple_std.txt"
+    log:
+        std=["multiple_std1.log", "multiple_std2.log"]
+    shell:
+        """
+        touch {output}
+        echo stdout log >> /dev/stdout
+        echo stderr log >> /dev/stderr
+        """
+
+rule redirect_output_std_collision:
+    output:
+        "std_collision.txt"
+    log:
+        std="std_collision.log",
+        stdout="std_collision.log"
+    shell: 
+        """
+        touch {output}
+        echo stdout log >> /dev/stdout
+        echo stderr log >> /dev/stderr
+        """

--- a/tests/test_output_redirection/Snakefile.compile_error
+++ b/tests/test_output_redirection/Snakefile.compile_error
@@ -1,8 +1,0 @@
-
-rule main_target:
-    output: "combined_err.txt"
-    log: std="output.log", stdout="other.log"
-    shell: """touch {output}
-      echo stdout log >> /dev/stdout
-      echo stderr log >> /dev/stderr
-      """

--- a/tests/test_output_redirection/expected-results/combined.log
+++ b/tests/test_output_redirection/expected-results/combined.log
@@ -1,0 +1,2 @@
+stdout log
+stderr log

--- a/tests/test_output_redirection/expected-results/manual_pipe.log
+++ b/tests/test_output_redirection/expected-results/manual_pipe.log
@@ -1,0 +1,2 @@
+stdout log
+stdout log piped

--- a/tests/test_output_redirection/expected-results/output.err
+++ b/tests/test_output_redirection/expected-results/output.err
@@ -1,0 +1,1 @@
+stderr log

--- a/tests/test_output_redirection/expected-results/output.log
+++ b/tests/test_output_redirection/expected-results/output.log
@@ -1,0 +1,1 @@
+stdout log

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,6 +1,0 @@
-from snakemake.shell import shell
-
-
-def test_collect_stdout():
-    output = shell("echo test output", read=True)
-    assert output == b"test output\n"


### PR DESCRIPTION
### Description

This PR picks up where @tylergannon left off in #289. Since I don't have access to that branch, I've opened a new PR to try to get that contribution over the finish line, but if it would be better to do this some other way, I'm happy to do that!

Besides the changes that @tylergannon already implemented, I've started addressing @johanneskoester's comments from that PR:

1. I've added a test to cover the case where a user explicitly pipes to a log file called `stdout`. This works as expected: the log file contains both the process' stdout and the piped output.
2. The log files are now explicitly closed after the process exits.

My main open question is that in #289, @johanneskoester [commented](https://github.com/snakemake/snakemake/pull/289#discussion_r399346400):

> The log files should be opened in append mode, such that multiple shell commands below each other don't overwrite their output.

I switched the log files to be opened in append mode, but I'm not sure exactly what kind of workflow @johanneskoester was referring to here, or even really what the expected behavior is for multiple uses of the same log file. I added a test (which fails) for what I thought this was supposed to mean, but if anyone has tips for how to test this, I'd love to hear them!

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
