### PR TITLE
fix: always make sure that the original path of source cached files is properly passed into metadata persistence records

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1150,6 +1150,7 @@ def checkpoint_target(value):
 
 def sourcecache_entry(value, orig_path_or_uri):
     from snakemake.sourcecache import SourceFile
+
     assert not isinstance(
         orig_path_or_uri, SourceFile
     ), "bug: sourcecache_entry should recive a path or uri, not a SourceFile"

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1150,7 +1150,9 @@ def checkpoint_target(value):
 
 
 def sourcecache_entry(value, orig_path_or_uri):
-    assert not isinstance(orig_path_or_uri, SourceFile), "bug: sourcecache_entry should recive a path or uri, not a SourceFile"
+    assert not isinstance(
+        orig_path_or_uri, SourceFile
+    ), "bug: sourcecache_entry should recive a path or uri, not a SourceFile"
     return flag(value, "sourcecache_entry", orig_path_or_uri)
 
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -31,7 +31,6 @@ from snakemake.exceptions import (
 from snakemake.logging import logger
 from inspect import isfunction, ismethod
 from snakemake.common import DYNAMIC_FILL, ON_WINDOWS, async_run
-from snakemake.sourcecache import SourceFile
 
 
 class Mtime:
@@ -1150,6 +1149,7 @@ def checkpoint_target(value):
 
 
 def sourcecache_entry(value, orig_path_or_uri):
+    from snakemake.sourcecache import SourceFile
     assert not isinstance(
         orig_path_or_uri, SourceFile
     ), "bug: sourcecache_entry should recive a path or uri, not a SourceFile"

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -31,6 +31,7 @@ from snakemake.exceptions import (
 from snakemake.logging import logger
 from inspect import isfunction, ismethod
 from snakemake.common import DYNAMIC_FILL, ON_WINDOWS, async_run
+from snakemake.sourcecache import SourceFile
 
 
 class Mtime:
@@ -1149,6 +1150,7 @@ def checkpoint_target(value):
 
 
 def sourcecache_entry(value, orig_path_or_uri):
+    assert not isinstance(orig_path_or_uri, SourceFile), "bug: sourcecache_entry should recive a path or uri, not a SourceFile"
     return flag(value, "sourcecache_entry", orig_path_or_uri)
 
 

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -457,7 +457,7 @@ class Persistence:
     @lru_cache()
     def _input(self, job):
         get_path = (
-            lambda f: get_flag_value(f, "sourcecache_entry").get_path_or_uri()
+            lambda f: get_flag_value(f, "sourcecache_entry")
             if is_flagged(f, "sourcecache_entry")
             else f
         )

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1155,13 +1155,15 @@ class Workflow:
             # This will only work if the method is evaluated during parsing mode.
             # Otherwise, the stack can be empty already.
             path = self.current_basedir.join(rel_path)
+            orig_path = path.get_path_or_uri()
         else:
             # heuristically determine path
             calling_dir = os.path.dirname(calling_file)
             path = smart_join(calling_dir, rel_path)
+            orig_path = path
 
         return sourcecache_entry(
-            self.sourcecache.get_path(infer_source_file(path)), path
+            self.sourcecache.get_path(infer_source_file(path)), orig_path
         )
 
     @property


### PR DESCRIPTION
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
