### PR TITLE
fix: SyntaxWarnings due to non-raw regex pattern strings

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -747,7 +747,7 @@ class Conda:
         version = shell.check_output(
             self._get_cmd("conda --version"), stderr=subprocess.PIPE, text=True
         )
-        version_matches = re.findall("\d+.\d+.\d+", version)
+        version_matches = re.findall(r"\d+.\d+.\d+", version)
         if len(version_matches) != 1:
             raise WorkflowError(
                 f"Unable to determine conda version. 'conda --version' returned {version}"

--- a/snakemake/linting/rules.py
+++ b/snakemake/linting/rules.py
@@ -111,7 +111,7 @@ class RuleLinter(Linter):
                 links=[links.external_scripts, links.notebooks],
             )
 
-    def lint_iofile_by_index(self, rule, regex=re.compile("(input|output)\[[0-9]+\]")):
+    def lint_iofile_by_index(self, rule, regex=re.compile(r"(input|output)\[[0-9]+\]")):
         if rule.shellcmd and regex.search(rule.shellcmd):
             yield Lint(
                 title="Do not access input and output files individually by index in shell commands",

--- a/snakemake/linting/snakefiles.py
+++ b/snakemake/linting/snakefiles.py
@@ -63,7 +63,7 @@ class SnakefileLinter(Linter):
     def lint_envvars(
         self,
         snakefile,
-        regex=re.compile("os.environ\[(?P<quote>['\"])(?P<name>.+)?(?P=quote)\]"),
+        regex=re.compile(r"os.environ\[(?P<quote>['\"])(?P<name>.+)?(?P=quote)\]"),
     ):
         for match in regex.finditer(snakefile):
             line = get_line(match, snakefile)

--- a/snakemake/remote/XRootD.py
+++ b/snakemake/remote/XRootD.py
@@ -151,7 +151,7 @@ class XRootDHelper(object):
 
     def _parse_url(self, url):
         match = re.search(
-            "(?P<domain>(?:[A-Za-z]+://)[A-Za-z0-9:@\_\-\.]+\:?/)(?P<path>.+)", url
+            r"(?P<domain>(?:[A-Za-z]+://)[A-Za-z0-9:@\_\-\.]+\:?/)(?P<path>.+)", url
         )
         if match is None:
             return None

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -343,7 +343,7 @@ def infer_source_file(path_or_uri, basedir: SourceFile = None):
 
 class SourceCache:
     cache_whitelist = [
-        "https://raw.githubusercontent.com/snakemake/snakemake-wrappers/\d+\.\d+.\d+"
+        r"https://raw.githubusercontent.com/snakemake/snakemake-wrappers/\d+\.\d+.\d+"
     ]  # TODO add more prefixes for uris that are save to be cached
 
     def __init__(self, runtime_cache_path=None):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1325,7 +1325,7 @@ class Workflow(WorkflowExecutorInterface):
         invalid_envvars = [
             envvar
             for envvar in envvars
-            if re.match("^\w+$", envvar, flags=re.ASCII) is None
+            if re.match(r"^\w+$", envvar, flags=re.ASCII) is None
         ]
         if invalid_envvars:
             raise WorkflowError(
@@ -1410,7 +1410,7 @@ class Workflow(WorkflowExecutorInterface):
         self._scatter.update(self.overwrite_scatter)
 
         # add corresponding wildcard constraint
-        self.global_wildcard_constraints(scatteritem="\d+-of-\d+")
+        self.global_wildcard_constraints(scatteritem=r"\d+-of-\d+")
 
         def func(key, *args, **wildcards):
             n = self._scatter[key]


### PR DESCRIPTION
Fixes warnings of the form:

```
SyntaxWarning: invalid escape sequence '\['
```

Some of these warnings were causing linting test failures on Python 3.12.

### Description

Converts several regex pattern strings to raw strings (`r""`) in order to avoid `SyntaxWarning` due to invalid backslash-escape sequences

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.

The changes in the first commit fix test failures on Python 3.12. It’s not immediately clear how I would test the changes in the second commit, although I confirm that they eliminate (non-failure) `SyntaxWarning` messages when byte-compiling the modules.

* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

No documentation changes are required.