### PR TITLE
feat: limit the number of input/output files in job properties

### DIFF
--- a/docs/executing/cluster.rst
+++ b/docs/executing/cluster.rst
@@ -209,6 +209,10 @@ Adapting to a specific cluster can involve quite a lot of options. It is therefo
 Job Properties
 ~~~~~~~~~~~~~~
 
+.. sidebar:: Note
+
+    If there are more than 100 input and/or output files for a job, ``None`` will be used instead of listing all values. This is to prevent the jobscript from becoming larger than `Slurm jobscript size limits <https://slurm.schedmd.com/slurm.conf.html#OPT_max_script_size=#>`_.
+
 When executing a workflow on a cluster using the ``--cluster`` parameter (see below), Snakemake creates a job script for each job to execute. This script is then invoked using the provided cluster submission command (e.g. ``qsub``). Sometimes you want to provide a custom wrapper for the cluster submission command that decides about additional parameters. As this might be based on properties of the job, Snakemake stores the job properties (e.g. name, rulename, threads, input, output, params etc.) as JSON inside the job script (for group jobs, the rulename will be "GROUP", otherwise it will be the same as the job name). For convenience, there exists a parser function `snakemake.utils.read_job_properties` that can be used to access the properties. The following shows an example job submission wrapper:
 
 .. code-block:: python
@@ -231,3 +235,4 @@ When executing a workflow on a cluster using the ``--cluster`` parameter (see be
     job_properties["cluster"]["time"]
 
     os.system("qsub -t {threads} {script}".format(threads=threads, script=jobscript))
+

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1371,6 +1371,10 @@ With the ``touch`` flag, Snakemake touches (i.e. creates or updates) the file ``
 Job Properties
 --------------
 
+.. sidebar:: Note
+
+    If there are more than 100 input and/or output files for a job, ``None`` will be used instead of listing all values. This is to prevent the jobscript from becoming larger than `Slurm jobscript size limits <https://slurm.schedmd.com/slurm.conf.html#OPT_max_script_size=#>`_.
+
 When executing a workflow on a cluster using the ``--cluster`` parameter (see below), Snakemake creates a job script for each job to execute.
 This script is then invoked using the provided cluster submission command (e.g. ``qsub``).
 Sometimes you want to provide a custom wrapper for the cluster submission command that decides about additional parameters.

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -35,6 +35,9 @@ NOTHING_TO_BE_DONE_MSG = (
 )
 
 ON_WINDOWS = platform.system() == "Windows"
+# limit the number of input/output files list in job properties
+# see https://github.com/snakemake/snakemake/issues/2097
+IO_PROP_LIMIT = 100
 
 
 def mb_to_mib(mb):

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -40,7 +40,7 @@ from snakemake.common import (
     lazy_property,
     get_uuid,
     TBDString,
-    IO_PROP_LIMIT
+    IO_PROP_LIMIT,
 )
 
 

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -40,6 +40,7 @@ from snakemake.common import (
     lazy_property,
     get_uuid,
     TBDString,
+    IO_PROP_LIMIT
 )
 
 
@@ -999,8 +1000,8 @@ class Job(AbstractJob):
             "type": "single",
             "rule": self.rule.name,
             "local": self.is_local,
-            "input": self.input,
-            "output": self.output,
+            "input": None if len(self.input) > IO_PROP_LIMIT else self.input,
+            "output": None if len(self.output) > IO_PROP_LIMIT else self.output,
             "wildcards": self.wildcards_dict,
             "params": params,
             "log": self.log,
@@ -1432,8 +1433,8 @@ class GroupJob(AbstractJob):
             "type": "group",
             "groupid": self.groupid,
             "local": self.is_local,
-            "input": self.input,
-            "output": self.output,
+            "input": None if len(self.input) > IO_PROP_LIMIT else self.input,
+            "output": None if len(self.output) > IO_PROP_LIMIT else self.output,
             "threads": self.threads,
             "resources": resources,
             "jobid": self.jobid,


### PR DESCRIPTION
### Description

This PR closes #2097

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
