### PR TITLE
chore: Remove references to allows_directories

### DIFF
--- a/snakemake/remote/FTP.py
+++ b/snakemake/remote/FTP.py
@@ -28,7 +28,6 @@ except ImportError as e:
 
 class RemoteProvider(AbstractRemoteProvider):
     supports_default = True
-    allows_directories = True
 
     def __init__(
         self, *args, keep_local=False, stay_on_remote=False, is_default=False, **kwargs

--- a/snakemake/remote/SFTP.py
+++ b/snakemake/remote/SFTP.py
@@ -22,7 +22,6 @@ except ImportError as e:
 
 class RemoteProvider(AbstractRemoteProvider):
     supports_default = True
-    allows_directories = True
 
     def __init__(
         self,

--- a/snakemake/remote/__init__.py
+++ b/snakemake/remote/__init__.py
@@ -65,7 +65,6 @@ class AbstractRemoteProvider:
     __metaclass__ = ABCMeta
 
     supports_default = False
-    allows_directories = False
 
     def __init__(
         self, *args, keep_local=False, stay_on_remote=False, is_default=False, **kwargs

--- a/snakemake/remote/gfal.py
+++ b/snakemake/remote/gfal.py
@@ -25,7 +25,6 @@ except ImportError as e:
 
 class RemoteProvider(AbstractRemoteProvider):
     supports_default = True
-    allows_directories = True
 
     gfalcntx = gfal2.creat_context()
 


### PR DESCRIPTION
### Description
The usage of `allows_directories` was removed in #423, but it is still referenced in the code base.
