### PR TITLE
fix: Limit python versions for testing

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python
+  - python < 3.10 # 3.10 breaks nose
   - yte
   - stopit
   - datrie


### PR DESCRIPTION
### Description

Starting with Python3.10 collections.Callable moved to collections.abc.Callable, which [breaks nose](https://github.com/nose-devs/nose/issues/1122).
 Seems that for now testing can only be done with earlier versions.
 In the long run some other testing solution might be needed.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
