### PR TITLE
fix: Use `job.rule.name` attribute to fill rule field in summary

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2250,8 +2250,7 @@ class DAG:
         for job in self.jobs:
             output = job.rule.output if self.dynamic(job) else job.expanded_output
             for f in output:
-                rule = self.workflow.persistence.rule(f)
-                rule = "-" if rule is None else rule
+                rule = job.rule.name
 
                 version = self.workflow.persistence.version(f)
                 version = "-" if version is None else str(version)


### PR DESCRIPTION
### Description

This PR fixes #2216, by using the job rule name as derived in the dag.

I am not entirely sure what the persistence class does here, but I guess it somehow caches the jobname in the .snakemake directory when the rule is run. This probably leads to incorrect summaries before the rules have been cached, which does not seem like the intended behavior of the summary option.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
