### PR TITLE
fix: better job status queries for slurm executor 

### DIFF
--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -299,7 +299,9 @@ class SlurmExecutor(ClusterExecutor):
                     sacct_res = subprocess.check_output(
                         sacct_cmd, text=True, shell=True, stderr=subprocess.PIPE
                     )
-                    logger.debug(f"The sacct output is (took {time.time() - before_sacct} seconds):\n'{sacct_res}'")
+                    logger.debug(
+                        f"The sacct output is (took {time.time() - before_sacct} seconds):\n'{sacct_res}'"
+                    )
                     res = {
                         x.split("|")[0]: x.split("|")[1]
                         for x in sacct_res.strip().split("\n")
@@ -321,7 +323,9 @@ class SlurmExecutor(ClusterExecutor):
                             stderr=subprocess.PIPE,
                             text=True,
                         )
-                        logger.debug(f"The scontrol output is (took {time.time() - before_scontrol} seconds):\n'{out}'")
+                        logger.debug(
+                            f"The scontrol output is (took {time.time() - before_scontrol} seconds):\n'{out}'"
+                        )
                         m = re.search(r"JobState=(\w+)", out)
                         res = {jobid: m.group(1)}
                         break

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -105,7 +105,7 @@ class SlurmExecutor(ClusterExecutor):
         quiet=False,
         printshellcmds=False,
         restart_times=0,
-        max_status_checks_per_second=0.03,
+        max_status_checks_per_second=2,
         cluster_config=None,
     ):
         super().__init__(

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -384,4 +384,4 @@ class SlurmExecutor(ClusterExecutor):
 
             async with async_lock(self.lock):
                 self.active_jobs.extend(still_running)
-            time.sleep(1 / self.max_status_checks_per_second)
+            time.sleep(30)

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -293,11 +293,12 @@ class SlurmExecutor(ClusterExecutor):
             async with self.status_rate_limiter:
                 sacct_error = None
                 try:
+                    before_sacct = time.time()
                     sacct_cmd = f"sacct -P -n --format=JobIdRaw,State -j {jobid}"
                     sacct_res = subprocess.check_output(
                         sacct_cmd, text=True, shell=True, stderr=subprocess.PIPE
                     )
-                    logger.debug(f"The sacct output is: '{sacct_res}'")
+                    logger.debug(f"The sacct output is (took {time.time() - before_sacct} seconds):\n'{sacct_res}'")
                     res = {
                         x.split("|")[0]: x.split("|")[1]
                         for x in sacct_res.strip().split("\n")
@@ -311,6 +312,7 @@ class SlurmExecutor(ClusterExecutor):
                 # Try getting job with scontrol instead in case sacct is misconfigured
                 if not res:
                     try:
+                        before_scontrol = time.time()
                         sctrl_cmd = f"scontrol show jobid -dd {jobid}"
                         out = subprocess.check_output(
                             sctrl_cmd,
@@ -318,7 +320,7 @@ class SlurmExecutor(ClusterExecutor):
                             stderr=subprocess.PIPE,
                             text=True,
                         )
-                        logger.debug(f"The scontrol output is: '{out}'")
+                        logger.debug(f"The scontrol output is (took {time.time() - before_scontrol} seconds):\n'{out}'")
                         m = re.search(r"JobState=(\w+)", out)
                         res = {jobid: m.group(1)}
                         break

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -577,7 +577,7 @@ class JobScheduler:
                     )
                     logger.debug(
                         "Ready jobs ({})".format(len(needrun))
-                        #+ "\n\t".join(map(str, needrun))
+                        # + "\n\t".join(map(str, needrun))
                     )
 
                     if not self._last_job_selection_empty:
@@ -587,7 +587,7 @@ class JobScheduler:
 
                     logger.debug(
                         "Selected jobs ({})".format(len(run))
-                        #+ "\n\t".join(map(str, run))
+                        # + "\n\t".join(map(str, run))
                     )
                     logger.debug(
                         "Resources after job selection: {}".format(self.resources)

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -562,8 +562,8 @@ class JobScheduler:
                         "Resources before job selection: {}".format(self.resources)
                     )
                     logger.debug(
-                        "Ready jobs ({}):\n\t".format(len(needrun))
-                        + "\n\t".join(map(str, needrun))
+                        "Ready jobs ({})".format(len(needrun))
+#                        + "\n\t".join(map(str, needrun))
                     )
 
                     if not self._last_job_selection_empty:
@@ -572,8 +572,8 @@ class JobScheduler:
                     self._last_job_selection_empty = not run
 
                     logger.debug(
-                        "Selected jobs ({}):\n\t".format(len(run))
-                        + "\n\t".join(map(str, run))
+                        "Selected jobs ({})".format(len(run))
+#                        + "\n\t".join(map(str, run))
                     )
                     logger.debug(
                         "Resources after job selection: {}".format(self.resources)

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -577,7 +577,7 @@ class JobScheduler:
                     )
                     logger.debug(
                         "Ready jobs ({})".format(len(needrun))
-#                        + "\n\t".join(map(str, needrun))
+                        #+ "\n\t".join(map(str, needrun))
                     )
 
                     if not self._last_job_selection_empty:
@@ -587,7 +587,7 @@ class JobScheduler:
 
                     logger.debug(
                         "Selected jobs ({})".format(len(run))
-#                        + "\n\t".join(map(str, run))
+                        #+ "\n\t".join(map(str, run))
                     )
                     logger.debug(
                         "Resources after job selection: {}".format(self.resources)

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -194,11 +194,25 @@ class JobScheduler:
                 cores=local_cores,
                 keepincomplete=keepincomplete,
             )
-            # we need to adjust the maximum status checks on a
-            # SLURM cluster for not to overstrain the scheduler
-            if max_status_checks_per_second > 1:
-                # # every 30 sec is a resonable default
-                max_status_checks_per_second = 0.03
+            # we need to adjust the maximum status checks per second
+            # on a SLURM cluster, to not overstrain the scheduler;
+            # timings for tested SLURM clusters, extracted from --verbose
+            # output with:
+            # ```
+            #   grep "sacct output" .snakemake/log/2023-02-13T210004.601290.snakemake.log | \
+            #   awk '{ counter += 1; sum += $6; sum_of_squares += ($6)^2 } \
+            #     END { print "average: ",sum/counter," sd: ",sqrt((sum_of_squares - sum^2/counter) / counter); }
+            # ````
+            #   * cluster 1:
+            #     * sacct:    average:  0.073896   sd:  0.0640178
+            #     * scontrol: average:  0.0193017  sd:  0.0358858
+            # Thus, 2 status checks per second should leave enough
+            # capacity for everybody.
+            # TODO: check timings on other slurm clusters, to:
+            #   * confirm that this cap is reasonable
+            #   * check if scontrol is the quicker option across the board
+            if max_status_checks_per_second > 2:
+                max_status_checks_per_second = 2
 
             self._executor = SlurmExecutor(
                 workflow,


### PR DESCRIPTION
### Description

This PR changes two things:

1. Previously, checking `active_jobs` was only initiated after sleeping for `1/max_status_checks_per_second` seconds, which meant a minimum sleeping time of 30 seconds. This sleeping interval is now set to a fixed 30 seconds. However, one idea could also be to turn this into a new variable for the generic executor, and expose it to the user via a command-line argument -- it is also manually set for other executors (e.g. the google executor), and might require fine-tuning for specific workflows and/or clusters.
2. Previously, a `max_status_checks_per_second > 1` specified by the user was set down to `max_status_checks_per_second = 0.03` (no clue why there were different values in the comparison and the final setting) and the default value was also `0.03`. This means that only one job was checked for its status every 30 seconds. For workflows with hundreds or thousands of short-running jobs, this meant that it could easily take hours for finished jobs to be registered as `COMPLETED` and until that point, the respective resources were not available for scheduling new jobs. The new default and maximum of `max_status_checks_per_second = 2` considerably speeds this up, but stays well below the number of status checks that would be possible on the Slurm cluster I tested this on (which would be almost 20 for `sacct` and more than 50 for `scontrol`). Here, it would be useful if users on other Slurm clusters could check, whether `scontrol` is also always quicker for them, compared to `sacct`. If so, it would make sense to make `scontrol` the (cheaper) default (which also works for jobs that are not yet started), and `sacct` the fall-back (which also works for jobs that have already finished a while ago and might not be found by `scontrol` any more).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
