### PR TITLE
docs: Improve error message when rule contains multiple run/shell/script/notebook/wrapper/template_engine/cwl keywords

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -789,9 +789,8 @@ class Rule(GlobalKeywordState):
                 ):
                     if self.run:
                         raise self.error(
-                            "Multiple run or shell keywords in rule {}.".format(
-                                self.rulename
-                            ),
+                            "Multiple run/shell/script/notebook/wrapper/template_engine/cwl "
+                            "keywords in rule {}.".format(self.rulename),
                             token,
                         )
                     self.run = True


### PR DESCRIPTION
### Description

Update `parser.py`  so that the help message is more helpful when a rule contains multiple run/shell/script/notebook/wrapper/template_engine/cwl keywords, which is not allowed.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
