### PR TITLE
fix: do not overwrite default resources setting in azure batch executor

### DIFF
--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -291,7 +291,6 @@ class AzBatchExecutor(ClusterExecutor):
             dirname = dirname.removeprefix(osxprefix)
 
         self.workdir = dirname
-        self.workflow.default_resources = DefaultResources(mode="bare")
 
         # Relative path for running on instance
         self._set_snakefile()


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
