### PR TITLE
feat: changed report layout to display menu always left of the results. For fullscreen, one can still hide the menu, which leads to automatic growth of the results

### DIFF
--- a/snakemake/report/template/components/app.js
+++ b/snakemake/report/template/components/app.js
@@ -18,8 +18,12 @@ class App extends React.Component {
 
     render() {
         return [
-            e(Navbar, { key: "navbar", app: this }),
-            e(ContentDisplay, { key: "content", app: this })
+            e(
+                "div",
+                { class: "flex flex-row w-screen h-screen" },
+                e(Navbar, { key: "navbar", app: this }),
+                e(ContentDisplay, { key: "content", app: this })
+            )
         ];
     }
 

--- a/snakemake/report/template/components/content.js
+++ b/snakemake/report/template/components/content.js
@@ -10,7 +10,7 @@ class ContentDisplay extends React.Component {
     render() {
         return e(
             "div",
-            { className: "flex items-center justify-center min-h-screen z-0" },
+            { className: "grow flex items-center justify-center min-h-screen" },
             this.renderContent()
         )
     }
@@ -21,11 +21,7 @@ class ContentDisplay extends React.Component {
             case "rulegraph":
                 return e(
                     "div",
-                    { className: "flex gap-3 p-3 items-start w-screen" },
-                    e(
-                        "div",
-                        { className: "w-1/5" }
-                    ),
+                    { className: "grow flex gap-3 p-3 items-start" },
                     e(
                         "div",
                         { className: "overflow-auto max-h-screen" },
@@ -62,12 +58,12 @@ class ContentDisplay extends React.Component {
             case "pdf":
                 return e(
                     "iframe",
-                    { src: this.props.app.state.contentPath, className: "w-screen h-screen" }
+                    { src: this.props.app.state.contentPath, className: "w-full h-screen" }
                 );
             case "text":
                 return e(
                     "div",
-                    { className: "p-3 w-3/4" },
+                    { className: "p-3 w-full" },
                     e(
                         "pre",
                         { className: "whitespace-pre-line text-sm" },

--- a/snakemake/report/template/components/navbar.js
+++ b/snakemake/report/template/components/navbar.js
@@ -7,21 +7,21 @@ class Navbar extends React.Component {
     }
 
     render() {
-        let translateNavbar = "";
-        let translateShowButton = "-translate-x-full"
+        let showHideNavbar = `${this.getWidth()}`;
+        let showHideShowButton = "-translate-x-full"
         if (this.props.app.state.hideNavbar) {
-            translateNavbar = "-translate-x-full";
-            translateShowButton = ""
+            showHideNavbar = "w-0";
+            showHideShowButton = ""
         }
         return [
             e(
                 "div",
-                { className: `fixed z-50 p-2 transition-translate bg-white/70 backdrop-blur-sm rounded-br-lg ${translateShowButton}` },
+                { className: `fixed z-50 p-2 transition-translate bg-white/70 backdrop-blur-sm rounded-br-lg ${showHideShowButton}` },
                 this.getShowButton()
             ),
             e(
                 "nav",
-                { className: `fixed z-50 transition-all ${translateNavbar} ${this.getWidth()} text-white text-sm bg-slate-900/70 backdrop-blur-sm h-screen overflow-auto` },
+                { className: `transition-all ${showHideNavbar} text-white text-sm bg-slate-900/70 backdrop-blur-sm h-screen overflow-auto` },
                 e(
                     "h1",
                     { className: "sticky relative top-0 left-0 bg-white/80 backdrop-blur-sm text-slate-700 text-l tracking-wide px-3 py-1 mb-1 flex items-center" },

--- a/snakemake/report/template/components/navbar.js
+++ b/snakemake/report/template/components/navbar.js
@@ -8,10 +8,10 @@ class Navbar extends React.Component {
 
     render() {
         let showHideNavbar = `${this.getWidth()}`;
-        let showHideShowButton = "-translate-x-full"
+        let showHideShowButton = "-translate-x-full";
         if (this.props.app.state.hideNavbar) {
             showHideNavbar = "w-0";
-            showHideShowButton = ""
+            showHideShowButton = "";
         }
         return [
             e(


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
