### PR TITLE
fix: Detect pandas availability to select serializer

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -35,10 +35,12 @@ class Persistence:
         shadow_prefix=None,
         warn_only=False,
     ):
-        try:
-            self._serialize_param = self._serialize_param_pandas
-        except ModuleNotFoundError:
-            self._serialize_param = self._serialize_param_builtin
+        import importlib.util
+        self._serialize_param = (
+            self._serialize_param_pandas
+            if importlib.util.find_spec("pandas") is not None
+            else self._serialize_param_builtin
+        )
 
         self._max_len = None
 

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -36,6 +36,7 @@ class Persistence:
         warn_only=False,
     ):
         import importlib.util
+
         self._serialize_param = (
             self._serialize_param_pandas
             if importlib.util.find_spec("pandas") is not None

--- a/tests/common.py
+++ b/tests/common.py
@@ -57,7 +57,7 @@ def has_gcloud_service_key():
 
 
 def has_azbatch_account_url():
-    return "AZ_BATCH_ACCOUNT_URL" in os.environ
+    return os.environ.get("AZ_BATCH_ACCOUNT_URL")
 
 
 def has_zenodo_token():

--- a/tests/common.py
+++ b/tests/common.py
@@ -56,6 +56,10 @@ def has_gcloud_service_key():
     return "GCP_AVAILABLE" in os.environ
 
 
+def has_azbatch_account_url():
+    return "AZ_BATCH_ACCOUNT_URL" in os.environ
+
+
 def has_zenodo_token():
     return os.environ.get("ZENODO_SANDBOX_PAT")
 
@@ -65,6 +69,12 @@ gcloud = pytest.mark.skipif(
     reason="Skipping GCLOUD tests because not on "
     "CI, no inet connection or not logged "
     "in to gcloud.",
+)
+
+azbatch = pytest.mark.skipif(
+    not is_connected() or not has_azbatch_account_url(),
+    reason="Skipping AZBATCH tests because "
+    "no inet connection or no AZ_BATCH_ACCOUNT_URL.",
 )
 
 connected = pytest.mark.skipif(not is_connected(), reason="no internet connection")

--- a/tests/test_azure_batch_executor.py
+++ b/tests/test_azure_batch_executor.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from common import *
 
 
+@azbatch
 def test_az_batch_executor():
     # AZ_BATCH_ACCOUNT_URL=https://${batch_account_name}.${region}.batch.azure.com
     bau = os.getenv("AZ_BATCH_ACCOUNT_URL")


### PR DESCRIPTION
### Description

- previous try catch solution wasn't triggered
- use detecting availability of the module instead

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
