### PR TITLE
fix: get python version for script environment in a backwards compatible way that works down to python 2.7

### DIFF
--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -639,7 +639,7 @@ class PythonScript(ScriptBase):
         # stuff may be printed around in unpredictable ways.
         # The code below has to work with python 2.7 as well, therefore it should be written backwards compatible.
         out = self._execute_cmd(
-            'python -c "import sys, json; from __future__ import print_function; '
+            'python -c "from __future__ import print_function; import sys, json; '
             'print(json.dumps([sys.version_info.major, sys.version_info.minor]))"',
             read=True,
         )

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -634,8 +634,12 @@ class PythonScript(ScriptBase):
             return os.path.exists(os.path.join(prefix, "python.exe"))
 
     def _get_python_version(self):
+        # Obtain a clean version string. Using python --version is not reliable, because depending on the distribution
+        # stuff may be printed around in unpredictable ways.
+        # The code below has to work with python 2.7 as well, therefore it should be written backwards compatible.
         out = self._execute_cmd(
-            "python -c \"import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')\"",
+            "python -c \"import sys; from __future__ import print_function; "
+            "print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))\"",
             read=True,
         )
         try:

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -638,7 +638,7 @@ class PythonScript(ScriptBase):
         # stuff may be printed around in unpredictable ways.
         # The code below has to work with python 2.7 as well, therefore it should be written backwards compatible.
         out = self._execute_cmd(
-            "python -c \"import sys; from __future__ import print_function; "
+            'python -c "import sys; from __future__ import print_function; '
             "print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))\"",
             read=True,
         )

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -23,6 +23,7 @@ import pickle
 import subprocess
 import collections
 import re
+import json
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Tuple, Pattern, Union, Optional, List
@@ -638,12 +639,12 @@ class PythonScript(ScriptBase):
         # stuff may be printed around in unpredictable ways.
         # The code below has to work with python 2.7 as well, therefore it should be written backwards compatible.
         out = self._execute_cmd(
-            "python -c \"import sys; from __future__ import print_function; "
-            "print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))\"",
+            'python -c "import sys, json; from __future__ import print_function; '
+            'print(json.dumps([sys.version_info.major, sys.version_info.minor]))"',
             read=True,
         )
         try:
-            return tuple(map(int, out.strip().split(".")))
+            return tuple(json.loads(out))
         except ValueError as e:
             raise WorkflowError(
                 f"Unable to determine Python version from output '{out}': {e}"

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -638,7 +638,7 @@ class PythonScript(ScriptBase):
         # stuff may be printed around in unpredictable ways.
         # The code below has to work with python 2.7 as well, therefore it should be written backwards compatible.
         out = self._execute_cmd(
-            'python -c "import sys; from __future__ import print_function; '
+            "python -c \"import sys; from __future__ import print_function; "
             "print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))\"",
             read=True,
         )


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
