### PR TITLE
fix: ensure user and group rw permissions for metadata files and source cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
           CI: true
         shell: bash -el {0}
         run: |
-          pytest -v tests/test_slurm.py
+          pytest --show-capture=stderr -v tests/test_slurm.py
 
       - name: Test local
         env:
@@ -207,7 +207,7 @@ jobs:
           ZENODO_SANDBOX_PAT: "${{ secrets.ZENODO_SANDBOX_PAT }}"
         shell: bash -el {0}
         run: |
-          pytest -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/tests.py tests/test_schema.py tests/test_linting.py tests/tests.py
+          pytest --show-capture=stderr -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/tests.py tests/test_schema.py tests/test_linting.py tests/tests.py
       - name: Build and publish docker image
         if: >-
           contains(github.event.pull_request.labels.*.name,
@@ -240,7 +240,7 @@ jobs:
       - name: Test GA4GH TES executor
         shell: bash -el {0}
         run: |
-          pytest -s -v -x tests/test_tes.py
+          pytest --show-capture=stderr -s -v -x tests/test_tes.py
 
       - name: Delete container image
         if: >-
@@ -288,4 +288,4 @@ jobs:
           CI: true
           ZENODO_SANDBOX_PAT: "${{ secrets.ZENODO_SANDBOX_PAT }}"
         run: |
-          python -m pytest -v -x tests/tests.py
+          python -m pytest --show-capture=stderr -v -x tests/tests.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,6 +169,7 @@ jobs:
           mamba install -n snakemake "singularity<=3.8.6"
       - name: Setup apt dependencies
         run: |
+          sudo apt update
           sudo apt install -y stress git wget openmpi-bin libopenmpi-dev mariadb-server
       - name: Setup iRODS
         run: |

--- a/snakemake/caching/local.py
+++ b/snakemake/caching/local.py
@@ -66,11 +66,11 @@ class OutputFileCache(AbstractOutputFileCache):
             ):
                 if not os.path.exists(outputfile):
                     raise WorkflowError(
-                        "Cannot move output file {} to cache. It does not exist "
+                        f"Cannot move output file {outputfile} to cache. It does not exist "
                         "(maybe it was not created by the job?)."
                     )
                 self.check_writeable(cachefile)
-                logger.info("Moving output file {} to cache.".format(outputfile))
+                logger.info(f"Moving output file {outputfile} to cache.")
 
                 tmp = tmpdir / cachefile.name
                 # First move is performed into a tempdir (it might involve a copy if not on the same FS).

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -530,7 +530,9 @@ class Persistence:
         ) as tmpfile:
             json.dump(json_value, tmpfile)
         # ensure read and write permissions for user and group
-        os.chmod(tmpfile.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
+        os.chmod(
+            tmpfile.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP
+        )
         os.replace(tmpfile.name, recpath)
 
     def _delete_record(self, subject, id):

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -9,6 +9,7 @@ import signal
 import marshal
 import pickle
 import json
+import stat
 import tempfile
 import time
 from base64 import urlsafe_b64encode, b64encode
@@ -528,6 +529,8 @@ class Persistence:
             suffix=f".{os.path.basename(recpath)[:8]}",
         ) as tmpfile:
             json.dump(json_value, tmpfile)
+        # ensure read and write permissions for user and group
+        os.chmod(tmpfile.name, stat.IRUSR | stat.IWUSR | stat.IRGRP | stat.IWGRP)
         os.replace(tmpfile.name, recpath)
 
     def _delete_record(self, subject, id):

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -530,7 +530,7 @@ class Persistence:
         ) as tmpfile:
             json.dump(json_value, tmpfile)
         # ensure read and write permissions for user and group
-        os.chmod(tmpfile.name, stat.IRUSR | stat.IWUSR | stat.IRGRP | stat.IWGRP)
+        os.chmod(tmpfile.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
         os.replace(tmpfile.name, recpath)
 
     def _delete_record(self, subject, id):

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -8,6 +8,7 @@ import posixpath
 import re
 import os
 import shutil
+import stat
 from snakemake import utils
 import tempfile
 import io
@@ -416,6 +417,8 @@ class SourceCache:
             )
             tmp_source.write(source.read())
             tmp_source.close()
+            # ensure read and write permissions for owner and group
+            os.chmod(tmp_source.name, stat.IRUSR | stat.IWUSR | stat.IRGRP | stat.IWGRP)
             # Atomic move to right name.
             # This way we avoid the need to lock.
             shutil.move(tmp_source.name, cache_entry)

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -418,7 +418,10 @@ class SourceCache:
             tmp_source.write(source.read())
             tmp_source.close()
             # ensure read and write permissions for owner and group
-            os.chmod(tmp_source.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
+            os.chmod(
+                tmp_source.name,
+                stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP,
+            )
             # Atomic move to right name.
             # This way we avoid the need to lock.
             shutil.move(tmp_source.name, cache_entry)

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -418,7 +418,7 @@ class SourceCache:
             tmp_source.write(source.read())
             tmp_source.close()
             # ensure read and write permissions for owner and group
-            os.chmod(tmp_source.name, stat.IRUSR | stat.IWUSR | stat.IRGRP | stat.IWGRP)
+            os.chmod(tmp_source.name, stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
             # Atomic move to right name.
             # This way we avoid the need to lock.
             shutil.move(tmp_source.name, cache_entry)


### PR DESCRIPTION
This way, multiple users can more conveniently work on the same workdir.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
