### PR TITLE
fix: limit length of failed logs decorations

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -479,7 +479,8 @@ class Logger:
                     yield logfile_header
                     return
                 yield logfile_header
-                max_len = max(max(len(l) for l in lines), len(logfile_header))
+                # take the length of the longest line, but limit to max 80
+                max_len = min(max(max(len(l) for l in lines), len(logfile_header)), 80)
                 yield "=" * max_len
                 yield from lines
                 yield "=" * max_len


### PR DESCRIPTION
### Description

Limit the maximum length of the decorations around the logfile output of a failed job (when `--show-failed-logs` is given) to 80.

Fixes #2101.


### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
