### PR TITLE
fix: issue with aggregated checkpoint output on GLS

### DIFF
--- a/tests/test_cloud_checkpoints_issue2021/Snakefile
+++ b/tests/test_cloud_checkpoints_issue2021/Snakefile
@@ -1,0 +1,38 @@
+import os
+
+# This test file is adapted from this one:
+# https://github.com/snakemake/snakemake/blob/e03a3b42eea89d512290bf98ee7d77ce2e17447c/tests/test_cloud_checkpoints_issue574/Snakefile
+from snakemake.remote.GS import RemoteProvider as GSRemoteProvider
+GS = GSRemoteProvider()
+
+rule all:
+    input:
+        "landsat-data.txt.bz2"
+
+checkpoint copy:
+    input:
+        GS.remote("gcp-public-data-landsat/LC08/01/001/003/LC08_L1GT_001003_20170430_20170501_01_RT/LC08_L1GT_001003_20170430_20170501_01_RT_MTL.txt")
+    output:
+        directory("landsat-dir")
+    resources:
+        mem_mb=100
+    run:
+        shell('mkdir {output}')
+        for i in range(3):
+            shell('cp {input} {output}/landsat-data-$(date "+%s%N").txt')
+
+def get_files(wc):
+    checkpoint_output = checkpoints.copy.get().output[0]
+    query = os.path.join(checkpoint_output, "landsat-data-{s}.txt")
+    return expand(query, s=glob_wildcards(query).s)
+
+rule pack:
+    input: get_files
+    output:
+        "landsat-data.txt.bz2"
+    conda:
+        "env.yml"
+    log:
+        "logs/pack.log"
+    shell:
+        "cat {input} | bzip2 -c > {output}; echo successful > {log}"

--- a/tests/test_cloud_checkpoints_issue2021/config.json
+++ b/tests/test_cloud_checkpoints_issue2021/config.json
@@ -1,0 +1,1 @@
+{"message": "hahaha"}

--- a/tests/test_cloud_checkpoints_issue2021/env.yml
+++ b/tests/test_cloud_checkpoints_issue2021/env.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - bzip2

--- a/tests/test_google_lifesciences.py
+++ b/tests/test_google_lifesciences.py
@@ -169,6 +169,7 @@ def test_github_issue1460():
     finally:
         cleanup_google_storage(storage_prefix, bucket_name)
 
+
 @google_credentials
 def test_cloud_checkpoints_issue2021():
     """see Github issue #2021"""
@@ -186,4 +187,3 @@ def test_cloud_checkpoints_issue2021():
         )
     finally:
         cleanup_google_storage(storage_prefix, bucket_name)
-

--- a/tests/test_google_lifesciences.py
+++ b/tests/test_google_lifesciences.py
@@ -168,3 +168,22 @@ def test_github_issue1460():
         )
     finally:
         cleanup_google_storage(storage_prefix, bucket_name)
+
+@google_credentials
+def test_cloud_checkpoints_issue2021():
+    """see Github issue #2021"""
+    bucket_name = get_temp_bucket_name()
+    create_google_storage(bucket_name)
+    storage_prefix = "test_cloud_checkpoints_issue2021"
+    workdir = dpath("test_cloud_checkpoints_issue2021")
+    try:
+        run(
+            workdir,
+            use_conda=True,
+            default_remote_prefix="%s/%s" % (bucket_name, storage_prefix),
+            google_lifesciences=True,
+            google_lifesciences_cache=False,
+        )
+    finally:
+        cleanup_google_storage(storage_prefix, bucket_name)
+


### PR DESCRIPTION
resolves #2021

### Description
PR #1294 (from a year ago) added a simple test for checkpoints on the cloud.

This PR adds tests for a more complicated example where the output of the checkpoint is now aggregated over wildcards. In this case, we are trying to reproduce the behavior in #2021, in which Snakemake might be
1. rebuilding the DAG when it doesn't need to be and
2. applying the remote prefix to the checkpoint output more than once (as it did in #574)

Note that this PR does not yet contain a fix for the strange behavior. Our hope is just to reproduce things with the test suite at the moment. As noted in https://github.com/snakemake/snakemake/issues/574#issuecomment-701870887, it can be difficult to debug issues on the cloud because Snakemake redeploys a different version of itself in each cloud instance. But labeling this PR with `update-container-image` allows us to deploy a temporary version of the code from this PR.

### QC
* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
    The docs do not need updating in this case, since this PR simply adds tests and fixes a bug.
