### PR TITLE
refactor: removed unused import

### DIFF
--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -3,20 +3,16 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-from collections import defaultdict
 import os
-import subprocess
 import glob
-from argparse import ArgumentError, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentDefaultsHelpFormatter
 import logging as _logging
 import re
 import sys
-import inspect
 import threading
 import webbrowser
 from functools import partial
 import importlib
-import shutil
 import shlex
 from importlib.machinery import SourceFileLoader
 from snakemake.target_jobs import parse_target_jobs_cli_args
@@ -29,7 +25,7 @@ from snakemake.exceptions import (
     print_exception,
     WorkflowError,
 )
-from snakemake.logging import setup_logger, logger, SlackLogger, WMSLogger
+from snakemake.logging import setup_logger, logger
 from snakemake.io import load_configfile, wait_for_files
 from snakemake.shell import shell
 from snakemake.utils import update_config, available_cpu_count

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -25,7 +25,7 @@ from snakemake.exceptions import (
     print_exception,
     WorkflowError,
 )
-from snakemake.logging import setup_logger, logger
+from snakemake.logging import setup_logger, logger, SlackLogger, WMSLogger
 from snakemake.io import load_configfile, wait_for_files
 from snakemake.shell import shell
 from snakemake.utils import update_config, available_cpu_count

--- a/snakemake/benchmark.py
+++ b/snakemake/benchmark.py
@@ -7,11 +7,9 @@ import contextlib
 import datetime
 from itertools import chain
 import os
-import sys
 import time
 import threading
 
-from snakemake.exceptions import WorkflowError
 from snakemake.logging import logger
 
 #: Interval (in seconds) between measuring resource usage

--- a/snakemake/caching/__init__.py
+++ b/snakemake/caching/__init__.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 import os
 
 from snakemake.jobs import Job
-from snakemake.io import is_flagged, get_flag_value, apply_wildcards
+from snakemake.io import apply_wildcards
 from snakemake.exceptions import WorkflowError, CacheMissException
 from snakemake.caching.hash import ProvenanceHashMap
 

--- a/snakemake/caching/local.py
+++ b/snakemake/caching/local.py
@@ -12,8 +12,7 @@ import stat
 from snakemake.logging import logger
 from snakemake.jobs import Job
 from snakemake.exceptions import WorkflowError
-from snakemake.caching.hash import ProvenanceHashMap
-from snakemake.caching import LOCATION_ENVVAR, AbstractOutputFileCache
+from snakemake.caching import AbstractOutputFileCache
 
 
 class OutputFileCache(AbstractOutputFileCache):

--- a/snakemake/caching/remote.py
+++ b/snakemake/caching/remote.py
@@ -5,11 +5,10 @@ __license__ = "MIT"
 
 import os
 
-from snakemake.caching.hash import ProvenanceHashMap
 from snakemake.caching import AbstractOutputFileCache
 from snakemake.exceptions import WorkflowError
 from snakemake.jobs import Job
-from snakemake.io import get_flag_value, IOFile
+from snakemake.io import get_flag_value
 
 
 class OutputFileCache(AbstractOutputFileCache):

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -5,7 +5,6 @@ __license__ = "MIT"
 
 import concurrent.futures
 import contextlib
-from functools import update_wrapper
 import itertools
 import math
 import platform
@@ -15,7 +14,6 @@ import threading
 import uuid
 import os
 import asyncio
-import sys
 import collections
 from pathlib import Path
 

--- a/snakemake/cwl.py
+++ b/snakemake/cwl.py
@@ -5,19 +5,15 @@ __license__ = "MIT"
 
 from urllib.request import pathname2url
 import os
-import subprocess
 import tempfile
 import json
 import shutil
-import uuid
 from itertools import chain
 
 from snakemake.utils import format
-from snakemake.logging import logger
 from snakemake.exceptions import WorkflowError
 from snakemake.shell import shell
 from snakemake.common import get_container_image, Mode
-from snakemake.io import is_flagged
 
 
 def cwl(

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -16,7 +16,6 @@ from itertools import chain, filterfalse, groupby
 from functools import partial
 from pathlib import Path
 import uuid
-import math
 import subprocess
 
 from snakemake.io import (
@@ -25,7 +24,6 @@ from snakemake.io import (
     is_callable,
     wait_for_files,
     is_flagged,
-    IOFile,
 )
 from snakemake.jobs import Reason, JobFactory, GroupJobFactory, Job
 from snakemake.exceptions import MissingInputException, WildcardError
@@ -37,7 +35,7 @@ from snakemake.exceptions import RemoteFileException, WorkflowError, ChildIOExce
 from snakemake.exceptions import InputFunctionException
 from snakemake.logging import logger
 from snakemake.common import DYNAMIC_FILL, ON_WINDOWS, group_into_chunks, is_local_file
-from snakemake.deployment import conda, singularity
+from snakemake.deployment import singularity
 from snakemake.output_index import OutputIndex
 from snakemake import workflow
 from snakemake.sourcecache import LocalSourceFile, SourceFile

--- a/snakemake/decorators.py
+++ b/snakemake/decorators.py
@@ -3,7 +3,6 @@ __copyright__ = "Copyright 2022, Christopher Tomkins-Tinch"
 __email__ = "tomkinsc@broadinstitute.org"
 __license__ = "MIT"
 
-import functools
 import inspect
 
 

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -263,12 +263,6 @@ class Env:
         """Create self-contained archive of environment."""
         from snakemake.shell import shell
 
-        try:
-            pass
-        except ImportError:
-            raise WorkflowError(
-                "Error importing PyYAML. " "Please install PyYAML to archive workflows."
-            )
         # importing requests locally because it interferes with instantiating conda environments
         import requests
 

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -14,8 +14,6 @@ from snakemake.sourcecache import (
 )
 import subprocess
 import tempfile
-from urllib.request import urlopen
-from urllib.error import URLError
 import hashlib
 import shutil
 from distutils.version import StrictVersion
@@ -36,16 +34,13 @@ from snakemake.common import (
     is_local_file,
     lazy_property,
     parse_uri,
-    strip_prefix,
     ON_WINDOWS,
 )
-from snakemake import utils
 from snakemake.deployment import singularity, containerize
 from snakemake.io import (
     IOFile,
     apply_wildcards,
     contains_wildcard,
-    git_content,
     _IOFile,
 )
 
@@ -269,7 +264,7 @@ class Env:
         from snakemake.shell import shell
 
         try:
-            import yaml
+            pass
         except ImportError:
             raise WorkflowError(
                 "Error importing PyYAML. " "Please install PyYAML to archive workflows."

--- a/snakemake/deployment/containerize.py
+++ b/snakemake/deployment/containerize.py
@@ -2,10 +2,7 @@ from pathlib import Path
 import hashlib
 import os
 
-from snakemake.common import get_container_image
-from snakemake.io import contains_wildcard
 from snakemake.exceptions import WorkflowError
-from snakemake.deployment import conda
 from snakemake.logging import logger
 from snakemake.sourcecache import LocalSourceFile
 

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -9,8 +9,6 @@ import os
 import hashlib
 from distutils.version import LooseVersion
 
-import snakemake
-from snakemake.deployment.conda import Conda
 from snakemake.common import (
     is_local_file,
     parse_uri,

--- a/snakemake/executors/__init__.py
+++ b/snakemake/executors/__init__.py
@@ -9,21 +9,16 @@ import os
 import sys
 import contextlib
 import time
-import datetime
 import json
-import textwrap
 import stat
 import shutil
 import shlex
 import threading
 import concurrent.futures
 import subprocess
-import signal
 import tempfile
 from functools import partial
-from itertools import chain
 from collections import namedtuple
-import random
 import base64
 import uuid
 import re
@@ -31,32 +26,26 @@ import math
 from snakemake.target_jobs import encode_target_jobs_cli_args
 from fractions import Fraction
 
-from snakemake.jobs import Job
 from snakemake.shell import shell
 from snakemake.logging import logger
 from snakemake.stats import Stats
-from snakemake.utils import format, Unformattable, makedirs
+from snakemake.utils import makedirs
 from snakemake.io import get_wildcard_names, Wildcards
 from snakemake.exceptions import print_exception, get_exception_origin
 from snakemake.exceptions import format_error, RuleException, log_verbose_traceback
 from snakemake.exceptions import (
-    ProtectedOutputException,
     WorkflowError,
-    ImproperShadowException,
     SpawnedJobError,
     CacheMissException,
 )
 from snakemake.common import (
     Mode,
-    __version__,
     get_container_image,
     get_uuid,
     lazy_property,
-    dict_to_key_value_args,
     async_lock,
 )
-from snakemake.executors.common import format_cli_arg, format_cli_pos_arg, join_cli_args
-from snakemake.io import _IOFile
+from snakemake.executors.common import format_cli_arg, join_cli_args
 
 
 # TODO move each executor into a separate submodule

--- a/snakemake/executors/flux.py
+++ b/snakemake/executors/flux.py
@@ -5,11 +5,9 @@ __license__ = "MIT"
 
 import os
 import shlex
-import sys
 from collections import namedtuple
 
 from snakemake.executors import ClusterExecutor, sleep
-from snakemake.executors.common import format_cli_arg, join_cli_args
 from snakemake.logging import logger
 from snakemake.resources import DefaultResources
 from snakemake.common import async_lock

--- a/snakemake/executors/ga4gh_tes.py
+++ b/snakemake/executors/ga4gh_tes.py
@@ -5,14 +5,12 @@ __license__ = "MIT"
 
 import asyncio
 import os
-import stat
-import time
 from collections import namedtuple
 
 from snakemake.logging import logger
 from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor
-from snakemake.common import Mode, get_container_image, async_lock
+from snakemake.common import get_container_image, async_lock
 
 TaskExecutionServiceJob = namedtuple(
     "TaskExecutionServiceJob", "job jobid callback error_callback"

--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -5,7 +5,6 @@ __license__ = "MIT"
 
 import logging
 import os
-import sys
 import time
 import shutil
 import tarfile

--- a/snakemake/executors/google_lifesciences_helper.py
+++ b/snakemake/executors/google_lifesciences_helper.py
@@ -9,7 +9,6 @@
 #    gls.py save <bucket> /google/logs/output source/logs
 
 import argparse
-import datetime
 
 from google.cloud import storage
 from glob import glob

--- a/snakemake/executors/slurm/slurm_jobstep.py
+++ b/snakemake/executors/slurm/slurm_jobstep.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-
+from snakemake.common.tbdstring import TBDString
 from snakemake.executors import ClusterExecutor
 
 

--- a/snakemake/executors/slurm/slurm_jobstep.py
+++ b/snakemake/executors/slurm/slurm_jobstep.py
@@ -1,16 +1,7 @@
 import os
 import subprocess
-from snakemake.common.tbdstring import TBDString
 
-from snakemake.jobs import Job
-from snakemake.logging import logger
-from snakemake.deployment.conda import Conda
-from snakemake.exceptions import print_exception
-from snakemake.exceptions import log_verbose_traceback
-from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor
-from snakemake.utils import makedirs
-from snakemake.io import get_wildcard_names, Wildcards
 
 
 class SlurmJobstepExecutor(ClusterExecutor):

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -1,28 +1,16 @@
 from collections import namedtuple
-from functools import partial
 from io import StringIO
 from fractions import Fraction
 import csv
 import os
-import re
-import stat
-import sys
 import time
 import shlex
-import shutil
 import subprocess
-import tarfile
-import tempfile
 import uuid
 
-from snakemake.jobs import Job
 from snakemake.logging import logger
-from snakemake.exceptions import print_exception
-from snakemake.exceptions import log_verbose_traceback
 from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor
-from snakemake.utils import makedirs
-from snakemake.io import get_wildcard_names, Wildcards
 from snakemake.common import async_lock
 
 SlurmJob = namedtuple("SlurmJob", "job jobid callback error_callback slurm_logfile")

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -3,15 +3,12 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-from abc import abstractmethod
-import enum
 import os
 import sys
 import base64
 import tempfile
 import json
 import shutil
-import copy
 
 from collections import defaultdict
 from itertools import chain, filterfalse
@@ -22,7 +19,6 @@ from snakemake.io import (
     IOFile,
     Wildcards,
     Resources,
-    _IOFile,
     is_flagged,
     get_flag_value,
     wait_for_files,
@@ -36,7 +32,6 @@ from snakemake.logging import logger
 from snakemake.common import (
     DYNAMIC_FILL,
     is_local_file,
-    parse_uri,
     lazy_property,
     get_uuid,
     TBDString,

--- a/snakemake/linting/rules.py
+++ b/snakemake/linting/rules.py
@@ -1,7 +1,7 @@
 from itertools import chain
 import re
 
-from snakemake.io import get_wildcard_names, is_flagged
+from snakemake.io import is_flagged
 from snakemake.linting import Linter, Lint, links, NAME_PATTERN
 
 

--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -10,8 +10,6 @@ import re
 from snakemake.exceptions import WorkflowError
 from snakemake.path_modifier import PathModifier
 from snakemake import wrapper
-from snakemake.checkpoints import Checkpoints
-from snakemake.common import Rules, Scatter, Gather
 
 
 def get_name_modifier_func(rules=None, name_modifier=None, parent_modifier=None):

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -1,13 +1,10 @@
 from abc import abstractmethod
-import os, sys
+import os
 from pathlib import Path
-from urllib.error import URLError
 import tempfile
 import re
-import shutil
 
 from snakemake.exceptions import WorkflowError
-from snakemake.shell import shell
 from snakemake.script import get_source, ScriptBase, PythonScript, RScript
 from snakemake.logging import logger
 from snakemake.common import is_local_file

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -3,15 +3,9 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-from tempfile import TemporaryFile
 import tokenize
 import textwrap
-import os
-from urllib.error import HTTPError, URLError, ContentTooShortError
-import urllib.request
-from io import TextIOWrapper
 
-from snakemake.exceptions import WorkflowError
 from snakemake import common
 
 dd = textwrap.dedent

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -36,7 +36,6 @@ class Persistence:
         warn_only=False,
     ):
         try:
-
             self._serialize_param = self._serialize_param_pandas
         except ImportError:
             self._serialize_param = self._serialize_param_builtin

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -5,16 +5,14 @@ __license__ = "MIT"
 
 import os
 import shutil
-import signal
-import marshal
 import pickle
 import json
 import stat
 import tempfile
 import time
 from base64 import urlsafe_b64encode, b64encode
-from functools import lru_cache, partial
-from itertools import filterfalse, count
+from functools import lru_cache
+from itertools import count
 from pathlib import Path
 
 import snakemake.exceptions
@@ -38,7 +36,6 @@ class Persistence:
         warn_only=False,
     ):
         try:
-            import pandas as pd
 
             self._serialize_param = self._serialize_param_pandas
         except ImportError:

--- a/snakemake/remote/AzBlob.py
+++ b/snakemake/remote/AzBlob.py
@@ -16,7 +16,6 @@ import re
 # module specific
 from snakemake.exceptions import WorkflowError, AzureFileException
 from snakemake.remote import (
-    AbstractRemoteObject,
     AbstractRemoteProvider,
     AbstractRemoteRetryObject,
 )

--- a/snakemake/remote/EGA.py
+++ b/snakemake/remote/EGA.py
@@ -4,24 +4,19 @@ __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 
 import os
-import json
 import time
-import uuid
 from collections import namedtuple
 import hashlib
 
 import requests
-from requests.auth import HTTPBasicAuth
 
 
 from snakemake.remote import (
-    AbstractRemoteObject,
     AbstractRemoteProvider,
     check_deprecated_retry,
 )
 from snakemake.exceptions import WorkflowError
 from snakemake.common import lazy_property
-from snakemake.logging import logger
 
 
 EGAFileInfo = namedtuple("EGAFileInfo", ["size", "status", "id", "checksum"])

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -6,15 +6,12 @@ __license__ = "MIT"
 import base64
 import os
 import re
-import struct
 import time
 
 from snakemake.remote import AbstractRemoteObject, AbstractRemoteProvider
 from snakemake.exceptions import WorkflowError, CheckSumMismatchException
 from snakemake.common import lazy_property
 import snakemake.io
-from snakemake.utils import os_sync
-from snakemake.logging import logger
 
 try:
     import google.cloud

--- a/snakemake/remote/NCBI.py
+++ b/snakemake/remote/NCBI.py
@@ -8,7 +8,6 @@ import time
 import os
 import re
 import json
-import logging
 import xml.etree.ElementTree as ET
 
 # module-specific

--- a/snakemake/remote/S3.py
+++ b/snakemake/remote/S3.py
@@ -6,13 +6,9 @@ __license__ = "MIT"
 # built-ins
 import os
 import re
-import math
-import functools
-import concurrent.futures
 
 # module-specific
 from snakemake.remote import (
-    AbstractRemoteObject,
     AbstractRemoteProvider,
     AbstractRemoteRetryObject,
 )

--- a/snakemake/remote/S3Mocked.py
+++ b/snakemake/remote/S3Mocked.py
@@ -4,11 +4,10 @@ __email__ = "tomkinsc@broadinstitute.org"
 __license__ = "MIT"
 
 # built-ins
-import os, sys
+import os
 from contextlib import contextmanager
 import pickle
 import time
-import threading
 import functools
 
 # intra-module

--- a/snakemake/remote/XRootD.py
+++ b/snakemake/remote/XRootD.py
@@ -7,9 +7,7 @@ import os
 from os.path import abspath, join, normpath
 import re
 
-from stat import S_ISREG
 from snakemake.remote import (
-    AbstractRemoteObject,
     AbstractRemoteProvider,
     AbstractRemoteRetryObject,
 )

--- a/snakemake/remote/dropbox.py
+++ b/snakemake/remote/dropbox.py
@@ -6,7 +6,7 @@ __license__ = "MIT"
 import os
 
 # module-specific
-from snakemake.remote import AbstractRemoteProvider, AbstractRemoteObject
+from snakemake.remote import AbstractRemoteProvider
 from snakemake.exceptions import DropboxFileException, WorkflowError
 from snakemake.utils import os_sync
 

--- a/snakemake/remote/gfal.py
+++ b/snakemake/remote/gfal.py
@@ -4,9 +4,7 @@ __email__ = "johannes.koester@tu-dortmund.de"
 __license__ = "MIT"
 
 import os
-import re
 import stat
-from datetime import datetime
 
 from snakemake.remote import (
     AbstractRemoteProvider,

--- a/snakemake/remote/gridftp.py
+++ b/snakemake/remote/gridftp.py
@@ -6,7 +6,6 @@ __license__ = "MIT"
 
 import os
 import subprocess as sp
-import time
 import shutil
 
 from snakemake.exceptions import WorkflowError

--- a/snakemake/remote/iRODS.py
+++ b/snakemake/remote/iRODS.py
@@ -4,16 +4,13 @@ __email__ = "oliver.stolpe@bihealth.org"
 __license__ = "MIT"
 
 import os
-import re
 
-from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime
 from pytz import timezone
 
 # module-specific
 from snakemake.remote import (
     AbstractRemoteProvider,
-    AbstractRemoteObject,
     AbstractRemoteRetryObject,
 )
 from snakemake.exceptions import WorkflowError

--- a/snakemake/remote/webdav.py
+++ b/snakemake/remote/webdav.py
@@ -3,14 +3,13 @@ __copyright__ = "Copyright 2022, Christopher Tomkins-Tinch"
 __email__ = "tomkinsc@broadinstitute.org"
 __license__ = "MIT"
 
-import os, sys
+import os
 import email.utils
 from contextlib import contextmanager
-import functools
 
 # module-specific
-from snakemake.remote import AbstractRemoteProvider, AbstractRemoteObject, DomainObject
-from snakemake.exceptions import WebDAVFileException, WorkflowError
+from snakemake.remote import AbstractRemoteProvider, DomainObject
+from snakemake.exceptions import WorkflowError
 from snakemake.utils import os_sync
 
 try:

--- a/snakemake/remote/zenodo.py
+++ b/snakemake/remote/zenodo.py
@@ -9,12 +9,10 @@ from collections import namedtuple
 import requests
 from requests.exceptions import HTTPError
 from snakemake.remote import (
-    AbstractRemoteObject,
     AbstractRemoteProvider,
     AbstractRemoteRetryObject,
 )
 from snakemake.exceptions import ZenodoFileException, WorkflowError
-from snakemake.common import lazy_property
 
 
 ZenFileInfo = namedtuple(

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -451,12 +451,6 @@ class FileRecord:
 
     def render(self, env, rst_links, categories, files):
         if self.raw_caption is not None:
-            try:
-                pass
-            except ImportError as e:
-                raise WorkflowError(
-                    "Python package jinja2 must be installed to create reports."
-                )
 
             job = self.job
             snakemake = Snakemake(

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -13,19 +13,13 @@ import io
 import uuid
 import json
 import time
-import shutil
-import subprocess as sp
 import itertools
-import csv
-from collections import namedtuple, defaultdict
-from itertools import accumulate, chain
-import urllib.parse
+from collections import defaultdict
 import hashlib
 from zipfile import ZipFile, ZIP_DEFLATED
 from pathlib import Path
 import numbers
 
-import requests
 
 from docutils.parsers.rst.directives.images import Image, Figure
 from docutils.parsers.rst import directives
@@ -46,11 +40,8 @@ from snakemake.io import (
 )
 from snakemake.exceptions import InputFunctionException, WorkflowError
 from snakemake.script import Snakemake
-from snakemake import __version__
 from snakemake.common import (
     get_input_function_aux_params,
-    is_local_file,
-    num_if_possible,
     lazy_property,
 )
 from snakemake import logging
@@ -461,7 +452,7 @@ class FileRecord:
     def render(self, env, rst_links, categories, files):
         if self.raw_caption is not None:
             try:
-                from jinja2 import Template
+                pass
             except ImportError as e:
                 raise WorkflowError(
                     "Python package jinja2 must be installed to create reports."
@@ -575,7 +566,7 @@ def expand_labels(labels, wildcards, job):
 
 def auto_report(dag, path, stylesheet=None):
     try:
-        from jinja2 import Template, Environment, PackageLoader, UndefinedError
+        from jinja2 import Environment, PackageLoader, UndefinedError
     except ImportError as e:
         raise WorkflowError(
             "Python package jinja2 must be installed to create reports."

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -451,7 +451,6 @@ class FileRecord:
 
     def render(self, env, rst_links, categories, files):
         if self.raw_caption is not None:
-
             job = self.job
             snakemake = Snakemake(
                 job.input,

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -3,16 +3,11 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-import math
 import os
-import re
 import types
 import typing
 from snakemake.path_modifier import PATH_MODIFIER_FLAG
-import sys
-import inspect
 import collections
-from urllib.parse import urljoin
 from pathlib import Path
 from itertools import chain
 from functools import partial
@@ -25,9 +20,6 @@ except ImportError:  # python < 3.11
 from snakemake.io import (
     IOFile,
     _IOFile,
-    protected,
-    temp,
-    dynamic,
     Namedlist,
     AnnotatedString,
     contains_wildcard_constraints,

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -4,21 +4,14 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 import os, signal, sys
-import datetime
 import threading
-import operator
-import time
-import math
-import asyncio
 
 from functools import partial
-from collections import defaultdict
-from itertools import chain, accumulate, product
+from itertools import chain, accumulate
 from contextlib import ContextDecorator
 
 from snakemake.executors import (
     AbstractExecutor,
-    ClusterExecutor,
     DryrunExecutor,
     TouchExecutor,
     CPUExecutor,
@@ -36,8 +29,7 @@ from snakemake.executors.flux import FluxExecutor
 from snakemake.executors.google_lifesciences import GoogleLifeSciencesExecutor
 from snakemake.executors.ga4gh_tes import TaskExecutionServiceExecutor
 from snakemake.exceptions import RuleException, WorkflowError, print_exception
-from snakemake.shell import shell
-from snakemake.common import ON_WINDOWS, async_run
+from snakemake.common import ON_WINDOWS
 from snakemake.logging import logger
 
 from fractions import Fraction

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -3,7 +3,6 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-import inspect
 import itertools
 import os
 from collections.abc import Iterable
@@ -20,14 +19,12 @@ import tempfile
 import textwrap
 import sys
 import pickle
-import subprocess
 import collections
 import re
 import json
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Tuple, Pattern, Union, Optional, List
-from urllib.request import urlopen, pathname2url
 from urllib.error import URLError
 
 from snakemake.utils import format
@@ -38,10 +35,7 @@ from snakemake.common import (
     MIN_PY_VERSION,
     SNAKEMAKE_SEARCHPATH,
     ON_WINDOWS,
-    smart_join,
-    is_local_file,
 )
-from snakemake.io import git_content, split_git_path
 from snakemake.deployment import singularity
 
 # TODO use this to find the right place for inserting the preamble

--- a/snakemake/shell.py
+++ b/snakemake/shell.py
@@ -13,7 +13,7 @@ import stat
 import tempfile
 import threading
 
-from snakemake.utils import format, argvquote, cmd_exe_quote, find_bash_on_windows
+from snakemake.utils import format, argvquote, cmd_exe_quote
 from snakemake.common import ON_WINDOWS, RULEFUNC_CONTEXT_MARKER
 from snakemake.logging import logger
 from snakemake.deployment import singularity

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -23,8 +23,7 @@ from snakemake.common import (
     smart_join,
 )
 from snakemake.exceptions import WorkflowError, SourceFileError
-from snakemake.io import git_content, split_git_path
-from snakemake.logging import logger
+from snakemake.io import split_git_path
 
 
 def _check_git_args(tag: str = None, branch: str = None, commit: str = None):

--- a/snakemake/stats.py
+++ b/snakemake/stats.py
@@ -4,7 +4,6 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 import time
-import csv
 import json
 from collections import defaultdict
 

--- a/snakemake/unit_tests/__init__.py
+++ b/snakemake/unit_tests/__init__.py
@@ -1,4 +1,3 @@
-import textwrap
 from itertools import groupby
 from pathlib import Path
 import shutil
@@ -32,7 +31,7 @@ def generate(dag, path, deploy=["conda", "singularity"], configfiles=None):
     logger.info("Generating unit tests for each rule...")
 
     try:
-        from jinja2 import Template, Environment, PackageLoader
+        from jinja2 import Environment, PackageLoader
     except ImportError:
         raise WorkflowError(
             "Python package jinja2 must be installed to create reports."

--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -7,10 +7,8 @@ import os
 import json
 import re
 import inspect
-from typing import DefaultDict
 from snakemake.sourcecache import LocalSourceFile, infer_source_file
 import textwrap
-import platform
 from itertools import chain
 import collections
 import multiprocessing
@@ -18,11 +16,10 @@ import string
 import shlex
 import sys
 from urllib.parse import urljoin
-from urllib.request import url2pathname
 
 from snakemake.io import regex, Namedlist, Wildcards, _load_configfile
 from snakemake.logging import logger
-from snakemake.common import ON_WINDOWS, is_local_file, smart_join
+from snakemake.common import ON_WINDOWS
 from snakemake.exceptions import WorkflowError
 import snakemake
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -6,22 +6,14 @@ __license__ = "MIT"
 import re
 import os
 import sys
-import signal
-import json
-from tokenize import maybe
-from typing import DefaultDict
-import urllib
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from itertools import filterfalse, chain
 from functools import partial
-from operator import attrgetter
 import copy
-import subprocess
-from pathlib import Path, PosixPath
-from urllib.request import pathname2url, url2pathname
+from pathlib import Path
 
 
-from snakemake.logging import logger, format_resources, format_resource_names
+from snakemake.logging import logger, format_resources
 from snakemake.rules import Rule, Ruleorder, RuleProxy
 from snakemake.exceptions import (
     CreateCondaEnvironmentException,
@@ -29,7 +21,6 @@ from snakemake.exceptions import (
     CreateRuleException,
     UnknownRuleException,
     NoRulesException,
-    print_exception,
     WorkflowError,
 )
 from snakemake.shell import shell
@@ -60,6 +51,7 @@ from snakemake.io import (
     IOFile,
     sourcecache_entry,
 )
+
 from snakemake.persistence import Persistence
 from snakemake.utils import update_config
 from snakemake.script import script
@@ -67,13 +59,14 @@ from snakemake.notebook import notebook
 from snakemake.wrapper import wrapper
 from snakemake.cwl import cwl
 from snakemake.template_rendering import render_template
+
+
 import snakemake.wrapper
 from snakemake.common import (
     Mode,
     bytesto,
     ON_WINDOWS,
     is_local_file,
-    parse_uri,
     Rules,
     Scatter,
     Gather,
@@ -81,20 +74,18 @@ from snakemake.common import (
     NOTHING_TO_BE_DONE_MSG,
 )
 from snakemake.utils import simplify_path
-from snakemake.checkpoints import Checkpoint, Checkpoints
+from snakemake.checkpoints import Checkpoints
 from snakemake.resources import DefaultResources, ResourceScopes
 from snakemake.caching.local import OutputFileCache as LocalOutputFileCache
 from snakemake.caching.remote import OutputFileCache as RemoteOutputFileCache
 from snakemake.modules import ModuleInfo, WorkflowModifier, get_name_modifier_func
 from snakemake.ruleinfo import InOutput, RuleInfo
 from snakemake.sourcecache import (
-    GenericSourceFile,
     LocalSourceFile,
     SourceCache,
-    SourceFile,
     infer_source_file,
 )
-from snakemake.deployment.conda import Conda, is_conda_env_file
+from snakemake.deployment.conda import Conda
 from snakemake import sourcecache
 
 

--- a/snakemake/wrapper.py
+++ b/snakemake/wrapper.py
@@ -4,15 +4,9 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 
-import os
-import posixpath
-
-from urllib.error import URLError
-from urllib.request import urlopen
-
 from snakemake.exceptions import WorkflowError
 from snakemake.script import script
-from snakemake.sourcecache import LocalGitFile, SourceCache, infer_source_file
+from snakemake.sourcecache import SourceCache, infer_source_file
 
 
 PREFIX = "https://github.com/snakemake/snakemake-wrappers/raw/"


### PR DESCRIPTION
### Description

Deleted unused import statements to clean the list of imports a bit.  I could not test external packages/tools that use the import in snakemake(I can not test what I do not know) , so a word of caution here.  

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
