### PR TITLE
fix: 2142 log directive in default target rule

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1104,7 +1104,7 @@ class DAG:
                 reason.updated_input.update(updated_subworkflow_input)
             elif job in self.targetjobs:
                 # TODO find a way to handle added/removed input files here?
-                if not job.has_products():
+                if not job.has_products(include_logfiles=False):
                     if job.input:
                         if job.rule.norun:
                             reason.updated_input_run.update(

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -96,8 +96,8 @@ class AbstractJob:
     def products(self):
         raise NotImplementedError()
 
-    def has_products(self):
-        for o in self.products():
+    def has_products(self, include_logfiles=True):
+        for o in self.products(include_logfiles=include_logfiles):
             return True
         return False
 

--- a/tests/test_github_issue2142/Snakefile
+++ b/tests/test_github_issue2142/Snakefile
@@ -1,0 +1,8 @@
+rule all:
+    input: "data.txt"
+    log:
+        "logs/all.log"
+
+rule A:
+    output: "data.txt"
+    shell: "touch {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1961,6 +1961,8 @@ def test_cleanup_metadata_fail():
 def test_github_issue1389():
     run(dpath("test_github_issue1389"), resources={"foo": 4}, shouldfail=True)
 
+def test_github_issue2142():
+    run(dpath("test_github_issue2142"))
 
 def test_ensure_nonempty_fail():
     run(dpath("test_ensure"), targets=["a"], shouldfail=True)


### PR DESCRIPTION
### Description

When the default target rule (e.g `all`) contains a `log` directive, snakemake deems workflow complete and skips execution. See https://github.com/snakemake/snakemake/issues/2142

This PR fixes this bug by adding a `include_logfiles` flag to `job.has_product()` method, similar to one used in `job.products()`. In fact, this flag is simply passed on to `job.products()` internally. To maintain backward compatibility, default value for `include_logfiles` in `job.has_product()` is `True`, the opposite of default in `job.products()`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
