### PR TITLE
fix: handle non-PEP440 versions of apptainer/singulariy

### DIFF
--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -157,16 +157,16 @@ class Singularity:
         if raw_version.startswith("v"):
             raw_version = raw_version[1:]
 
-        parsedVersion = None
+        parsed_version = None
         trimend = len(raw_version)
-        while parsedVersion is None:
+        while parsed_version is None:
             try:
-                parsedVersion = packaging.version.Version(raw_version[:trimend])
+                parsed_version = packaging.version.Version(raw_version[:trimend])
             except packaging.version.InvalidVersion:
                 trimend = trimend - 1
                 if trimend == 0:
                     raise packaging.version.InvalidVersion(raw_version)
-        return parsedVersion
+        return parsed_version
 
     def check(self):
         from packaging.version import parse

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -165,7 +165,7 @@ class Singularity:
             except packaging.version.InvalidVersion:
                 trimend = trimend - 1
                 if trimend == 0:
-                    raise packaging.version.InvalidVersion(raw_version)
+                    raise WorkflowError(f"Apptainer/Singularity version cannot be parsed: {raw_version}")
         return parsed_version
 
     def check(self):

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -165,7 +165,9 @@ class Singularity:
             except packaging.version.InvalidVersion:
                 trimend = trimend - 1
                 if trimend == 0:
-                    raise WorkflowError(f"Apptainer/Singularity version cannot be parsed: {raw_version}")
+                    raise WorkflowError(
+                        f"Apptainer/Singularity version cannot be parsed: {raw_version}"
+                    )
         return parsed_version
 
     def check(self):


### PR DESCRIPTION

### Description
Apptainer and singularity use non-PEP440 version numbers like `1.1.8-1.el8` and `3.10.4-dirty`. packaging.version can not handle these version numbers. To mitigate the issue, a character is stripped away at the end of the string until it is parsable by packaging.version.

Should fix #2319  and #2334

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
