### PR TITLE
fix: Remove absolute path in config files

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1960,6 +1960,7 @@ def args_to_api(args, parser):
                         config=parse_config(args.config),
                         configfiles=args.configfile,
                         config_args=args.config,
+                        relpath=executor_plugin.common_settings.implies_no_shared_fs,
                     ),
                     storage_settings=storage_settings,
                     storage_provider_settings=storage_provider_settings,

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2818,7 +2818,10 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                     files.add(env_path)
 
         for f in self.workflow.configfiles:
-            files.add(f)
+            if isinstance(f, Path):
+                files.add(f.as_posix())
+            elif isinstance(f, str):
+                files.add(f)
 
         # get git-managed files
         # TODO allow a manifest file as alternative

--- a/snakemake/settings.py
+++ b/snakemake/settings.py
@@ -310,6 +310,7 @@ class ConfigSettings(SettingsBase):
     config: Mapping[str, str] = immutables.Map()
     configfiles: Sequence[Path] = tuple()
     config_args: Optional[str] = None
+    relpath: Optional[bool] = False
 
     def __post_init__(self):
         self.overwrite_config = self._get_overwrite_config()
@@ -326,7 +327,11 @@ class ConfigSettings(SettingsBase):
         return overwrite_config
 
     def _get_configfiles(self):
-        return list(map(Path.absolute, self.configfiles))
+        if self.relpath:
+            files = self.configfiles
+        else:
+            files = list(map(Path.absolute, self.configfiles))
+        return files
 
     def _get_config_args(self):
         if self.config_args is None:


### PR DESCRIPTION
### Description

I am proposing a minor change, namely to ommit appending the absolute path to the config file. This is not compatible with cloud execution (at least google life sciences), when using `--configfile` command line option. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
