### PR TITLE
fix: do not allow setting benchmark and between-workflow caching for the same rule. The reason is that when the result is taken from cache, there is no way to fill the benchmark file with any reasonable values.

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1620,6 +1620,15 @@ class Workflow:
                             "Invalid value for cache directive. Use True or 'omit-software'.",
                             rule=rule,
                         )
+            if ruleinfo.benchmark and self.get_cache_mode(rule):
+                raise WorkflowError(
+                    "Rules with a benchmark directive may not be marked as eligible "
+                    "for between-workflow caching at the same time. The reason is that "
+                    "when the result is taken from cache, there is no way to fill the benchmark file with "
+                    "any reasonable values. Either remove the benchmark directive or disable "
+                    "between-workflow caching for this rule.",
+                    rule=rule,
+                )
 
             if ruleinfo.default_target is True:
                 self.default_target = rule.name


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
