### PR TITLE
docs: Change snakemake-tutorial download link to always be the latest

### DIFF
--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -167,7 +167,7 @@ First, we download some example data on which the workflow shall be executed:
 
 .. code:: console
 
-    $ curl -L https://github.com/snakemake/snakemake-tutorial-data/archive/v5.24.1.tar.gz -o snakemake-tutorial-data.tar.gz
+    $ curl -L https://api.github.com/repos/snakemake/snakemake-tutorial-data/tarball -o snakemake-tutorial-data.tar.gz
 
 Next we extract the data. On Linux, run
 


### PR DESCRIPTION
### Description

Change the link for downloading the snakemake-tutorial materials to a version-agnostic link that always gets the latest release. Inspired by https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).