### PR TITLE
docs: fix minor typos in a linting rule

### DIFF
--- a/snakemake/linting/rules.py
+++ b/snakemake/linting/rules.py
@@ -103,10 +103,10 @@ class RuleLinter(Linter):
         if rule.is_run and len(func_code) > 70:
             yield Lint(
                 title="Migrate long run directives into scripts or notebooks",
-                body="Long run directives hamper workflow readability. Use the script or notebook direcive instead. "
+                body="Long run directives hamper workflow readability. Use the script or notebook directive instead. "
                 "Note that the script or notebook directive does not involve boilerplate. Similar to run, you "
                 "will have direct access to params, input, output, and wildcards."
-                "Only use the run direcive for a handful of lines.",
+                "Only use the run directive for a handful of lines.",
                 links=[links.external_scripts, links.notebooks],
             )
 


### PR DESCRIPTION
### Description

Minor PR to fix typos I saw while running `snakemake --lint`

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
