### PR TITLE
fix: slurm batch job status queries

### DIFF
--- a/snakemake/executors/slurm/slurm_jobstep.py
+++ b/snakemake/executors/slurm/slurm_jobstep.py
@@ -28,7 +28,7 @@ class SlurmJobstepExecutor(ClusterExecutor):
         printshellcmds=False,
         cluster_config=None,
         restart_times=0,
-        max_status_checks_per_second=1,
+        max_status_checks_per_second=0.5,
         **kwargs,
     ):
         # overwrite the command to execute a single snakemake job if necessary

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -316,6 +316,7 @@ class SlurmExecutor(ClusterExecutor):
                         ),
                         header=None,
                         delimiter="|",
+                        dtype=str,
                     ).values
                 )
             except pd.errors.EmptyDataError:

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -444,7 +444,7 @@ class SlurmExecutor(ClusterExecutor):
             # no jobs finished in the last query period
             if not active_jobs_ids - { j.jobid for j in still_running }:
                 # sleep a little longer, but never longer than a max
-                sleepy_time = min(sleepy_time + 20, 240)
+                sleepy_time = min(sleepy_time + 10, 120)
             else:
                 sleepy_time = MIN_SLEEP_TIME
             async with async_lock(self.lock):

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -430,7 +430,7 @@ class SlurmExecutor(ClusterExecutor):
                     # but the job should still be queueing or running and
                     # appear in slurmdbd (and thus `sacct` output) later
                     still_running.append(j)
-                    break
+                    continue
                 status = status_of_jobs[j.jobid]
                 if status == "COMPLETED":
                     j.callback(j.job)

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -316,7 +316,7 @@ class SlurmExecutor(ClusterExecutor):
                         ),
                         header=None,
                         delimiter="|",
-                    )
+                    ).values
                 )
             except pd.errors.EmptyDataError:
                 res = {}

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -308,13 +308,16 @@ class SlurmExecutor(ClusterExecutor):
                 f"It took: {query_duration} seconds\n"
                 f"The output is:\n'{command_res}'\n"
             )
-            res = dict(
-                pd.read_csv(
-                    StringIO(
-                        command_res
+            try:
+                res = dict(
+                    pd.read_csv(
+                        StringIO(
+                            command_res
+                        )
                     )
                 )
-            )
+            except pd.errors.EmptyDataError:
+                res = {}
         except subprocess.CalledProcessError as e:
             error = e.stderr
             pass

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -399,15 +399,20 @@ class SlurmExecutor(ClusterExecutor):
                         f"sacct -X --parsable2 --noheader --format=JobIdRaw,State --name {self.run_uuid}"
                     )
                     logger.debug(f"status_of_jobs after sacct is: {status_of_jobs}")
-                    ids_with_current_sacct_status = set(status_of_jobs.keys())
+                    # only take jobs that are still active
+                    active_jobs_ids_with_current_sacct_status = (
+                        set(status_of_jobs.keys()) & active_jobs_ids
+                    )
                     active_jobs_seen_by_sacct = (
-                        active_jobs_seen_by_sacct | ids_with_current_sacct_status
+                        active_jobs_seen_by_sacct
+                        | active_jobs_ids_with_current_sacct_status
                     )
                     logger.debug(
                         f"active_jobs_seen_by_sacct are: {active_jobs_seen_by_sacct}"
                     )
                     missing_sacct_status = (
-                        active_jobs_seen_by_sacct - ids_with_current_sacct_status
+                        active_jobs_seen_by_sacct
+                        - active_jobs_ids_with_current_sacct_status
                     )
                     if not missing_sacct_status:
                         break

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -342,6 +342,8 @@ class SlurmExecutor(ClusterExecutor):
         # intialize time to sleep in seconds
         MIN_SLEEP_TIME = 20
         sleepy_time = MIN_SLEEP_TIME
+        # only start checking statuses after bit -- otherwise nothing has been committed
+        time.sleep(sleepy_time)
         while True:
             # Initialize all query durations to specified 
             # 5 times the status_rate_limiter, to hit exactly

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from functools import partial
 from io import StringIO
 from fractions import Fraction
+import csv
 import os
 import re
 import stat
@@ -13,7 +14,6 @@ import subprocess
 import tarfile
 import tempfile
 import uuid
-import pandas as pd
 
 from snakemake.jobs import Job
 from snakemake.logging import logger
@@ -308,19 +308,7 @@ class SlurmExecutor(ClusterExecutor):
                 f"It took: {query_duration} seconds\n"
                 f"The output is:\n'{command_res}'\n"
             )
-            try:
-                res = dict(
-                    pd.read_csv(
-                        StringIO(
-                            command_res
-                        ),
-                        header=None,
-                        delimiter="|",
-                        dtype=str,
-                    ).values
-                )
-            except pd.errors.EmptyDataError:
-                res = {}
+            res = { entry[0]:entry[1] for entry in csv.reader( StringIO( command_res ), delimiter="|") }
         except subprocess.CalledProcessError as e:
             error = e.stderr
             pass

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -308,7 +308,10 @@ class SlurmExecutor(ClusterExecutor):
                 f"The output is:\n'{command_res}'\n"
             )
             res = {
-                entry[0]: entry[1]
+                # We split the second field in the output, as the State field
+                # could contain info beyond the JOB STATE CODE according to:
+                # https://slurm.schedmd.com/sacct.html#OPT_State
+                entry[0]: entry[1].split(sep=None, maxsplit=1)[0]
                 for entry in csv.reader(StringIO(command_res), delimiter="|")
             }
         except subprocess.CalledProcessError as e:

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -109,7 +109,7 @@ class SlurmExecutor(ClusterExecutor):
         quiet=False,
         printshellcmds=False,
         restart_times=0,
-        max_status_checks_per_second=2,
+        max_status_checks_per_second=0.5,
         cluster_config=None,
     ):
         super().__init__(

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -366,11 +366,12 @@ class SlurmExecutor(ClusterExecutor):
                 active_jobs_ids = { j.jobid for j in active_jobs }
                 self.active_jobs = list()
                 still_running = list()
-            STATUS_ATTEMPTS = 10
-            # this code is inspired by the snakemake profile: TODO: link to github
+            STATUS_ATTEMPTS = 5
+            # this code is inspired by the snakemake profile:
+            # https://github.com/Snakemake-Profiles/slurm/blob/a0e559e1eca607d0bd26c15f94d609e6905f8a8e/%7B%7Bcookiecutter.profile_name%7D%7D/slurm-status.py#L27
             for i in range(STATUS_ATTEMPTS):
                 # use self.status_rate_limiter and adaptive query
-                # timing to avoid too many API calls.
+                # timing to avoid too many API calls in retries.
                 rate_limit = Fraction(
                     min(
                         self.status_rate_limiter._rate_limit/self.status_rate_limiter._period,

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -363,7 +363,7 @@ class SlurmExecutor(ClusterExecutor):
                 # timing to avoid too many API calls.
                 rate_limit = Fraction(
                     min(
-                        self.status_rate_limiter._rate_limit/self.status_rate_limiter._preiod,
+                        self.status_rate_limiter._rate_limit/self.status_rate_limiter._period,
                         # if slurmdbd (sacct) is strained and slow, reduce the query frequency
                         (1/sacct_query_duration)/5,
                         # if slurmctld (squeue) is strained and slow, reduce the query frequency


### PR DESCRIPTION
### Description

This is a follow-up pull request to #2136 , providing a more thorough solution to putting less strain on the slurm cluster system with job status queries.

The solution suggested here:
* assigns the same UUID4 as the job name during `sbatch` job submission for all jobs during a run of snakemake -- this goes back to [an idea by Sean Maxwell on the `slurm-users` mailing list](https://lists.schedmd.com/pipermail/slurm-users/2023-February/009713.html)
* uses `sacct` as the job status query command, as this [will put less strain on `slurmctld` and instead query the `slurmdbd`](https://github.com/snakemake/snakemake/pull/2136#issuecomment-1442618490) and we assume that any reasonable cluster setup will have at least basic [job accounting](https://slurm.schedmd.com/accounting.html) set up
* uses `sacct --name <uuid4>` to make more efficient database queries to `slurmdbd`, according to [a suggestion by @wickberg](https://github.com/snakemake/snakemake/pull/2136#issuecomment-1446757458)
* adaptively adjusts the minimum wait time between job status query calls (although this only applies to retries when previously seen jobs are somehow not present -- this usually shouldn't happen, and usually queries are spaced by at least 20 seconds, see below), which will be the maximum (longer waiting time period) from either (this also goes back to [an idea by Sean Maxwell on the `slurm-users` mailing list`](https://lists.schedmd.com/pipermail/slurm-users/2023-February/009713.html)):
  *  the specified rate limit (default now set to 2 seconds between calls, but users can set this differently), or
  * 5 times the query time by the last call to `sacct`
* increase the sleep time between checking on all the running jobs by 10 seconds every time no job had finished at the last check; reset to a minimum wait time of 20 seconds once a job finishing was detected; cap at a maximum sleep time of 180 seconds

The solution explicitly DOES NOT use:
* `squeue --noheader --format=\"%F|%T\" --name <uuid4> --jobs <job_ids_of_jobs_with_no_sacct_status>` as the fallback job status query command any more, because we assume basic accounting is always set up on a cluster where workflows would be run (it would be better than `scontrol show job`, because it can also do the `--name` based filtering)
* either the `--yaml` or `--json` flags of slurm commands, as these seem to require (optional) plugins to be installed and they weren't on the system I tested -- so we cannot assume these to usually work. (This came up as an [idea by Bas van der Vlies on the `slurm-users` malining list](https://lists.schedmd.com/pipermail/slurm-users/2023-February/009728.html)
* use some kind of mechanism to wait for jobs finishing (this came up as an [idea by Brian Andrus on the `slurm-users` mailing list](https://lists.schedmd.com/pipermail/slurm-users/2023-February/009724.html), because the only easy solution I saw, was to have [`sbatch --wait`](https://slurm.schedmd.com/sbatch.html#OPT_wait) until a job finishes and only return then. However, this would keep a thread running for every job currently active, likely overstraining the login node in cases of high parallelism in the workflow (or oversubmissions).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
