### PR TITLE
add support for oci registry as storage remote

### DIFF
--- a/examples/tutorial-oras/README.md
+++ b/examples/tutorial-oras/README.md
@@ -1,0 +1,27 @@
+# Snakemake Tutorial with ORAS
+
+This is a derivative of the [Snakemake Tutorial](https://snakemake.readthedocs.io/en/stable/tutorial/tutorial.html)
+that combines the [data needed](https://github.com/snakemake/snakemake-tutorial-data/tree/master) with an OCI registry,
+and downloads using ORAS (OCI Registry as Storage). Given that you have a conda environment ready, you can run as follows:
+
+```bash
+# if you have mamba
+$ snakemake --cores 1 --use-conda
+
+# if you have conda
+$ snakemake --cores 1 --use-conda --conda-frontend=conda
+```
+
+If you don't have conda or mamba (and remove the flag) you'll need samtools, bwa, and the other dependency binaries
+available locally. You can also run this example in a container:
+
+```bash
+$ docker run -v $PWD:/code -it snakemake/snakemake 
+```
+And then (from the same example directory):
+
+```bash
+$ cd /code
+$ pip install oras
+$ snakemake --cores 1 --use-conda
+```

--- a/examples/tutorial-oras/Snakefile
+++ b/examples/tutorial-oras/Snakefile
@@ -1,0 +1,73 @@
+from snakemake.remote import ORAS
+ORAS = ORAS.RemoteProvider()
+
+SAMPLES = ["A", "B"]
+EXTENSIONS = ["", ".amb", ".ann", ".bwt", ".fai", ".pac", ".sa"]
+
+rule all:
+    input:
+        "plots/quals.svg"
+
+rule download:
+    input:
+        ORAS.remote(expand("data/genome.fa{ext}", ext=EXTENSIONS), artifact="ghcr.io/researchapps/snakemake-tutorial-data:test")
+    output:
+        expand("data/genome.fa{ext}", ext=EXTENSIONS)
+    shell:
+        "touch {output}"
+
+rule bwa_map:
+    input:
+        "data/genome.fa",
+        ORAS.remote("data/samples/{sample}.fastq", artifact="ghcr.io/researchapps/snakemake-tutorial-data:test")
+    output:
+        "mapped_reads/{sample}.bam"
+    conda:
+        "environment.yaml"
+    shell:
+        "bwa mem {input} | samtools view -Sb - > {output}"
+
+rule samtools_sort:
+    input:
+        "mapped_reads/{sample}.bam"
+    output:
+        "sorted_reads/{sample}.bam"
+    conda:
+        "environment.yaml"
+    shell:
+        "samtools sort -T sorted_reads/{wildcards.sample} "
+        "-O bam {input} > {output}"
+
+rule samtools_index:
+    input:
+        "sorted_reads/{sample}.bam"
+    output:
+        "sorted_reads/{sample}.bam.bai"
+    conda:
+        "environment.yaml"
+    shell:
+        "samtools index {input}"
+
+
+rule bcftools_call:
+    input:
+        "data/genome.fa",
+        bam=expand("sorted_reads/{sample}.bam", sample=SAMPLES),
+        bai=expand("sorted_reads/{sample}.bam.bai", sample=SAMPLES)
+    output:
+        "calls/all.vcf"
+    conda:
+        "environment.yaml"
+    shell:
+        "bcftools mpileup -f data/genome.fa {input.bam} | bcftools call -mv - > {output}"
+
+
+rule plot_quals:
+    input:
+        "calls/all.vcf"
+    output:
+        "plots/quals.svg"
+    conda:
+        "environment.yaml"
+    script:
+        "scripts/plot-quals.py"

--- a/examples/tutorial-oras/environment.yaml
+++ b/examples/tutorial-oras/environment.yaml
@@ -1,0 +1,13 @@
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - snakemake-minimal >=7.3
+  - jinja2
+  - matplotlib
+  - graphviz
+  - bcftools =1.15
+  - samtools =1.15
+  - bwa =0.7.17
+  - pysam =0.19
+  - pygments

--- a/examples/tutorial-oras/scripts/plot-quals.py
+++ b/examples/tutorial-oras/scripts/plot-quals.py
@@ -1,0 +1,9 @@
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from pysam import VariantFile
+
+quals = [record.qual for record in VariantFile(snakemake.input[0])]
+plt.hist(quals)
+
+plt.savefig(snakemake.output[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,8 @@ azure =
     azure-core
     azure-identity
     azure-mgmt-batch
+oras =
+    oras
 
 messaging = slacker
 pep =

--- a/snakemake/remote/ORAS.py
+++ b/snakemake/remote/ORAS.py
@@ -1,0 +1,202 @@
+__author__ = "Johannes Köster"
+__copyright__ = "Copyright 2022, Johannes Köster"
+__email__ = "johannes.koester@tu-dortmund.de"
+__license__ = "MIT"
+
+import os
+import time
+
+from snakemake.remote import AbstractRemoteObject, AbstractRemoteProvider
+from snakemake.exceptions import WorkflowError
+from snakemake.logging import logger
+import snakemake.io
+
+try:
+    import oras
+    import oras.provider
+except ImportError as e:
+    raise WorkflowError(
+        "The Python 3 package 'oras` needs to be installed for this remote. %s" % e.msg
+    )
+
+# Keep cached oras inventories for a session
+caches = {}
+
+
+class ORASCache(oras.provider.Registry):
+    """
+    An ORAS Cache is intended to hold one or more data files.
+
+    To properly index, when the artifact is being created, it is recommended
+    to upload the files listing individually instead of reference of a
+    directory to make it possible to index with Snakemake.
+    """
+
+    def exists(self, artifact, filename):
+        """
+        Determine if a reference exists
+        """
+        if artifact not in caches:
+            self.inventory(artifact, filename)
+
+        if artifact not in caches or filename not in caches[artifact]:
+            return False
+        return filename in caches[artifact]
+
+    def list(self, filename):
+        """
+        Given a path
+        """
+
+    def download(self, artifact, filename):
+        """
+        Download a path (registry and filename) to a destination.
+        """
+        container = self.get_container(artifact)
+        digest = caches[artifact][filename]["digest"]
+        dest = caches[artifact][filename]["annotations"][
+            "org.opencontainers.image.title"
+        ]
+        self.download_blob(container, digest, dest)
+
+    def size(self, artifact, filename):
+        """
+        Get the size of path.
+        """
+        if self.exists(artifact, filename):
+            return caches[artifact][filename]["size"]
+        return 0
+
+    def parent(self, filename):
+        """
+        Derive the parent of a path.
+        """
+        return os.path.dirname(filename)
+
+    def inventory(self, artifact, filename):
+        """
+        Get the inventory of a registry.
+        """
+        container = self.get_container(artifact)
+
+        # Get the manifest with file contents
+        manifest = self.get_manifest(container)
+
+        # Organize by path. ORAS stories the path (name of file) under org.opencontainers.image.title
+        contents = {}
+        for layer in manifest.get("layers", {}):
+            if "org.opencontainers.image.title" not in layer.get("annotations", {}):
+                logger.warning(
+                    f"Layer {layer} is missing ORAS annotation org.opencontainers.image.title and cannot be used."
+                )
+                continue
+            path = layer["annotations"]["org.opencontainers.image.title"]
+            contents[path] = layer
+        caches[artifact] = contents
+        return contents
+
+
+class RemoteProvider(AbstractRemoteProvider):
+    supports_default = True
+
+    def __init__(
+        self, *args, keep_local=False, stay_on_remote=False, is_default=False, **kwargs
+    ):
+        super(RemoteProvider, self).__init__(
+            *args,
+            keep_local=keep_local,
+            stay_on_remote=stay_on_remote,
+            is_default=is_default,
+            **kwargs,
+        )
+        self.client = ORASCache()
+
+    def remote_interface(self):
+        return self.client
+
+    @property
+    def default_protocol(self):
+        """The protocol that is prepended to the path when no protocol is specified."""
+        return "oras://"
+
+    @property
+    def available_protocols(self):
+        """List of valid protocols for this remote provider."""
+        return ["oras://"]
+
+
+class RemoteObject(AbstractRemoteObject):
+    def __init__(
+        self, *args, keep_local=False, provider=None, user_project=None, **kwargs
+    ):
+        super(RemoteObject, self).__init__(
+            *args, keep_local=keep_local, provider=provider, **kwargs
+        )
+        if "artifact" not in kwargs:
+            raise WorkflowError(
+                "The ORAS provider requires an artifact URI from an OCI registry."
+            )
+
+        if provider:
+            self.client = provider.remote_interface()
+        else:
+            self.client = ORASCache()
+
+        # keep user_project available for when bucket is initialized
+        self._user_project = user_project
+        self._artifact = kwargs["artifact"]
+
+    async def inventory(self, cache: snakemake.io.IOCache):
+        if cache.remaining_wait_time <= 0:
+            # No more time to create inventory.
+            return
+
+        contents = self.client.inventory(self._artifact, self._file)
+
+        start_time = time.time()
+        for name, metadata in contents.items():
+            cache.exists_remote[name] = True
+            cache.size[name] = metadata["size"]
+        cache.remaining_wait_time -= time.time() - start_time
+
+    def get_inventory_parent(self):
+        return self.client.parent(self._file)
+
+    def exists(self):
+        return self.client.exists(self._artifact, self._file)
+
+    def mtime(self):
+        if self.client.exists(self._artifact, self._file):
+            return 0
+        else:
+            raise WorkflowError(
+                "The file does not seem to exist remotely: %s" % self.local_file()
+            )
+
+    def size(self):
+        size = self.client.size(self._artifact, self._file)
+        if size:
+            return size
+
+    def _download(self):
+        """Download with maximum retry duration of 600 seconds (10 minutes)"""
+        if not self.exists():
+            return None
+        return self.client.download(self._artifact, self._file)
+
+    def is_directory(self):
+        # TODO not sure if an empty path can be represented in an archive
+        if snakemake.io.is_flagged(self.file(), "directory"):
+            return True
+        elif self.client.exists(self._artifact, self.file()):
+            return False
+        else:
+            return any(self.directory_entries())
+
+    @property
+    def name(self):
+        return self._file
+
+    @property
+    def list(self):
+        return self.client.list(self._file)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - stopit
   - datrie
   - boto3
+  - oras-py
   - moto
   - junit-xml # needed for S3Mocked
   - httpretty

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -762,6 +762,10 @@ def test_remote_gs():
     run(dpath("test_remote_gs"))
 
 
+def test_remote_oras():
+    run(dpath("test_remote_oras"))
+
+
 @pytest.mark.skip(reason="Need to choose how to provide billable project")
 @connected
 @not_ci


### PR DESCRIPTION
### Description

 - Fixes #2351 

This is a WIP to add support for OCI Registry as Storage, or ORAS. I think I have most of the remote provider working, but I'm not great at writing workflows and I need some help writing the small tutorial download step for the snakemake tutorial data. E.g., I have:

```
from snakemake.remote import ORAS
ORAS = ORAS.RemoteProvider()

SAMPLES = ["A", "B"]
EXTENSIONS = ["", ".amb", ".ann", ".bwt", ".fai", ".pac", ".sa"]

rule all:
    input:
        "plots/quals.svg"

rule download:
    input:
        ORAS.remote(expand("data/genome.fa{ext}", ext=EXTENSIONS), artifact="ghcr.io/researchapps/snakemake-tutorial-data:test")
    output:
        expand("data/genome.fa{ext}", ext=EXTENSIONS)
    shell:
        "touch {output}"
```
But it says I have a circular dependency. If I change the output path to something like input it goes away, but I'd really like this to work as is!

```
CyclicGraphException in rule download in file /code/examples/tutorial-oras/Snakefile, line 11:
Cyclic dependency on rule download.
```

I think normally for the tutorial the user downloads all the inputs apriori so it's not an issue. See the Snakefile included here for what I'm trying to do.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
