### PR TITLE
docs: fix a copy&paste (?) mistake

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -321,7 +321,7 @@ To quickly exemplify the latter, you could provide the following workflow profil
     set-threads:
         b: 16
 
-to set the memory requirement of rule ``b`` to 1000 MB.
+to set the (maximum) number of threads rule ``b`` uses to 16.
 
 
 .. _snakefiles-resources:


### PR DESCRIPTION
### Description

The current documentation mentions, within the tutorial:

```
set-threads:
    b: 16

to set the memory requirement of rule b to 1000 MB.
```
which is apparently a copy&paste left-over from a similar section within the same document:
```
set-resources:
    b:
        mem_mb: 1000

to set the memory requirement of rule b to 1000 MB.
```
This request fixes this.



### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
    - **does not apply**
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
    - **This is only a documentation change.**
