### PR TITLE
fix: is_run error with local, group jobs

### DIFF
--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -674,7 +674,7 @@ class CPUExecutor(RealExecutor):
             error_callback(job)
         except (Exception, BaseException) as ex:
             self.print_job_error(job)
-            if self.workflow.verbose or (job.is_run and not job.is_group()):
+            if self.workflow.verbose or (not job.is_group() and job.is_run):
                 print_exception(ex, self.workflow.linemaps)
             error_callback(job)
 


### PR DESCRIPTION
### Description

Ran into a bug where executing a workflow locally causes a crash with group jobs.
```
    if self.workflow.verbose or (job.is_run and not job.is_group()):
                                 ^^^^^^^^^^
AttributeError: 'GroupJob' object has no attribute 'is_run'
```
Swapping the order of the checks fixes this issue; not sure why the CI didn't catch this bug.