### PR TITLE
fix: Solve apptainer version issue

### DIFF
--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -170,6 +170,7 @@ class Singularity:
                 )
             if v.startswith("apptainer"):
                 v = v.rsplit(" ", 1)[-1]
+                v = v.split("-")[0]
                 if parse(v) < parse("1.0.0"):
                     raise WorkflowError("Minimum apptainer version is 1.0.0.")
             else:


### PR DESCRIPTION
### Description

Small fix to solve apptainer 1.1.9-1.el8 issue

```
Traceback (most recent call last):
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/snakemake/__init__.py", line 771, in snakemake
    success = workflow.execute(
              ^^^^^^^^^^^^^^^^^
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/snakemake/workflow.py", line 919, in execute
    dag.pull_container_imgs(
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/snakemake/dag.py", line 367, in pull_container_imgs
    img.pull(dryrun)
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/snakemake/deployment/singularity.py", line 46, in pull
    self.singularity.check()
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/snakemake/deployment/singularity.py", line 174, in check
    if parse(v) < parse("1.0.0"):
       ^^^^^^^^
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/packaging/version.py", line 52, in parse
    return Version(version)
           ^^^^^^^^^^^^^^^^
  File "/g/korbel2/weber/miniconda3/envs/snakemake_latest_latest/lib/python3.11/site-packages/packaging/version.py", line 198, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: '1.1.9-1.el8
'
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
