### PR TITLE
fix: addressing #2197 by allowing 256 character account names in slurm

### DIFF
--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -33,7 +33,7 @@ def get_account():
     tries to deduce the acccount from recent jobs,
     returns None, if none is found
     """
-    cmd = f'sacct -nu "{os.environ["USER"]}" -o Account%20 | head -n1'
+    cmd = f'sacct -nu "{os.environ["USER"]}" -o Account%256 | head -n1'
     try:
         sacct_out = subprocess.check_output(
             cmd, shell=True, text=True, stderr=subprocess.PIPE
@@ -50,7 +50,7 @@ def test_account(account):
     """
     tests whether the given account is registered, raises an error, if not
     """
-    cmd = f'sacctmgr -n -s list user "{os.environ["USER"]}" format=account%20'
+    cmd = f'sacctmgr -n -s list user "{os.environ["USER"]}" format=account%256'
     try:
         accounts = subprocess.check_output(
             cmd, shell=True, text=True, stderr=subprocess.PIPE


### PR DESCRIPTION
### Description

This changes the format string on the calls to 'sacct' and 'sacctmgr' to allow for long slurm account names.  This fix seems to work on our slurm cluster.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
