### PR TITLE
fix: require toposort >= 1.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,6 +169,9 @@ jobs:
           mamba install -n snakemake "singularity<=3.8.6"
       - name: Setup apt dependencies
         run: |
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
           sudo apt install -y stress git wget openmpi-bin libopenmpi-dev mariadb-server
       - name: Setup iRODS
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     stopit
     tabulate
     throttler
-    toposort
+    toposort >=1.10
     wrapt
     yte >=1.0,<2.0
 

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -49,7 +49,7 @@ dependencies:
   - tibanna
   - environment-modules
   - nbformat
-  - toposort
+  - toposort >=1.10
   - mamba
   - crc32c
   - pip


### PR DESCRIPTION
Closes #2134, speeds up DAG resolution through pulling in the latest `toposort` that leads to a 200x speedup of the `toposort()` function for larger DAGs, see:
https://gitlab.com/ericvsmith/toposort/-/merge_requests/4

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
