### PR TITLE
fix: prevents DeprecationWarning caused by using old  draft of json schema

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,7 +3,7 @@ import pytest
 from snakemake.utils import validate
 import pandas as pd
 
-CONFIG_SCHEMA = """$schema: "http://json-schema.org/draft-07/schema#"
+CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
 description: Configuration schema
 type: object
 properties:
@@ -31,7 +31,7 @@ BAR_JSON_SCHEMA = {
     }
 }
 
-DF_SCHEMA = """$schema: "http://json-schema.org/draft-04/schema#"
+DF_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
 description: an entry in the sample sheet
 properties:
   sample:

--- a/tests/test_validate/config.schema.yaml
+++ b/tests/test_validate/config.schema.yaml
@@ -1,4 +1,4 @@
-$schema: "http://json-schema.org/draft-06/schema#"
+$schema: "https://json-schema.org/draft/2020-12/schema#"
 
 description: snakemake configuration file
 

--- a/tests/test_validate/samples.schema.yaml
+++ b/tests/test_validate/samples.schema.yaml
@@ -1,4 +1,4 @@
-$schema: "https://json-schema.org/draft-06/schema#"
+$schema: "https://json-schema.org/draft/2020-12/schema#"
 description: an entry in the sample sheet
 properties:
   sample:


### PR DESCRIPTION

### Description
Prevents DeprecationWarning caused by using an old draft of JSON schema when running tests. updated JSON schema and use https.  


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

### Context

Run into this issue while sorting out documentation about testing.
