### PR TITLE
fix: use text/markdown for long_description_content_type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description =
     language in python style. Snakemake workflows are essentially Python
     scripts extended by declarative code to define rules. Rules describe
     how to create output files from input files.
-long_description_content_type = text/plain
+long_description_content_type = text/markdown
 license = MIT
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
This minor edit changes the `long_description_content_type` to `text/markdown`. The current rendering on [PyPI](https://pypi.org/project/snakemake/7.22.0/) with `text/plain` is fixed width, whereas `text/markdown` should render it more normally.