### PR TITLE
refactor: format()  and %s replaced by f-strings

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -519,7 +519,7 @@ def snakemake(
             return False
 
     if not os.path.exists(snakefile):
-        logger.error('Error: Snakefile "{}" not found.'.format(snakefile))
+        logger.error(f'Error: Snakefile "{snakefile}" not found.')
         return False
     snakefile = os.path.abspath(snakefile)
 
@@ -554,7 +554,7 @@ def snakemake(
     if workdir:
         olddir = os.getcwd()
         if not os.path.exists(workdir):
-            logger.info("Creating specified working directory {}.".format(workdir))
+            logger.info(f"Creating specified working directory {workdir}.")
             os.makedirs(workdir)
         workdir = os.path.abspath(workdir)
         os.chdir(workdir)
@@ -2620,7 +2620,7 @@ def main(argv=None):
 
     if sys.version_info < MIN_PY_VERSION:
         print(
-            "Snakemake requires at least Python {}.".format(MIN_PY_VERSION),
+            f"Snakemake requires at least Python {MIN_PY_VERSION}.",
             file=sys.stderr,
         )
         exit(1)
@@ -2874,8 +2874,8 @@ def main(argv=None):
             port = args.gui
             host = "127.0.0.1"
 
-        url = "http://{}:{}".format(host, port)
-        print("Listening on {}.".format(url), file=sys.stderr)
+        url = f"http://{host}:{port}"
+        print(f"Listening on {url}.", file=sys.stderr)
 
         def open_browser():
             try:
@@ -3144,7 +3144,7 @@ def bash_completion(snakefile="Snakefile"):
         )
     else:
         candidates = []
-        files = glob.glob("{}*".format(prefix))
+        files = glob.glob(f"{prefix}*")
         if files:
             candidates.extend(files)
         if os.path.exists(snakefile):

--- a/snakemake/_version.py
+++ b/snakemake/_version.py
@@ -106,7 +106,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print(f"unable to find command, tried {commands}")
         return None, None
     stdout = process.communicate()[0].strip().decode()
     if process.returncode != 0:
@@ -141,8 +141,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
 
     if verbose:
         print(
-            "Tried directories %s but none started with prefix %s"
-            % (str(rootdirs), parentdir_prefix)
+            f"Tried directories {rootdirs} but none started with prefix {parentdir_prefix}"
         )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
@@ -358,7 +357,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, runner=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+            pieces["error"] = "tag '{}' doesn't start with prefix '{}'".format(
                 full_tag,
                 tag_prefix,
             )

--- a/snakemake/benchmark.py
+++ b/snakemake/benchmark.py
@@ -91,7 +91,7 @@ class BenchmarkRecord:
             if x is None:
                 return "-"
             elif isinstance(x, float):
-                return "{:.2f}".format(x)
+                return f"{x:.2f}"
             else:
                 return str(x)
 
@@ -113,7 +113,7 @@ class BenchmarkRecord:
                 "Benchmark: not collected for "
                 "; ".join(
                     [
-                        "{{'pid': {}, 'name': '{}''}}".format(record[0], record[1])
+                        f"{{'pid': {record[0]}, 'name': '{record[1]}''}}"
                         for record in self.skipped_procs
                     ]
                 )
@@ -122,7 +122,7 @@ class BenchmarkRecord:
                 "Benchmark: collected for "
                 "; ".join(
                     [
-                        "{{'pid': {}, 'name': '{}'}}".format(record[0], record[1])
+                        f"{{'pid': {record[0]}, 'name': '{record[1]}'}}"
                         for record in self.processed_procs
                     ]
                 )
@@ -132,7 +132,7 @@ class BenchmarkRecord:
                 map(
                     to_tsv_str,
                     (
-                        "{:.4f}".format(self.running_time),
+                        f"{self.running_time:.4f}",
                         timedelta_to_str(datetime.timedelta(seconds=self.running_time)),
                         self.max_rss,
                         self.max_vms,
@@ -153,7 +153,7 @@ class BenchmarkRecord:
             )
             return "\t".join(
                 [
-                    "{:.4f}".format(self.running_time),
+                    f"{self.running_time:.4f}",
                     timedelta_to_str(datetime.timedelta(seconds=self.running_time)),
                     "NA",
                     "NA",

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -94,7 +94,7 @@ class Batch:
         return self.idx == self.batches
 
     def __str__(self):
-        return "{}/{} (rule {})".format(self.idx, self.batches, self.rulename)
+        return f"{self.idx}/{self.batches} (rule {self.rulename})"
 
 
 class DAG:
@@ -683,7 +683,7 @@ class DAG:
         """Write-protect output files that are marked with protected()."""
         for f in job.expanded_output:
             if f in job.protected_output:
-                logger.info("Write-protecting output file {}.".format(f))
+                logger.info(f"Write-protecting output file {f}.")
                 f.protect()
 
     def handle_touch(self, job):
@@ -691,7 +691,7 @@ class DAG:
         for f in job.expanded_output:
             if f in job.touch_output:
                 f = job.shadowed_path(f)
-                logger.info("Touching output file {}.".format(f))
+                logger.info(f"Touching output file {f}.")
                 f.touch_or_create()
                 assert os.path.exists(f)
 
@@ -751,7 +751,7 @@ class DAG:
             if self.dryrun:
                 logger.info(f"Would remove temporary output {f}")
             else:
-                logger.info("Removing temporary output {}.".format(f))
+                logger.info(f"Removing temporary output {f}.")
                 f.remove(remove_non_empty_dir=True)
 
     def handle_log(self, job, upload_remote=True):
@@ -824,7 +824,7 @@ class DAG:
 
             for f in unneeded_files():
                 if f.exists_local:
-                    logger.info("Removing local copy of remote file: {}".format(f))
+                    logger.info(f"Removing local copy of remote file: {f}")
                     f.remove()
 
     def jobid(self, job):
@@ -905,7 +905,7 @@ class DAG:
                     "the output files more specific. "
                     "A common pattern is to have different prefixes "
                     "in the output files of different rules."
-                    + "\nProblematic file pattern: {}".format(file)
+                    + f"\nProblematic file pattern: {file}"
                     if file
                     else "",
                 )
@@ -920,7 +920,7 @@ class DAG:
 
         n = len(self.dependencies)
         if progress and n % 1000 == 0 and n and self._progress != n:
-            logger.info("Processed {} potential jobs.".format(n))
+            logger.info(f"Processed {n} potential jobs.")
             self._progress = n
 
         producers.sort(reverse=True)
@@ -1584,7 +1584,7 @@ class DAG:
                 depending = list(self.depending[job])
                 # re-evaluate depending jobs, replace and update DAG
                 for j in depending:
-                    logger.debug("Updating job {}.".format(j))
+                    logger.debug(f"Updating job {j}.")
                     newjob = j.updated()
                     self.replace_job(j, newjob, recursive=False)
                     updated = True
@@ -1741,7 +1741,7 @@ class DAG:
                 if newrule_ is not None:
                     self.specialize_rule(job_.rule, newrule_)
                     if not self.dynamic(job_):
-                        logger.debug("Updating job {}.".format(job_))
+                        logger.debug(f"Updating job {job_}.")
                         newjob_ = self.new_job(
                             newrule_, targetfile=job_.output[0] if job_.output else None
                         )
@@ -1821,10 +1821,10 @@ class DAG:
 
         self.update([newjob])
 
-        logger.debug("Replace {} with dynamic branch {}".format(job, newjob))
+        logger.debug(f"Replace {job} with dynamic branch {newjob}")
         for job_, files in depending:
             # if not job_.dynamic_input:
-            logger.debug("updating depending job {}".format(job_))
+            logger.debug(f"updating depending job {job_}")
             self.dependencies[job_][newjob].update(files)
             self.depending[newjob][job_].update(files)
 
@@ -2039,7 +2039,7 @@ class DAG:
             name, value = wildcard
             if DYNAMIC_FILL in value:
                 value = "..."
-            return "{}: {}".format(name, value)
+            return f"{name}: {value}"
 
         node2rule = lambda job: job.rule
         node2label = lambda job: "\\n".join(
@@ -2174,7 +2174,7 @@ class DAG:
                     node_id=node_id, color=color
                 ),
                 "<tr><td>",
-                '<b><font point-size="18">{node.name}</font></b>'.format(node=node),
+                f'<b><font point-size="18">{node.name}</font></b>',
                 "</td></tr>",
                 "<hr/>",
                 '<tr><td align="left"> {input_header} </td></tr>'.format(
@@ -2283,7 +2283,7 @@ class DAG:
                 elif self.reason(job).updated_input:
                     status = "updated input files"
                 elif self.workflow.persistence.version_changed(job, file=f):
-                    status = "version changed to {}".format(job.rule.version)
+                    status = f"version changed to {job.rule.version}"
                 elif self.workflow.persistence.code_changed(job, file=f):
                     status = "rule implementation changed"
                 elif self.workflow.persistence.input_changed(job, file=f):
@@ -2378,7 +2378,7 @@ class DAG:
                     # symlinks fail f.exists.
                     if f.exists or os.path.islink(f):
                         if f.protected:
-                            logger.error("Skipping write-protected file {}.".format(f))
+                            logger.error(f"Skipping write-protected file {f}.")
                         else:
                             msg = "Deleting {}" if not dryrun else "Would delete {}"
                             logger.info(msg.format(f))
@@ -2426,9 +2426,7 @@ class DAG:
         jobs = list(self.jobs)
 
         if len(jobs) > max_jobs:
-            logger.info(
-                "Job-DAG is too large for visualization (>{} jobs).".format(max_jobs)
-            )
+            logger.info(f"Job-DAG is too large for visualization (>{max_jobs} jobs).")
         else:
             logger.d3dag(
                 nodes=[node(job) for job in jobs],

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -34,7 +34,7 @@ def format_error(
         ex.__class__.__name__,
         location,
         ":\n" + msg if msg else ".",
-        "\n{}".format(tb) if show_traceback and tb else "",
+        f"\n{tb}" if show_traceback and tb else "",
     )
 
 
@@ -62,7 +62,7 @@ def format_traceback(tb, linemaps):
         if file in linemaps:
             lineno = linemaps[file][lineno]
         if code is not None:
-            yield '  File "{}", line {}, in {}'.format(file, lineno, function)
+            yield f'  File "{file}", line {lineno}, in {function}'
 
 
 def log_verbose_traceback(ex):
@@ -155,20 +155,20 @@ class WorkflowError(Exception):
         elif isinstance(arg, WorkflowError):
             spec = ""
             if arg.rule is not None:
-                spec += "rule {}".format(arg.rule)
+                spec += f"rule {arg.rule}"
             if arg.snakefile is not None:
                 if spec:
                     spec += ", "
-                spec += "line {}, {}".format(arg.lineno, arg.snakefile)
+                spec += f"line {arg.lineno}, {arg.snakefile}"
 
             if spec:
-                spec = " ({})".format(spec)
+                spec = f" ({spec})"
 
             return "{}{}:\n{}".format(
                 arg.__class__.__name__, spec, textwrap.indent(str(arg), "    ")
             )
         else:
-            return "{}: {}".format(arg.__class__.__name__, str(arg))
+            return f"{arg.__class__.__name__}: {arg}"
 
     def __init__(self, *args, lineno=None, snakefile=None, rule=None):
         super().__init__("\n".join(self.format_arg(arg) for arg in args))
@@ -183,7 +183,7 @@ class WorkflowError(Exception):
 
 class SourceFileError(WorkflowError):
     def __init__(self, msg):
-        super().__init__("Error in source file definition: {}".format(msg))
+        super().__init__(f"Error in source file definition: {msg}")
 
 
 class WildcardError(WorkflowError):
@@ -237,9 +237,7 @@ class InputFunctionException(WorkflowError):
             "Error:\n  "
             + self.format_arg(msg)
             + "\nWildcards:\n"
-            + "\n".join(
-                "  {}={}".format(name, value) for name, value in wildcards.items()
-            )
+            + "\n".join(f"  {name}={value}" for name, value in wildcards.items())
             + "\nTraceback:\n"
             + "\n".join(format_traceback(cut_traceback(msg), rule.workflow.linemaps))
         )
@@ -385,9 +383,7 @@ class AmbiguousRuleException(RuleException):
 
 class CyclicGraphException(RuleException):
     def __init__(self, repeatedrule, file, rule=None):
-        super().__init__(
-            "Cyclic dependency on rule {}.".format(repeatedrule), rule=rule
-        )
+        super().__init__(f"Cyclic dependency on rule {repeatedrule}.", rule=rule)
         self.file = file
 
 
@@ -404,9 +400,9 @@ class MissingRuleException(RuleException):
 
 class UnknownRuleException(RuleException):
     def __init__(self, name, prefix="", lineno=None, snakefile=None):
-        msg = "There is no rule named {}.".format(name)
+        msg = f"There is no rule named {name}."
         if prefix:
-            msg = "{} {}".format(prefix, msg)
+            msg = f"{prefix} {msg}"
         super().__init__(msg, lineno=lineno, snakefile=snakefile)
 
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -343,7 +343,7 @@ class _IOFile(str):
         """
         if not self.exists:
             raise WorkflowError(
-                "File {} cannot be opened, since it does not exist.".format(self)
+                f"File {self} cannot be opened, since it does not exist."
             )
         if not self.exists_local and self.is_remote:
             self.download_from_remote()
@@ -615,7 +615,7 @@ class _IOFile(str):
             try:
                 if os.lstat(self.file):
                     raise WorkflowError(
-                        "File {} seems to be a broken symlink.".format(self.file)
+                        f"File {self.file} seems to be a broken symlink."
                     )
             except FileNotFoundError as e:
                 # there is no broken symlink present, hence all fine
@@ -633,7 +633,7 @@ class _IOFile(str):
     def download_from_remote(self):
         if self.is_remote and self.remote_object.exists():
             if not self.should_stay_on_remote:
-                logger.info("Downloading from remote: {}".format(self.file))
+                logger.info(f"Downloading from remote: {self.file}")
                 self.remote_object.download()
                 logger.info("Finished download.")
         else:
@@ -643,7 +643,7 @@ class _IOFile(str):
 
     def upload_to_remote(self):
         if self.is_remote:
-            logger.info("Uploading to remote: {}".format(self.file))
+            logger.info(f"Uploading to remote: {self.file}")
             self.remote_object.upload()
             logger.info("Finished upload.")
 
@@ -865,9 +865,7 @@ def wait_for_files(
 
     missing = get_missing()
     if missing:
-        logger.info(
-            "Waiting at most {} seconds for missing files.".format(latency_wait)
-        )
+        logger.info(f"Waiting at most {latency_wait} seconds for missing files.")
         for _ in range(latency_wait):
             missing = get_missing()
             if not missing:
@@ -907,9 +905,7 @@ def remove(file, remove_non_empty_dir=False):
             except OSError as e:
                 # skip non empty directories
                 if e.errno == 39:
-                    logger.info(
-                        "Skipped removing non-empty directory {}".format(e.filename)
-                    )
+                    logger.info(f"Skipped removing non-empty directory {e.filename}")
                 else:
                     logger.warning(str(e))
     # Remember that dangling symlinks fail the os.path.exists() test, but
@@ -943,7 +939,7 @@ def regex(filepattern):
                     "Constraint regex must be defined only in the first "
                     "occurence of the wildcard in a string."
                 )
-            f.append("(?P={})".format(wildcard))
+            f.append(f"(?P={wildcard})")
         else:
             wildcards.add(wildcard)
             f.append(
@@ -975,7 +971,7 @@ def apply_wildcards(
             return str(value)  # convert anything into a str
         except KeyError as ex:
             if keep_dynamic:
-                return "{{{}}}".format(name)
+                return f"{{{name}}}"
             elif fill_missing:
                 return dynamic_fill
             else:
@@ -1281,7 +1277,7 @@ def expand(*args, **wildcards):
             for comb in map(format_dict, combinator(*flatten(wildcards[filepattern])))
         ]
     except KeyError as e:
-        raise WildcardError("No values given for wildcard {}.".format(e))
+        raise WildcardError(f"No values given for wildcard {e}.")
 
 
 def multiext(prefix, *extensions):
@@ -1372,7 +1368,7 @@ def update_wildcard_constraints(
             return match.group(0)
         # Only update if a new constraint has actually been set
         elif newconstraint is not None:
-            return "{{{},{}}}".format(name, newconstraint)
+            return f"{{{name},{newconstraint}}}"
         else:
             return match.group(0)
 
@@ -1435,7 +1431,7 @@ def get_git_root_parent_directory(path, input_path):
         tail, head = os.path.split(path)
         if tail is None:
             raise WorkflowError(
-                "Neither provided git path ({}) ".format(input_path)
+                f"Neither provided git path ({input_path}) "
                 + "or parent directories contain a valid git repo."
             )
         else:
@@ -1458,7 +1454,7 @@ def git_content(git_file):
 
     if git_file.startswith("git+file:"):
         (root_path, file_path, version) = split_git_path(git_file)
-        return git.Repo(root_path).git.show("{}:{}".format(version, file_path))
+        return git.Repo(root_path).git.show(f"{version}:{file_path}")
     else:
         raise WorkflowError(
             "Provided git path ({}) doesn't meet the "
@@ -1717,7 +1713,7 @@ def _load_configfile(configpath_or_obj, filetype="Config"):
                     "whitespace and tab indentation.".format(filetype)
                 )
     except FileNotFoundError:
-        raise WorkflowError("{} file {} not found.".format(filetype, configpath))
+        raise WorkflowError(f"{filetype} file {configpath} not found.")
 
 
 def load_configfile(configpath):

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -679,7 +679,7 @@ class Job(AbstractJob):
                 if f in requested:
                     if f in self.dynamic_output:
                         if not self.expand_dynamic(f_):
-                            yield "{} (dynamic)".format(f_)
+                            yield f"{f_} (dynamic)"
                     else:
                         yield from handle_file(f)
         else:
@@ -1282,7 +1282,7 @@ class GroupJob(AbstractJob):
             yield from layer
 
     def __repr__(self):
-        return "JobGroup({},{})".format(self.groupid, repr(self.jobs))
+        return f"JobGroup({self.groupid},{repr(self.jobs)})"
 
     def __contains__(self, job):
         return job in self.jobs
@@ -1535,13 +1535,9 @@ class GroupJob(AbstractJob):
         try:
             return format(string, **_variables)
         except NameError as ex:
-            raise WorkflowError(
-                "NameError with group job {}: {}".format(self.jobid, str(ex))
-            )
+            raise WorkflowError(f"NameError with group job {self.jobid}: {str(ex)}")
         except IndexError as ex:
-            raise WorkflowError(
-                "IndexError with group job {}: {}".format(self.jobid, str(ex))
-            )
+            raise WorkflowError(f"IndexError with group job {self.jobid}: {str(ex)}")
         except Exception as ex:
             raise WorkflowError(
                 f"Error when formatting {string} for group job {self.jobid}: {ex}"

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -146,20 +146,16 @@ class WMSLogger:
 
         # We first ensure that the server is running, period
         response = requests.get(
-            self.address + "/api/service-info", headers=self._headers
+            f"{self.address}/api/service-info", headers=self._headers
         )
         if response.status_code != 200:
-            sys.stderr.write(
-                "Problem with server: {} {}".format(self.address, os.linesep)
-            )
+            sys.stderr.write(f"Problem with server: {self.address} {os.linesep}")
             sys.exit(-1)
 
         # And then that it's ready to be interacted with
         if response.json().get("status") != "running":
             sys.stderr.write(
-                "The status of the server {} is not in 'running' mode {}".format(
-                    self.address, os.linesep
-                )
+                f"The status of the server {self.address} is not in 'running' mode {os.linesep}"
             )
             sys.exit(-1)
 
@@ -185,7 +181,7 @@ class WMSLogger:
         }
 
         response = requests.get(
-            self.address + "/create_workflow",
+            f"{self.address}/create_workflow",
             headers=self._headers,
             params=self.args,
             data=metadata,
@@ -209,7 +205,7 @@ class WMSLogger:
             return
 
         if status_code == 404:
-            sys.stderr.write("The wms %s endpoint was not found" % endpoint)
+            sys.stderr.write(f"The wms {endpoint} endpoint was not found")
             sys.exit(-1)
         elif status_code == 401:
             sys.stderr.write(
@@ -218,7 +214,7 @@ class WMSLogger:
             sys.exit(-1)
         elif status_code == 500:
             sys.stderr.write(
-                "There was a server error when trying to access %s" % endpoint
+                f"There was a server error when trying to access {endpoint}"
             )
             sys.exit(-1)
         elif status_code == 403:
@@ -227,8 +223,7 @@ class WMSLogger:
 
         # Any other response code is not acceptable
         sys.stderr.write(
-            "The %s response code %s is not recognized."
-            % (endpoint, response.status_code)
+            f"The {endpoint} response code {response.status_code} is not recognized."
         )
 
     @property
@@ -252,7 +247,7 @@ class WMSLogger:
 
             # For an exception, return the name and a message
             elif key == "exception":
-                result[key] = "%s: %s" % (
+                result[key] = "{}: {}".format(
                     msg["exception"].__class__.__name__,
                     msg["exception"] or "Exception",
                 )
@@ -343,7 +338,7 @@ class Logger:
     def logfile_hint(self):
         if self.mode == Mode.default and not self.dryrun:
             logfile = self.get_logfile()
-            self.info("Complete log: {}".format(os.path.relpath(logfile)))
+            self.info(f"Complete log: {os.path.relpath(logfile)}")
 
     def location(self, msg):
         callerframerecord = inspect.stack()[1]
@@ -432,7 +427,7 @@ class Logger:
             def format_item(item, omit=None, valueformat=str):
                 value = msg[item]
                 if value != omit:
-                    return "    {}: {}".format(item, valueformat(value))
+                    return f"    {item}: {valueformat(value)}"
 
             yield "{}{} {}:".format(
                 "local" if msg["local"] else "",
@@ -454,7 +449,7 @@ class Logger:
 
             wildcards = format_wildcards(msg["wildcards"])
             if wildcards:
-                yield "    wildcards: " + wildcards
+                yield f"    wildcards: {wildcards}"
 
             for item, omit in zip("priority threads".split(), [0, 1]):
                 fmt = format_item(item, omit=omit)
@@ -463,7 +458,7 @@ class Logger:
 
             resources = format_resources(msg["resources"])
             if resources:
-                yield "    resources: " + resources
+                yield f"    resources: {resources}"
 
         def show_logs(logs):
             for f in logs:
@@ -487,12 +482,12 @@ class Logger:
 
         def indent(item):
             if msg.get("indent"):
-                return "    " + item
+                return f"    {item}"
             else:
                 return item
 
         def timestamp():
-            self.logger.info(indent("[{}]".format(time.asctime())))
+            self.logger.info(indent(f"[{time.asctime()}]"))
 
         level = msg["level"]
 
@@ -652,7 +647,7 @@ def format_dict(dict_like, omit_keys=None, omit_values=None):
             "bug: format_dict applied to something neither a dict nor a Namedlist"
         )
     return ", ".join(
-        "{}={}".format(name, str(value))
+        f"{name}={value}"
         for name, value in items
         if name not in omit_keys and value not in omit_values
     )

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -155,7 +155,7 @@ class JupyterNotebook(ScriptBase):
 
 class PythonJupyterNotebook(JupyterNotebook):
     def get_preamble(self):
-        preamble_addendum = "import os; os.chdir(r'{cwd}');".format(cwd=os.getcwd())
+        preamble_addendum = f"import os; os.chdir(r'{os.getcwd()}');"
 
         return PythonScript.generate_preamble(
             self.path,
@@ -193,7 +193,7 @@ class PythonJupyterNotebook(JupyterNotebook):
 
 class RJupyterNotebook(JupyterNotebook):
     def get_preamble(self):
-        preamble_addendum = "setwd('{cwd}');".format(cwd=os.getcwd())
+        preamble_addendum = f"setwd('{os.getcwd()}');"
 
         return RScript.generate_preamble(
             self.path,
@@ -277,7 +277,7 @@ def notebook(
                 # draft the notebook, it does not exist yet
                 language = None
                 draft = True
-                path = "file://{}".format(os.path.abspath(local_path))
+                path = f"file://{os.path.abspath(local_path)}"
                 if path.endswith(".py.ipynb"):
                     language = "jupyter_python"
                 elif path.endswith(".r.ipynb"):
@@ -336,7 +336,7 @@ def notebook(
         executor.evaluate(edit=edit)
     elif edit.draft_only:
         executor.draft()
-        msg = "Generated skeleton notebook:\n{} ".format(path)
+        msg = f"Generated skeleton notebook:\n{path} "
         if conda_env and not container_img:
             msg += (
                 "\n\nEditing with VSCode:\nOpen notebook, run command 'Select notebook kernel' (Ctrl+Shift+P or Cmd+Shift+P), and choose:"

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -157,7 +157,7 @@ class KeywordState(TokenAutomaton):
             for t in self.start():
                 yield t, token
         else:
-            self.error("Colon expected after keyword {}.".format(self.keyword), token)
+            self.error(f"Colon expected after keyword {self.keyword}.", token)
 
     def is_block_end(self, token):
         return (self.line and self.indent <= 0) or is_eof(token)
@@ -189,7 +189,7 @@ class KeywordState(TokenAutomaton):
 
 class GlobalKeywordState(KeywordState):
     def start(self):
-        yield "workflow.{keyword}(".format(keyword=self.keyword)
+        yield f"workflow.{self.keyword}("
 
 
 class DecoratorKeywordState(KeywordState):
@@ -197,7 +197,7 @@ class DecoratorKeywordState(KeywordState):
     args = list()
 
     def start(self):
-        yield "@workflow.{}".format(self.decorator)
+        yield f"@workflow.{self.decorator}"
         yield "\n"
         yield "def __{}({}):".format(self.decorator, ", ".join(self.args))
 
@@ -212,12 +212,12 @@ class RuleKeywordState(KeywordState):
 
     def start(self):
         yield "\n"
-        yield "@workflow.{keyword}(".format(keyword=self.keyword)
+        yield f"@workflow.{self.keyword}("
 
 
 class SectionKeywordState(KeywordState):
     def start(self):
-        yield ", {keyword}=".format(keyword=self.keyword)
+        yield f", {self.keyword}="
 
     def end(self):
         # no end needed
@@ -369,7 +369,7 @@ class Subworkflow(GlobalKeywordState):
 
     def name(self, token):
         if is_name(token):
-            yield "workflow.subworkflow({name!r}".format(name=token.string), token
+            yield f"workflow.subworkflow({token.string!r}", token
             self.has_name = True
         elif is_colon(token) and self.has_name:
             self.primary_token = token
@@ -812,7 +812,7 @@ class Rule(GlobalKeywordState):
                     yield t
             except KeyError:
                 self.error(
-                    "Unexpected keyword {} in rule definition".format(token.string),
+                    f"Unexpected keyword {token.string} in rule definition",
                     token,
                 )
             except StopAutomaton as e:
@@ -824,7 +824,7 @@ class Rule(GlobalKeywordState):
             yield token.string, token
         elif is_string(token):
             yield "\n", token
-            yield "@workflow.docstring({})".format(token.string), token
+            yield f"@workflow.docstring({token.string})", token
         else:
             self.error(
                 "Expecting rule keyword, comment or docstrings "
@@ -922,7 +922,7 @@ class Module(GlobalKeywordState):
 
     def name(self, token):
         if is_name(token):
-            yield "workflow.module({name!r}".format(name=token.string), token
+            yield f"workflow.module({token.string!r}", token
             self.has_name = True
         elif is_colon(token) and self.has_name:
             self.primary_token = token
@@ -994,7 +994,7 @@ class UseRule(GlobalKeywordState):
         rulename = self.rules[0]
         if rulename == "*":
             rulename = "__allrules__"
-        yield "def __userule_{}_{}():".format(self.from_module, rulename)
+        yield f"def __userule_{self.from_module}_{rulename}():"
         # the end is detected.
         # So we can savely reset the indent to zero here
         self.indent = 0
@@ -1181,7 +1181,7 @@ class UseRule(GlobalKeywordState):
                 yield from ()
             except KeyError:
                 self.error(
-                    "Unexpected keyword {} in rule definition".format(token.string),
+                    f"Unexpected keyword {token.string} in rule definition",
                     token,
                 )
             except StopAutomaton as e:

--- a/snakemake/path_modifier.py
+++ b/snakemake/path_modifier.py
@@ -106,7 +106,7 @@ class PathModifier:
             return path
 
         # This will convert any AnnotatedString to str
-        fullpath = "{}/{}".format(self.workflow.default_remote_prefix, path)
+        fullpath = f"{self.workflow.default_remote_prefix}/{path}"
         fullpath = os.path.normpath(fullpath)
         remote = self.workflow.default_remote_provider.remote(fullpath)
         return remote

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -140,7 +140,7 @@ class Persistence:
                 i += 1
                 # this can take a while for large folders...
                 if (i % 10000) == 0 and i > 0:
-                    logger.info("{} files migrated".format(i))
+                    logger.info(f"{i} files migrated")
 
         logger.info("Migration complete")
 
@@ -557,7 +557,7 @@ class Persistence:
             except json.JSONDecodeError as e:
                 pass
         # case: file is corrupted, delete it
-        logger.warning(f"Deleting corrupted metadata record.")
+        logger.warning("Deleting corrupted metadata record.")
         self._delete_record(subject, id)
         return dict()
 
@@ -568,14 +568,14 @@ class Persistence:
         return (
             f
             for f, _ in listfiles(
-                os.path.join(self._lockdir, "{{n,[0-9]+}}.{}.lock".format(type))
+                os.path.join(self._lockdir, f"{{n,[0-9]+}}.{type}.lock")
             )
             if not os.path.isdir(f)
         )
 
     def _lock(self, files, type):
         for i in count(0):
-            lockfile = os.path.join(self._lockdir, "{}.{}.lock".format(i, type))
+            lockfile = os.path.join(self._lockdir, f"{i}.{type}.lock")
             if not os.path.exists(lockfile):
                 self._lockfile[type] = lockfile
                 with open(lockfile, "w") as lock:

--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -26,7 +26,7 @@ class DefaultResources:
 
     @classmethod
     def encode_arg(cls, name, value):
-        return "{}={}".format(name, value)
+        return f"{name}={value}"
 
     def __init__(self, args=None, from_other=None, mode="full"):
         if mode == "full":
@@ -34,7 +34,7 @@ class DefaultResources:
         elif mode == "bare":
             self._args = dict(DefaultResources.bare_defaults)
         else:
-            raise ValueError("Unexpected mode for DefaultResources: {}".format(mode))
+            raise ValueError(f"Unexpected mode for DefaultResources: {mode}")
 
         if from_other is not None:
             self._args = dict(from_other._args)
@@ -84,7 +84,7 @@ class DefaultResources:
             self.parsed.update(parse_resources(self._args, fallback=fallback))
 
     def set_resource(self, name, value):
-        self._args[name] = "{}".format(value)
+        self._args[name] = f"{value}"
         self.parsed[name] = value
 
     @property

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -201,7 +201,7 @@ class Rule:
             # perform the partial expansion from f's string representation
             s = str(f).replace("{", "{{").replace("}", "}}")
             for key in wildcards.keys():
-                s = s.replace("{{{{{}}}}}".format(key), "{{{}}}".format(key))
+                s = s.replace(f"{{{{{key}}}}}", f"{{{key}}}")
             # build result
             anno_s = AnnotatedString(s)
             anno_s.flags = f.flags
@@ -1209,14 +1209,12 @@ class Rule:
             return False
         except sre_constants.error as ex:
             raise IOFileException(
-                "{} in wildcard statement".format(ex),
+                f"{ex} in wildcard statement",
                 snakefile=self.snakefile,
                 lineno=self.lineno,
             )
         except ValueError as ex:
-            raise IOFileException(
-                "{}".format(ex), snakefile=self.snakefile, lineno=self.lineno
-            )
+            raise IOFileException(f"{ex}", snakefile=self.snakefile, lineno=self.lineno)
 
     def get_wildcards(self, requested_output, wildcards_dict=None):
         """

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -572,11 +572,9 @@ class JobScheduler:
                     for job in needrun:
                         job.reset_params_and_resources()
 
+                    logger.debug(f"Resources before job selection: {self.resources}")
                     logger.debug(
-                        "Resources before job selection: {}".format(self.resources)
-                    )
-                    logger.debug(
-                        "Ready jobs ({})".format(len(needrun))
+                        f"Ready jobs ({len(needrun)})"
                         # + "\n\t".join(map(str, needrun))
                     )
 
@@ -586,12 +584,10 @@ class JobScheduler:
                     self._last_job_selection_empty = not run
 
                     logger.debug(
-                        "Selected jobs ({})".format(len(run))
+                        f"Selected jobs ({len(run)})"
                         # + "\n\t".join(map(str, run))
                     )
-                    logger.debug(
-                        "Resources after job selection: {}".format(self.resources)
-                    )
+                    logger.debug(f"Resources after job selection: {self.resources}")
 
                 # update running jobs
                 with self._lock:
@@ -740,7 +736,7 @@ class JobScheduler:
             # assert self.resources["_cores"] > 0
             scheduled_jobs = {
                 job: pulp.LpVariable(
-                    "job_{}".format(idx), lowBound=0, upBound=1, cat=pulp.LpInteger
+                    f"job_{idx}", lowBound=0, upBound=1, cat=pulp.LpInteger
                 )
                 for idx, job in enumerate(jobs)
             }
@@ -760,14 +756,14 @@ class JobScheduler:
 
             temp_job_improvement = {
                 temp_file: pulp.LpVariable(
-                    "temp_file_{}".format(idx), lowBound=0, upBound=1, cat="Continuous"
+                    f"temp_file_{idx}", lowBound=0, upBound=1, cat="Continuous"
                 )
                 for idx, temp_file in enumerate(temp_files)
             }
 
             temp_file_deletable = {
                 temp_file: pulp.LpVariable(
-                    "deletable_{}".format(idx),
+                    f"deletable_{idx}",
                     lowBound=0,
                     upBound=1,
                     cat=pulp.LpInteger,

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -211,7 +211,7 @@ class REncoder:
 
             except ImportError:
                 pass
-        raise ValueError("Unsupported value for conversion into R: {}".format(value))
+        raise ValueError(f"Unsupported value for conversion into R: {value}")
 
     @classmethod
     def encode_list(cls, l):
@@ -221,13 +221,13 @@ class REncoder:
     def encode_items(cls, items):
         def encode_item(item):
             name, value = item
-            return '"{}" = {}'.format(name, cls.encode_value(value))
+            return f'"{name}" = {cls.encode_value(value)}'
 
         return ", ".join(map(encode_item, items))
 
     @classmethod
     def encode_dict(cls, d):
-        d = "list({})".format(cls.encode_items(d.items()))
+        d = f"list({cls.encode_items(d.items())})"
         return d
 
     @classmethod
@@ -272,9 +272,7 @@ class JuliaEncoder:
                     return str(value)
             except ImportError:
                 pass
-        raise ValueError(
-            "Unsupported value for conversion into Julia: {}".format(value)
-        )
+        raise ValueError(f"Unsupported value for conversion into Julia: {value}")
 
     @classmethod
     def encode_list(cls, l):
@@ -284,7 +282,7 @@ class JuliaEncoder:
     def encode_items(cls, items):
         def encode_item(item):
             name, value = item
-            return '"{}" => {}'.format(name, cls.encode_value(value))
+            return f'"{name}" => {cls.encode_value(value)}'
 
         return ", ".join(map(encode_item, items))
 
@@ -292,12 +290,12 @@ class JuliaEncoder:
     def encode_positional_items(cls, namedlist):
         encoded = ""
         for index, value in enumerate(namedlist):
-            encoded += "{} => {}, ".format(index + 1, cls.encode_value(value))
+            encoded += f"{index + 1} => {cls.encode_value(value)}, "
         return encoded
 
     @classmethod
     def encode_dict(cls, d):
-        d = "Dict({})".format(cls.encode_items(d.items()))
+        d = f"Dict({cls.encode_items(d.items())})"
         return d
 
     @classmethod

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -55,9 +55,7 @@ class shell:
     def check_output(cls, cmd, **kwargs):
         executable = cls.get_executable()
         if ON_WINDOWS and executable:
-            cmd = '"{}" {} {}'.format(
-                executable, cls._win_command_prefix, argvquote(cmd)
-            )
+            cmd = f'"{executable}" {cls._win_command_prefix} {argvquote(cmd)}'
             return sp.check_output(cmd, shell=False, executable=executable, **kwargs)
         else:
             return sp.check_output(cmd, shell=True, executable=executable, **kwargs)
@@ -69,9 +67,7 @@ class shell:
             cmd = shutil.which(cmd)
             if not cmd:
                 raise WorkflowError(
-                    "Cannot set default shell {} because it "
-                    "is not available in your "
-                    "PATH.".format(cmd)
+                    f"Cannot set default shell {cmd} because it is not available in your PATH."
                 )
         if ON_WINDOWS:
             if cmd is None:
@@ -175,7 +171,7 @@ class shell:
         # incompatible with the module's environment.
         if env_modules and "slurm" not in (item.filename for item in inspect.stack()):
             cmd = env_modules.shellcmd(cmd)
-            logger.info("Activating environment modules: {}".format(env_modules))
+            logger.info(f"Activating environment modules: {env_modules}")
 
         if conda_env:
             if ON_WINDOWS and not cls.get_executable():
@@ -207,11 +203,9 @@ class shell:
                 container_workdir=shadow_dir,
                 is_python_script=context.get("is_python_script", False),
             )
-            logger.info("Activating singularity image {}".format(container_img))
+            logger.info(f"Activating singularity image {container_img}")
         if conda_env:
-            logger.info(
-                "Activating conda environment: {}".format(os.path.relpath(conda_env))
-            )
+            logger.info(f"Activating conda environment: {os.path.relpath(conda_env)}")
 
         tmpdir_resource = resources.get("tmpdir", None)
         # environment variable lists for linear algebra libraries taken from:

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -245,7 +245,7 @@ class HostingProviderFile(SourceFile):
         )
 
     def join(self, path):
-        path = os.path.normpath("{}/{}".format(self.path, path))
+        path = os.path.normpath(f"{self.path}/{path}")
         if ON_WINDOWS:
             # convert back to URL separators
             # (win specific separators are introduced by normpath above)
@@ -276,7 +276,7 @@ class GithubFile(HostingProviderFile):
         self.token = os.environ.get("GITHUB_TOKEN", None)
 
     def get_path_or_uri(self):
-        auth = ":{}@".format(self.token) if self.token else ""
+        auth = f":{self.token}@" if self.token else ""
         return "https://{}raw.githubusercontent.com/{}/{}/{}".format(
             auth, self.repo, self.ref, self.path
         )
@@ -299,7 +299,7 @@ class GitlabFile(HostingProviderFile):
     def get_path_or_uri(self):
         from urllib.parse import quote
 
-        auth = "&private_token={}".format(self.token) if self.token else ""
+        auth = f"&private_token={self.token}" if self.token else ""
         return "https://{}/api/v4/projects/{}/repository/files/{}/raw?ref={}{}".format(
             self.host or "gitlab.com",
             quote(self.repo, safe=""),
@@ -446,7 +446,7 @@ class SourceCache:
 
             return io.BytesIO(
                 git.Repo(source_file.repo_path)
-                .git.show("{}:{}".format(source_file.ref, source_file.path))
+                .git.show(f"{source_file.ref}:{source_file.path}")
                 .encode()
             )
 
@@ -455,4 +455,4 @@ class SourceCache:
         try:
             return open(path_or_uri, mode, encoding=None if "b" in mode else encoding)
         except Exception as e:
-            raise WorkflowError("Failed to open source file {}".format(path_or_uri), e)
+            raise WorkflowError(f"Failed to open source file {path_or_uri}", e)

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -125,7 +125,7 @@ def validate(data, schema, set_default=True):
                             jsonschema.validate(record, schema, resolver=resolver)
                     except jsonschema.exceptions.ValidationError as e:
                         raise WorkflowError(
-                            "Error validating row {} of data frame.".format(i), e
+                            f"Error validating row {i} of data frame.", e
                         )
                 if set_default:
                     newdata = pd.DataFrame(recordlist, data.index)
@@ -337,7 +337,7 @@ class SequenceFormatter(string.Formatter):
     def format_field(self, value, format_spec):
         if isinstance(value, Wildcards):
             return ",".join(
-                "{}={}".format(name, value)
+                f"{name}={value}"
                 for name, value in sorted(value.items(), key=lambda item: item[0])
             )
         if isinstance(value, (list, tuple, set, frozenset)):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -351,10 +351,7 @@ class Workflow:
         gb = bytesto(os.stat(filename).st_size, "g")
         if gb > warning_size_gb:
             logger.warning(
-                "File {} (size {} GB) is greater than the {} GB suggested size "
-                "Consider uploading larger files to storage first.".format(
-                    filename, gb, warning_size_gb
-                )
+                f"File {filename} (size {gb} GB) is greater than the {warning_size_gb} GB suggested size Consider uploading larger files to storage first."
             )
         return filename
 
@@ -418,7 +415,7 @@ class Workflow:
         is_overwrite = self.is_rule(name)
         if not allow_overwrite and is_overwrite:
             raise CreateRuleException(
-                "The name {} is already used by another rule".format(name),
+                f"The name {name} is already used by another rule",
                 lineno=lineno,
                 snakefile=snakefile,
             )
@@ -782,7 +779,7 @@ class Workflow:
                 )
                 updated = list()
                 if subworkflow_targets:
-                    logger.info("Executing subworkflow {}.".format(subworkflow.name))
+                    logger.info(f"Executing subworkflow {subworkflow.name}.")
                     if not subsnakemake(
                         subworkflow.snakefile,
                         workdir=subworkflow.workdir,
@@ -802,9 +799,7 @@ class Workflow:
                     )
                 else:
                     logger.info(
-                        "Subworkflow {}: {}".format(
-                            subworkflow.name, NOTHING_TO_BE_DONE_MSG
-                        )
+                        f"Subworkflow {subworkflow.name}: {NOTHING_TO_BE_DONE_MSG}"
                     )
             if self.subworkflows:
                 logger.info("Executing main workflow.")
@@ -1010,13 +1005,11 @@ class Workflow:
             if len(dag):
                 shell_exec = shell.get_executable()
                 if shell_exec is not None:
-                    logger.info("Using shell: {}".format(shell_exec))
+                    logger.info(f"Using shell: {shell_exec}")
                 if cluster or cluster_sync or drmaa:
-                    logger.resources_info(
-                        "Provided cluster nodes: {}".format(self.nodes)
-                    )
+                    logger.resources_info(f"Provided cluster nodes: {self.nodes}")
                 elif kubernetes or tibanna or google_lifesciences:
-                    logger.resources_info("Provided cloud nodes: {}".format(self.nodes))
+                    logger.resources_info(f"Provided cloud nodes: {self.nodes}")
                 else:
                     if self._cores is not None:
                         warning = (
@@ -1024,16 +1017,14 @@ class Workflow:
                             if self._cores > 1
                             else " (use --cores to define parallelism)"
                         )
-                        logger.resources_info(
-                            "Provided cores: {}{}".format(self._cores, warning)
-                        )
+                        logger.resources_info(f"Provided cores: {self._cores}{warning}")
                         logger.resources_info(
                             "Rules claiming more threads " "will be scaled down."
                         )
 
                 provided_resources = format_resources(self.global_resources)
                 if provided_resources:
-                    logger.resources_info("Provided resources: " + provided_resources)
+                    logger.resources_info(f"Provided resources: {provided_resources}")
 
                 if self.run_local and any(rule.group for rule in self.rules):
                     logger.info("Group jobs: inactive (local execution)")
@@ -1216,7 +1207,7 @@ class Workflow:
         snakefile = infer_source_file(snakefile, basedir)
 
         if not self.modifier.allow_rule_overwrite and snakefile in self.included:
-            logger.info("Multiple includes of {} ignored".format(snakefile))
+            logger.info(f"Multiple includes of {snakefile} ignored")
             return
         self.included.append(snakefile)
         self.included_stack.append(snakefile)
@@ -1277,7 +1268,7 @@ class Workflow:
             n = self._scatter[key]
             return expand(
                 *args,
-                scatteritem=map("{{}}-of-{}".format(n).format, range(1, n + 1)),
+                scatteritem=map(f"{{}}-of-{n}".format, range(1, n + 1)),
                 **wildcards,
             )
 
@@ -1647,7 +1638,7 @@ class Workflow:
             if ruleinfo.localrule is True:
                 self._localrules.add(rule.name)
 
-            ruleinfo.func.__name__ = "__{}".format(rule.name)
+            ruleinfo.func.__name__ = f"__{rule.name}"
             self.globals[ruleinfo.func.__name__] = ruleinfo.func
 
             rule_proxy = RuleProxy(rule)

--- a/snakemake/wrapper.py
+++ b/snakemake/wrapper.py
@@ -50,11 +50,11 @@ def is_url(path):
 
 def find_extension(source_file, sourcecache: SourceCache):
     for ext in EXTENSIONS:
-        if source_file.get_filename().endswith("wrapper{}".format(ext)):
+        if source_file.get_filename().endswith(f"wrapper{ext}"):
             return source_file
 
     for ext in EXTENSIONS:
-        script = source_file.join("wrapper{}".format(ext))
+        script = source_file.join(f"wrapper{ext}")
 
         if sourcecache.exists(script):
             return script


### PR DESCRIPTION
### Description

Python support f-string since python 3.6.  Formatting strings with f-string has an higher readablity due to easier and more compressed syntax and is a tiny bit faster. This pull request rewrite format() and %s syntax to f-strings. However, there are still places were format is used because it is not straightforward to convert them without risk of breaking code. Most work is done with [ruff](https://beta.ruff.rs/docs/) 

`ruff check --select UP032,UP031,F541  . `

This pull request touches a lot of lines, so this might break other work in progress. 


### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
