### PR TITLE
docs: basics.rst: suggest VS Code instead of deprecated Atom as IDE

### DIFF
--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -85,7 +85,7 @@ Step 1: Mapping reads
 Our first Snakemake rule maps reads of a given sample to a given reference genome (see :ref:`tutorial-background`).
 For this, we will use the tool bwa_, specifically the subcommand ``bwa mem``.
 In the working directory, **create a new file** called ``Snakefile`` with an editor of your choice.
-We propose to use the integrated development environment (IDE) tool _`Visual Studio Code`, since it provides a good syntax highlighting _`Snakemake extension` and a _`remote extension` for directly using the IDE on a remote server.
+We propose to use the integrated development environment (IDE) tool `Visual Studio Code`_, since it provides a good syntax highlighting `Snakemake extension`_ and a `remote extension`_ for directly using the IDE on a remote server.
 In the Snakefile, define the following rule:
 
 .. code:: python

--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -14,7 +14,9 @@ Basics: An example workflow
 .. _Miniconda: https://conda.pydata.org/miniconda.html
 .. _Conda: https://conda.pydata.org
 .. _Bash: https://www.tldp.org/LDP/Bash-Beginners-Guide/html
-.. _Atom: https://atom.io
+.. _Visual Studio Code: https://code.visualstudio.com/
+.. _Snakemake extension: https://marketplace.visualstudio.com/items?itemName=Snakemake.snakemake-lang
+.. _remote extension: https://marketplace.visualstudio.com/items?itemName=ms-vscode.remote-explorer
 .. _Anaconda: https://anaconda.org
 .. _Graphviz: https://www.graphviz.org
 .. _RestructuredText: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
@@ -83,7 +85,7 @@ Step 1: Mapping reads
 Our first Snakemake rule maps reads of a given sample to a given reference genome (see :ref:`tutorial-background`).
 For this, we will use the tool bwa_, specifically the subcommand ``bwa mem``.
 In the working directory, **create a new file** called ``Snakefile`` with an editor of your choice.
-We propose to use the Atom_ editor, since it provides out-of-the-box syntax highlighting for Snakemake.
+We propose to use the integrated development environment (IDE) tool _`Visual Studio Code`, since it provides a good syntax highlighting _`Snakemake extension` and a _`remote extension` for directly using the IDE on a remote server.
 In the Snakefile, define the following rule:
 
 .. code:: python


### PR DESCRIPTION
### Description

Atom has been deprecated for quite a while, so we should suggest another editor / IDE. We have been using VS Code quite a bit and are very satisfied with its capabilities for developing Snakemake workflows, so that I think this is a reasonable suggestion. But other suggestions are welcome.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
