### PR TITLE
fix: `sre_constants` import because of deprecation

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -11,12 +11,16 @@ import typing
 from snakemake.path_modifier import PATH_MODIFIER_FLAG
 import sys
 import inspect
-import sre_constants
 import collections
 from urllib.parse import urljoin
 from pathlib import Path
 from itertools import chain
 from functools import partial
+
+try:
+    import re._constants as sre_constants
+except ImportError:  # python < 3.11
+    import sre_constants
 
 from snakemake.io import (
     IOFile,


### PR DESCRIPTION
- `sre_constants` is deprecated, the import statement was updated accordingly

### Description

The `re` module sources are being reorganized, see more information: https://github.com/python/cpython/issues/91308
Small fix accommodates changes for all python versions. 
