### PR TITLE
fix: fix index out of bounds error raised by usage of workflow.source_path called from input or params functions

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1146,9 +1146,11 @@ class Workflow:
         frame = inspect.currentframe().f_back
         calling_file = frame.f_code.co_filename
 
-        if calling_file == self.included_stack[-1].get_path_or_uri():
+        if self.included_stack and calling_file == self.included_stack[-1].get_path_or_uri():
             # called from current snakefile, we can try to keep the original source
             # file annotation
+            # This will only work if the method is evaluated during parsing mode.
+            # Otherwise, the stack can be empty already.
             path = self.current_basedir.join(rel_path)
         else:
             # heuristically determine path
@@ -1300,10 +1302,9 @@ class Workflow:
                     )
                     update_config(self.config, self.overwrite_config)
             elif not self.overwrite_configfiles:
+                fp_full = os.path.abspath(fp)
                 raise WorkflowError(
-                    "Workflow defines configfile {} but it is not present or accessible.".format(
-                        fp
-                    )
+                    f"Workflow defines configfile {fp} but it is not present or accessible (full checked path: {fp_full})."
                 )
             else:
                 # CLI configfiles have been specified, do not throw an error but update with their values


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
