### PR TITLE
perf: Improve execution speed of cleanup_workdir (in dag) 

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -277,8 +277,11 @@ class DAG:
                     for io_file in chain(job.output, job.input)
                     if not os.path.exists(io_file)
                 ):
-                    if os.path.exists(io_dir) and not len(os.listdir(io_dir)):
-                        os.removedirs(io_dir)
+                    if os.path.exists(io_dir):
+                        # check for empty dir
+                        with os.scandir(io_dir) as i:
+                            if next(i, None) is None:
+                                os.removedirs(io_dir)
 
     def cleanup(self):
         self.job_cache.clear()


### PR DESCRIPTION
### Description

The new version uses scandir instead of listdir, so it uses an iterator-based approach to detect whether a directory is empty or not. 
The execution time of the old version depended on the number of files in the directory, while the new version should be more or less constant.

### Benchmark
200K files in a directory mounted over nfs:

timeit (new version):
```
if os.path.exists(io_dir):
    with os.scandir(io_dir) as i:
        if next(i, None) is None:
```
--> 1.98 ms ± 22.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

timeit (old version):
`if os.path.exists(io_dir) and not len(os.listdir(io_dir)):`
--> 50.4 ms ± 169 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

### QC
<!-- Make sure that you can tick the boxes below. -->
No new function was added.
* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
