### PR TITLE
fix: remove distutils from snakemake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,7 @@ jobs:
           ZENODO_SANDBOX_PAT: "${{ secrets.ZENODO_SANDBOX_PAT }}"
         shell: bash -el {0}
         run: |
-          pytest --show-capture=stderr -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/tests.py tests/test_schema.py tests/test_linting.py tests/tests.py
+          pytest --show-capture=stderr -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/tests.py tests/test_schema.py tests/test_linting.py tests/test_version.py
       - name: Build and publish docker image
         if: >-
           contains(github.event.pull_request.labels.*.name,

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -35,7 +35,7 @@ from snakemake.common import (
     parse_uri,
     ON_WINDOWS,
 )
-from snakemake.deployment import singularity, containerize,version_compare
+from snakemake.deployment import singularity, containerize, version_compare
 
 from snakemake.io import (
     IOFile,
@@ -757,7 +757,7 @@ class Conda:
         else:
             version = version_matches[0]
 
-        if not version_compare.compare_version_geq(version,"4.2"):
+        if not version_compare.compare_version_geq(version, "4.2"):
             raise CreateCondaEnvironmentException(
                 "Conda must be version 4.2 or later, found version {}.".format(version)
             )

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -16,7 +16,10 @@ import subprocess
 import tempfile
 import hashlib
 import shutil
+<<<<<<< HEAD
 from distutils.version import StrictVersion
+=======
+>>>>>>> cb468347 (replaced packaging by home brew version to compare string to fix singularity issues with earlier solution)
 import json
 from glob import glob
 import tarfile
@@ -36,7 +39,8 @@ from snakemake.common import (
     parse_uri,
     ON_WINDOWS,
 )
-from snakemake.deployment import singularity, containerize
+from snakemake.deployment import singularity, containerize,version_compare
+
 from snakemake.io import (
     IOFile,
     apply_wildcards,
@@ -756,7 +760,8 @@ class Conda:
             )
         else:
             version = version_matches[0]
-        if StrictVersion(version) < StrictVersion("4.2"):
+
+        if not version_compare.compare_version_geq(version,"4.2"):
             raise CreateCondaEnvironmentException(
                 "Conda must be version 4.2 or later, found version {}.".format(version)
             )

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -16,10 +16,6 @@ import subprocess
 import tempfile
 import hashlib
 import shutil
-<<<<<<< HEAD
-from distutils.version import StrictVersion
-=======
->>>>>>> cb468347 (replaced packaging by home brew version to compare string to fix singularity issues with earlier solution)
 import json
 from glob import glob
 import tarfile

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -7,7 +7,10 @@ import subprocess
 import shutil
 import os
 import hashlib
+<<<<<<< HEAD
 from distutils.version import LooseVersion
+=======
+>>>>>>> cb468347 (replaced packaging by home brew version to compare string to fix singularity issues with earlier solution)
 
 from snakemake.common import (
     is_local_file,
@@ -17,6 +20,7 @@ from snakemake.common import (
 )
 from snakemake.exceptions import WorkflowError
 from snakemake.logging import logger
+from snakemake.deployment import version_compare
 
 
 SNAKEMAKE_MOUNTPOINT = "/mnt/snakemake"
@@ -173,12 +177,13 @@ class Singularity:
                 )
             if v.startswith("apptainer"):
                 v = v.rsplit(" ", 1)[-1]
-                if not LooseVersion(v) >= LooseVersion("1.0.0"):
-                    raise WorkflowError("Minimum apptainer version is 1.0.0.")
+                if not version_compare.compare_version_geq(v,"1.0.0"):
+                    raise WorkflowError(f"Minimum apptainer version is 1.0.0. Found version {v}")
             else:
                 v = v.rsplit(" ", 1)[-1]
                 if v.startswith("v"):
                     v = v[1:]
-                if not LooseVersion(v) >= LooseVersion("2.4.1"):
-                    raise WorkflowError("Minimum singularity version is 2.4.1.")
+
+                if not version_compare.compare_version_geq(v,"2.4.1"):
+                    raise WorkflowError(f"Minimum singularity version is 2.4.1. Found version {v}")
             self._version = v

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -173,13 +173,17 @@ class Singularity:
                 )
             if v.startswith("apptainer"):
                 v = v.rsplit(" ", 1)[-1]
-                if not version_compare.compare_version_geq(v,"1.0.0"):
-                    raise WorkflowError(f"Minimum apptainer version is 1.0.0. Found version {v}")
+                if not version_compare.compare_version_geq(v, "1.0.0"):
+                    raise WorkflowError(
+                        f"Minimum apptainer version is 1.0.0. Found version {v}"
+                    )
             else:
                 v = v.rsplit(" ", 1)[-1]
                 if v.startswith("v"):
                     v = v[1:]
 
-                if not version_compare.compare_version_geq(v,"2.4.1"):
-                    raise WorkflowError(f"Minimum singularity version is 2.4.1. Found version {v}")
+                if not version_compare.compare_version_geq(v, "2.4.1"):
+                    raise WorkflowError(
+                        f"Minimum singularity version is 2.4.1. Found version {v}"
+                    )
             self._version = v

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -7,10 +7,6 @@ import subprocess
 import shutil
 import os
 import hashlib
-<<<<<<< HEAD
-from distutils.version import LooseVersion
-=======
->>>>>>> cb468347 (replaced packaging by home brew version to compare string to fix singularity issues with earlier solution)
 
 from snakemake.common import (
     is_local_file,

--- a/snakemake/deployment/version_compare.py
+++ b/snakemake/deployment/version_compare.py
@@ -1,0 +1,29 @@
+def compare_version_geq(m:str,n:str) -> bool:
+    """
+    a poor man implementation of version comparison. 
+    External implementations are not used, since Snakemake inside containers
+     external packages do not work. e.g.: "tests/tests.py::test_singularity" 
+     would fail
+
+    Only tested with version number of conda,singularity and apptainer
+    """
+    if m==n:
+        return True
+    for q,r in zip(m.split("."),n.split(".")):
+        
+        if q.isdigit():
+            q=int(q)
+        elif "-rc" in q:
+            q=int(q.split("-rc")[0])-1
+
+        if r.isdigit():
+            r=int(r)
+        elif "-rc" in r:
+            r=int(r.split("-rc")[0])-1
+
+        if q>r:
+            return True
+        if q<r:
+            return False
+
+    return False

--- a/snakemake/deployment/version_compare.py
+++ b/snakemake/deployment/version_compare.py
@@ -1,29 +1,28 @@
-def compare_version_geq(m:str,n:str) -> bool:
+def compare_version_geq(m: str, n: str) -> bool:
     """
-    a poor man implementation of version comparison. 
+    a poor man implementation of version comparison.
     External implementations are not used, since Snakemake inside containers
-     external packages do not work. e.g.: "tests/tests.py::test_singularity" 
+     external packages do not work. e.g.: "tests/tests.py::test_singularity"
      would fail
 
     Only tested with version number of conda,singularity and apptainer
     """
-    if m==n:
+    if m == n:
         return True
-    for q,r in zip(m.split("."),n.split(".")):
-        
+    for q, r in zip(m.split("."), n.split(".")):
         if q.isdigit():
-            q=int(q)
+            q = int(q)
         elif "-rc" in q:
-            q=int(q.split("-rc")[0])-1
+            q = int(q.split("-rc")[0]) - 1
 
         if r.isdigit():
-            r=int(r)
+            r = int(r)
         elif "-rc" in r:
-            r=int(r.split("-rc")[0])-1
+            r = int(r.split("-rc")[0]) - 1
 
-        if q>r:
+        if q > r:
             return True
-        if q<r:
+        if q < r:
             return False
 
     return False

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,34 @@
+from snakemake.deployment.singularity import compare_version_geq
+import pytest
+
+
+def test_versiongt():
+    #test cases are based upon releases found in apptainer and singularity
+    assert compare_version_geq("1.0.0","1.0.0") == True
+    assert compare_version_geq("1.0.1","1.0.0") == True
+    assert compare_version_geq("1.1","1.0.0") == True
+    assert compare_version_geq("1.0.0","0.9.9") == True
+    assert compare_version_geq("0.9.9","1.0") == False
+    assert compare_version_geq("0.1.0","1.0") == False
+    assert compare_version_geq("1.0.0-rc.1","1.0.0") == False
+    assert compare_version_geq("1.2.0-rc.1","1.0.0") == True
+    assert compare_version_geq("2.4.1","2.4.1") == True
+    assert compare_version_geq("2.4.5","2.4.1") == True
+    assert compare_version_geq("2.3.1","2.4.1") == False
+    assert compare_version_geq("2.4.1-rc1","2.4.1") == False
+    assert compare_version_geq("3.10.0-rc.1","3.10.0") == False
+    assert compare_version_geq("2023.03-0","4.2") == True
+    assert compare_version_geq("2023.03-1","4.2") == True
+    assert compare_version_geq("4.2","2023.03-1") == False
+    assert compare_version_geq("2023.03-0","2023.03-1") == False
+     
+
+    
+
+    
+    
+
+
+
+
+

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,32 +3,21 @@ import pytest
 
 
 def test_versiongt():
-    #test cases are based upon releases found in apptainer and singularity
-    assert compare_version_geq("1.0.0","1.0.0") == True
-    assert compare_version_geq("1.0.1","1.0.0") == True
-    assert compare_version_geq("1.1","1.0.0") == True
-    assert compare_version_geq("1.0.0","0.9.9") == True
-    assert compare_version_geq("0.9.9","1.0") == False
-    assert compare_version_geq("0.1.0","1.0") == False
-    assert compare_version_geq("1.0.0-rc.1","1.0.0") == False
-    assert compare_version_geq("1.2.0-rc.1","1.0.0") == True
-    assert compare_version_geq("2.4.1","2.4.1") == True
-    assert compare_version_geq("2.4.5","2.4.1") == True
-    assert compare_version_geq("2.3.1","2.4.1") == False
-    assert compare_version_geq("2.4.1-rc1","2.4.1") == False
-    assert compare_version_geq("3.10.0-rc.1","3.10.0") == False
-    assert compare_version_geq("2023.03-0","4.2") == True
-    assert compare_version_geq("2023.03-1","4.2") == True
-    assert compare_version_geq("4.2","2023.03-1") == False
-    assert compare_version_geq("2023.03-0","2023.03-1") == False
-     
-
-    
-
-    
-    
-
-
-
-
-
+    # test cases are based upon releases found in apptainer and singularity
+    assert compare_version_geq("1.0.0", "1.0.0") == True
+    assert compare_version_geq("1.0.1", "1.0.0") == True
+    assert compare_version_geq("1.1", "1.0.0") == True
+    assert compare_version_geq("1.0.0", "0.9.9") == True
+    assert compare_version_geq("0.9.9", "1.0") == False
+    assert compare_version_geq("0.1.0", "1.0") == False
+    assert compare_version_geq("1.0.0-rc.1", "1.0.0") == False
+    assert compare_version_geq("1.2.0-rc.1", "1.0.0") == True
+    assert compare_version_geq("2.4.1", "2.4.1") == True
+    assert compare_version_geq("2.4.5", "2.4.1") == True
+    assert compare_version_geq("2.3.1", "2.4.1") == False
+    assert compare_version_geq("2.4.1-rc1", "2.4.1") == False
+    assert compare_version_geq("3.10.0-rc.1", "3.10.0") == False
+    assert compare_version_geq("2023.03-0", "4.2") == True
+    assert compare_version_geq("2023.03-1", "4.2") == True
+    assert compare_version_geq("4.2", "2023.03-1") == False
+    assert compare_version_geq("2023.03-0", "2023.03-1") == False

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-from snakemake.deployment.singularity import compare_version_geq
+from snakemake/deployment/version_compare import compare_version_geq
 import pytest
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,9 @@
-from snakemake/deployment/version_compare import compare_version_geq
+from snakemake.deployment.version_compare import compare_version_geq
 import pytest
 
 
 def test_versiongt():
-    # test cases are based upon releases found in apptainer and singularity
+    # Test cases are based upon releases found in apptainer and singularity
     assert compare_version_geq("1.0.0", "1.0.0") == True
     assert compare_version_geq("1.0.1", "1.0.0") == True
     assert compare_version_geq("1.1", "1.0.0") == True


### PR DESCRIPTION
### Description

Python 3.12 does not support the distutils library any more. In most cases, the go-to solution would be using the `packaging` package. This works in general cases well, but when using singularity this fails because the external packages are not in the container binding  (pytest tests/tests.py::test_singularity would trigger this)

I wrote a poor man version check and wrote test cases for the release numbers available in conda singularity and apptainer.  This works well for the version numbers of these programs, but I would not use this **untested** for other programs' version numbers.


### QC

* [ x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
