### PR TITLE
feat: Allow the environment variable SNAKEMAKE_CONDA_PREFIX to be present without --use-conda

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2764,7 +2764,7 @@ def main(argv=None):
         sys.exit(1)
 
     if (args.conda_prefix or args.conda_create_envs_only) and not args.use_conda:
-        if os.environ.get("SNAKEMAKE_CONDA_PREFIX", False):
+        if args.conda_prefix and os.environ.get("SNAKEMAKE_CONDA_PREFIX", False):
             print(
                 "Warning: The enviorment variable SNAKEMAKE_CONDA_PREFIX is set"
                 "but --use-conda is not."

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -2764,12 +2764,22 @@ def main(argv=None):
         sys.exit(1)
 
     if (args.conda_prefix or args.conda_create_envs_only) and not args.use_conda:
-        print(
-            "Error: --use-conda must be set if --conda-prefix or "
-            "--create-envs-only is set.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        if os.environ.get("SNAKEMAKE_CONDA_PREFIX", False):
+            print(
+                "Warning: The enviorment variable SNAKEMAKE_CONDA_PREFIX is set"
+                "but --use-conda is not."
+                "Snakemake will ignore SNAKEMAKE_CONDA_PREFIX"
+                "and conda enviorments will not be used or created.",
+                file=sys.stderr,
+            )
+            args.conda_prefix = None
+        else:
+            print(
+                "Error: --use-conda must be set if --conda-prefix or "
+                "--create-envs-only is set.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     if args.singularity_prefix and not args.use_singularity:
         print(


### PR DESCRIPTION
### Description

SNAKEMAKE_CONDA_PREFIX is a great tool for shared computing environments and I am encouraging everyone in our lab to set it in their `.bashrc` it to help with the number of conda builds we have and reduce file usage. However, there is one downside and that is it becomes impossible to run a non conda snakemake without clearing the environment variable because the lack of `--use-conda` will force snakemake to exit.

In this PR I suggest a quality of life improvement. Instead of having snakemake error out, it will instead warn that the environment variable is set but conda environments will not be used or built because `--use-conda` is not set. Note, this will only happen when the environment variable is set and not when it is passed as a command line argument. 

Thanks for considering!

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
