### PR TITLE
feat: Publish docker images for amd64 & arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,9 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: snakemake/snakemake
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
+        platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM bitnami/minideb:buster
-MAINTAINER Johannes Köster <johannes.koester@tu-dortmund.de>
+LABEL org.opencontainers.image.authors="Johannes Köster <johannes.koester@tu-dortmund.de>"
 ADD . /tmp/repo
 WORKDIR /tmp/repo
 ENV PATH /opt/conda/bin:${PATH}
 ENV LANG C.UTF-8
 ENV SHELL /bin/bash
 RUN install_packages wget curl bzip2 ca-certificates gnupg2 squashfs-tools git
-RUN /bin/bash -c "curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh > mambaforge.sh && \
+RUN /bin/bash -c "curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-\$(uname -m).sh > mambaforge.sh && \
     bash mambaforge.sh -b -p /opt/conda && \
     conda config --system --set channel_priority strict && \
     rm mambaforge.sh"


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

Hello! New to snakemake, but excited to be here. Had to make a couple of tweaks to the Dockerfile as I'm running on a newer mac and figured I'd try to contribute back.

1. Updated Dockerfile to download correct Mambaforge based on container architecture
    - Used `uname -m` rather than [docker's `$TARGETARCH`](https://docs.docker.com/build/building/multi-platform/) as it outputs what Mambaforge is expecting (`aarch64` & `x86_64`)
    - Can test building for different platforms using ex. `docker build . --platform linux/amd64`
2. Update github action to publish both architectures via Github actions 
    - Was not able to test this directly, but [copied right from the action documentation](https://github.com/elgohr/Publish-Docker-Github-Action#platforms)
3. Noticed VSCode complaining about the `MAINTAINER` key so swapped that out
    - [See the deprecation notice in the docs here](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
