### PR TITLE
fix: #2130 by patching the protect() method so the path of files in subdirectories is properly resolved during write-protection

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -671,12 +671,14 @@ class _IOFile(str):
         mode = (
             os.lstat(self.file).st_mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH
         )
+        # iterate over content if output is a directory
         if os.path.isdir(self.file):
-            for root, dirs, files in os.walk(self.file):
-                for d in dirs:
-                    lchmod(os.path.join(self.file, d), mode)
-                for f in files:
-                    lchmod(os.path.join(root, f), mode)
+            # topdown=False ensures we chmod first the content, then the dir itself
+            for dirpath, dirnames, filenames in os.walk(self.file, topdown=False):
+                # no need to treat differently directories or files
+                for content in (dirnames + filenames):
+                    lchmod(os.path.join(dirpath, content), mode)
+        # protect explicit output itself
         lchmod(self.file, mode)
 
     def remove(self, remove_non_empty_dir=False):

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -676,7 +676,7 @@ class _IOFile(str):
             # topdown=False ensures we chmod first the content, then the dir itself
             for dirpath, dirnames, filenames in os.walk(self.file, topdown=False):
                 # no need to treat differently directories or files
-                for content in (dirnames + filenames):
+                for content in dirnames + filenames:
                     lchmod(os.path.join(dirpath, content), mode)
         # protect explicit output itself
         lchmod(self.file, mode)

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -676,7 +676,7 @@ class _IOFile(str):
                 for d in dirs:
                     lchmod(os.path.join(self.file, d), mode)
                 for f in files:
-                    lchmod(os.path.join(self.file, f), mode)
+                    lchmod(os.path.join(root, f), mode)
         lchmod(self.file, mode)
 
     def remove(self, remove_non_empty_dir=False):


### PR DESCRIPTION
…bdirectories is properly resolved during write-protection

### Description

<!--Add a description of your PR here-->

This is a very small change that ensures paths to files in subdirectories are properly resolved during write-protection of `directory()` outputs.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
