### PR TITLE
style: ExecutorJobInterface->JobExecutorInterface

### DIFF
--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -24,7 +24,7 @@ from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor, sleep
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 from snakemake.logging import logger
@@ -426,7 +426,7 @@ class AzBatchExecutor(ClusterExecutor):
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,

--- a/snakemake/executors/flux.py
+++ b/snakemake/executors/flux.py
@@ -11,7 +11,7 @@ from snakemake.exceptions import WorkflowError
 from snakemake.executors import ClusterExecutor, sleep
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 from snakemake.logging import logger
@@ -79,7 +79,7 @@ class FluxExecutor(ClusterExecutor):
                 flux.job.cancel(self.f, job.jobid)
         self.shutdown()
 
-    def _set_job_resources(self, job: ExecutorJobInterface):
+    def _set_job_resources(self, job: JobExecutorInterface):
         """
         Given a particular job, generate the resources that it needs,
         including default regions and the virtual machine configuration
@@ -92,13 +92,13 @@ class FluxExecutor(ClusterExecutor):
         assert os.path.exists(self.workflow.main_snakefile)
         return self.workflow.main_snakefile
 
-    def _get_jobname(self, job: ExecutorJobInterface):
+    def _get_jobname(self, job: JobExecutorInterface):
         # Use a dummy job name (human readable and also namespaced)
         return f"snakejob-{self.run_namespace}-{job.name}-{job.jobid}"
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,

--- a/snakemake/executors/ga4gh_tes.py
+++ b/snakemake/executors/ga4gh_tes.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 from snakemake.logging import logger
@@ -77,7 +77,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
             max_status_checks_per_second=max_status_checks_per_second,
         )
 
-    def get_job_exec_prefix(self, job: ExecutorJobInterface):
+    def get_job_exec_prefix(self, job: JobExecutorInterface):
         return "mkdir /tmp/conda && cd /tmp"
 
     def shutdown(self):
@@ -98,7 +98,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,
@@ -223,7 +223,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
         logger.warning(members)
         return model(**members)
 
-    def _get_task_description(self, job: ExecutorJobInterface):
+    def _get_task_description(self, job: JobExecutorInterface):
         description = ""
         if job.is_group():
             msgs = [i.message for i in job.jobs if i.message]
@@ -235,7 +235,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
 
         return description
 
-    def _get_task_inputs(self, job: ExecutorJobInterface, jobscript, checkdir):
+    def _get_task_inputs(self, job: JobExecutorInterface, jobscript, checkdir):
         inputs = []
 
         # add workflow sources to inputs
@@ -277,7 +277,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
                 outputs.append(obj)
         return outputs
 
-    def _get_task_outputs(self, job: ExecutorJobInterface, checkdir):
+    def _get_task_outputs(self, job: JobExecutorInterface, checkdir):
         outputs = []
         # add output files to outputs
         outputs = self._append_task_outputs(outputs, job.output, checkdir)
@@ -308,7 +308,7 @@ class TaskExecutionServiceExecutor(ClusterExecutor):
         )
         return executors
 
-    def _get_task(self, job: ExecutorJobInterface, jobscript):
+    def _get_task(self, job: JobExecutorInterface, jobscript):
         import tes
 
         checkdir, _ = os.path.split(self.snakefile)

--- a/snakemake/executors/google_lifesciences.py
+++ b/snakemake/executors/google_lifesciences.py
@@ -17,7 +17,7 @@ import math
 
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 from snakemake.logging import logger
@@ -456,7 +456,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
             rule = self.workflow.get_rule(rule_name)
             rule.restart_times = restart_times
 
-    def _generate_job_resources(self, job: ExecutorJobInterface):
+    def _generate_job_resources(self, job: JobExecutorInterface):
         """
         Given a particular job, generate the resources that it needs,
         including default regions and the virtual machine configuration
@@ -757,7 +757,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
 
         _upload()
 
-    def _generate_log_action(self, job: ExecutorJobInterface):
+    def _generate_log_action(self, job: JobExecutorInterface):
         """generate an action to save the pipeline logs to storage."""
         # script should be changed to this when added to version control!
         # https://raw.githubusercontent.com/snakemake/snakemake/main/snakemake/executors/google_lifesciences_helper.py
@@ -779,7 +779,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
 
         return action
 
-    def _generate_job_action(self, job: ExecutorJobInterface):
+    def _generate_job_action(self, job: JobExecutorInterface):
         """
         Generate a single action to execute the job.
         """
@@ -813,11 +813,11 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
         }
         return action
 
-    def _get_jobname(self, job: ExecutorJobInterface):
+    def _get_jobname(self, job: JobExecutorInterface):
         # Use a dummy job name (human readable and also namespaced)
         return f"snakejob-{self.run_namespace}-{job.name}-{job.jobid}"
 
-    def _generate_pipeline_labels(self, job: ExecutorJobInterface):
+    def _generate_pipeline_labels(self, job: JobExecutorInterface):
         """
         Generate basic labels to identify the job, namespace, and that
         snakemake is running the show!
@@ -842,7 +842,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
             logger.warning("This API does not support environment secrets.")
         return envvars
 
-    def _generate_pipeline(self, job: ExecutorJobInterface):
+    def _generate_pipeline(self, job: JobExecutorInterface):
         """
         Based on the job details, generate a google Pipeline object
         to pass to pipelines.run. This includes actions, resources,
@@ -868,7 +868,7 @@ class GoogleLifeSciencesExecutor(ClusterExecutor):
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,

--- a/snakemake/executors/slurm/slurm_jobstep.py
+++ b/snakemake/executors/slurm/slurm_jobstep.py
@@ -4,7 +4,7 @@ from snakemake.common.tbdstring import TBDString
 from snakemake.executors import ClusterExecutor
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 
@@ -59,7 +59,7 @@ class SlurmJobstepExecutor(ClusterExecutor):
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,

--- a/snakemake/executors/slurm/slurm_submit.py
+++ b/snakemake/executors/slurm/slurm_submit.py
@@ -9,7 +9,7 @@ import subprocess
 import uuid
 from snakemake.interfaces import (
     DAGExecutorInterface,
-    ExecutorJobInterface,
+    JobExecutorInterface,
     WorkflowExecutorInterface,
 )
 
@@ -151,7 +151,7 @@ class SlurmExecutor(ClusterExecutor):
                 logger.warning("Unable to cancel jobs within a minute.")
         self.shutdown()
 
-    def get_account_arg(self, job: ExecutorJobInterface):
+    def get_account_arg(self, job: JobExecutorInterface):
         """
         checks whether the desired account is valid,
         returns a default account, if applicable
@@ -178,7 +178,7 @@ class SlurmExecutor(ClusterExecutor):
                     )
             return self._fallback_account_arg
 
-    def get_partition_arg(self, job: ExecutorJobInterface):
+    def get_partition_arg(self, job: JobExecutorInterface):
         """
         checks whether the desired partition is valid,
         returns a default partition, if applicable
@@ -197,7 +197,7 @@ class SlurmExecutor(ClusterExecutor):
 
     def run(
         self,
-        job: ExecutorJobInterface,
+        job: JobExecutorInterface,
         callback=None,
         submit_callback=None,
         error_callback=None,

--- a/snakemake/interfaces.py
+++ b/snakemake/interfaces.py
@@ -219,7 +219,7 @@ class GroupJobExecutorInterface(JobExecutorInterface, ABC):
         ...
 
 
-class DAGExecutorInterface(JobExecutorInterface, ABC):
+class DAGExecutorInterface(ABC):
     @abstractmethod
     def is_edit_notebook_job(self, job: JobExecutorInterface):
         ...
@@ -237,13 +237,13 @@ class DAGExecutorInterface(JobExecutorInterface, ABC):
         ...
 
 
-class JobSchedulerExecutorInterface(JobExecutorInterface, ABC):
+class JobSchedulerExecutorInterface(ABC):
     @abstractmethod
     def executor_error_callback(self, exception):
         ...
 
 
-class PersistenceExecutorInterface(JobExecutorInterface, ABC):
+class PersistenceExecutorInterface(ABC):
     @abstractmethod
     def cleanup(self):
         ...
@@ -259,7 +259,7 @@ class PersistenceExecutorInterface(JobExecutorInterface, ABC):
         ...
 
 
-class WorkflowExecutorInterface(JobExecutorInterface, ABC):
+class WorkflowExecutorInterface(ABC):
     @property
     @abstractmethod
     def latency_wait(self) -> int:

--- a/snakemake/interfaces.py
+++ b/snakemake/interfaces.py
@@ -147,10 +147,9 @@ class JobExecutorInterface(ABC):
 
 
 class SingleJobExecutorInterface(JobExecutorInterface, ABC):
-    @property
     @abstractmethod
-    def rule(self):
-        ...
+    def __init__(self, rule):
+        self.rule = rule
 
     @abstractmethod
     def prepare(self):

--- a/snakemake/interfaces.py
+++ b/snakemake/interfaces.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from typing import Optional, List, Dict
 
 
-class ExecutorJobInterface(ABC):
+class JobExecutorInterface(ABC):
     @property
     @abstractmethod
     def name(self):
@@ -110,11 +110,6 @@ class ExecutorJobInterface(ABC):
 
     @property
     @abstractmethod
-    def resources(self):
-        ...
-
-    @property
-    @abstractmethod
     def log(self):
         ...
 
@@ -136,7 +131,7 @@ class ExecutorJobInterface(ABC):
         ...
 
 
-class SingleJobExecutorInterface(ABC):
+class SingleJobExecutorInterface(JobExecutorInterface, ABC):
     @property
     @abstractmethod
     def rule(self):
@@ -207,7 +202,7 @@ class SingleJobExecutorInterface(ABC):
         ...
 
 
-class GroupJobExecutorInterface(ABC):
+class GroupJobExecutorInterface(JobExecutorInterface, ABC):
     @property
     @abstractmethod
     def jobs(self):
@@ -224,17 +219,17 @@ class GroupJobExecutorInterface(ABC):
         ...
 
 
-class DAGExecutorInterface(ABC):
+class DAGExecutorInterface(JobExecutorInterface, ABC):
     @abstractmethod
-    def is_edit_notebook_job(self, job: ExecutorJobInterface):
+    def is_edit_notebook_job(self, job: JobExecutorInterface):
         ...
 
     @abstractmethod
-    def incomplete_external_jobid(self, job: ExecutorJobInterface):
+    def incomplete_external_jobid(self, job: JobExecutorInterface):
         ...
 
     @abstractmethod
-    def jobid(self, job: ExecutorJobInterface):
+    def jobid(self, job: JobExecutorInterface):
         ...
 
     @abstractmethod
@@ -242,13 +237,13 @@ class DAGExecutorInterface(ABC):
         ...
 
 
-class JobSchedulerExecutorInterface(ABC):
+class JobSchedulerExecutorInterface(JobExecutorInterface, ABC):
     @abstractmethod
     def executor_error_callback(self, exception):
         ...
 
 
-class PersistenceExecutorInterface(ABC):
+class PersistenceExecutorInterface(JobExecutorInterface, ABC):
     @abstractmethod
     def cleanup(self):
         ...
@@ -264,7 +259,7 @@ class PersistenceExecutorInterface(ABC):
         ...
 
 
-class WorkflowExecutorInterface(ABC):
+class WorkflowExecutorInterface(JobExecutorInterface, ABC):
     @property
     @abstractmethod
     def latency_wait(self) -> int:
@@ -397,11 +392,6 @@ class WorkflowExecutorInterface(ABC):
     @property
     @abstractmethod
     def persistence(self) -> PersistenceExecutorInterface:
-        ...
-
-    @property
-    @abstractmethod
-    def keep_metadata(self):
         ...
 
     @property

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -16,7 +16,7 @@ from operator import attrgetter
 from typing import Optional
 from abc import ABC, abstractmethod
 from snakemake.interfaces import (
-    ExecutorJobInterface,
+    JobExecutorInterface,
     GroupJobExecutorInterface,
     SingleJobExecutorInterface,
 )
@@ -66,7 +66,7 @@ def jobfiles(jobs, type):
     return chain(*map(attrgetter(type), jobs))
 
 
-class AbstractJob(ExecutorJobInterface):
+class AbstractJob(JobExecutorInterface):
     @abstractmethod
     def reset_params_and_resources(self):
         ...

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -15,15 +15,28 @@ from itertools import chain, filterfalse
 from operator import attrgetter
 from typing import Optional
 
-from snakemake.common import (DYNAMIC_FILL, IO_PROP_LIMIT, TBDString, get_uuid,
-                              is_local_file, lazy_property)
-from snakemake.exceptions import (ProtectedOutputException, RuleException,
-                                  WorkflowError)
-from snakemake.interfaces import (GroupJobExecutorInterface,
-                                  JobExecutorInterface,
-                                  SingleJobExecutorInterface)
-from snakemake.io import (IOFile, Resources, Wildcards, get_flag_value,
-                          is_flagged, wait_for_files)
+from snakemake.common import (
+    DYNAMIC_FILL,
+    IO_PROP_LIMIT,
+    TBDString,
+    get_uuid,
+    is_local_file,
+    lazy_property,
+)
+from snakemake.exceptions import ProtectedOutputException, RuleException, WorkflowError
+from snakemake.interfaces import (
+    GroupJobExecutorInterface,
+    JobExecutorInterface,
+    SingleJobExecutorInterface,
+)
+from snakemake.io import (
+    IOFile,
+    Resources,
+    Wildcards,
+    get_flag_value,
+    is_flagged,
+    wait_for_files,
+)
 from snakemake.logging import logger
 from snakemake.resources import GroupResources
 from snakemake.target_jobs import TargetSpec

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1640,7 +1640,8 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
         if not isinstance(other, AbstractJob):
             return False
         if other.is_group():
-            return self.jobs == other.jobs
+            other: GroupJob  # type: ignore [no-redef]
+            return self.jobs == other.jobs  # type: ignore [attr-defined]
         else:
             return False
 
@@ -1806,10 +1807,10 @@ class Reason:
                         "Software environment definition has changed since last execution"
                     )
 
-        s = "; ".join(s)
+        s_ = "; ".join(s)
         if self.finished:
-            return f"Finished (was: {s})"
-        return s
+            return f"Finished (was: {s_})"
+        return s_
 
     def __bool__(self):
         v = bool(

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -3,46 +3,31 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
-import os
-import sys
 import base64
-import tempfile
 import json
+import os
 import shutil
-
+import sys
+import tempfile
+from abc import abstractmethod
 from collections import defaultdict
 from itertools import chain, filterfalse
 from operator import attrgetter
 from typing import Optional
-from abc import ABC, abstractmethod
-from snakemake.interfaces import (
-    JobExecutorInterface,
-    GroupJobExecutorInterface,
-    SingleJobExecutorInterface,
-)
 
-from snakemake.io import (
-    IOFile,
-    Wildcards,
-    Resources,
-    is_flagged,
-    get_flag_value,
-    wait_for_files,
-)
+from snakemake.common import (DYNAMIC_FILL, IO_PROP_LIMIT, TBDString, get_uuid,
+                              is_local_file, lazy_property)
+from snakemake.exceptions import (ProtectedOutputException, RuleException,
+                                  WorkflowError)
+from snakemake.interfaces import (GroupJobExecutorInterface,
+                                  JobExecutorInterface,
+                                  SingleJobExecutorInterface)
+from snakemake.io import (IOFile, Resources, Wildcards, get_flag_value,
+                          is_flagged, wait_for_files)
+from snakemake.logging import logger
 from snakemake.resources import GroupResources
 from snakemake.target_jobs import TargetSpec
 from snakemake.utils import format, listfiles
-from snakemake.exceptions import RuleException, ProtectedOutputException, WorkflowError
-
-from snakemake.logging import logger
-from snakemake.common import (
-    DYNAMIC_FILL,
-    is_local_file,
-    lazy_property,
-    get_uuid,
-    TBDString,
-    IO_PROP_LIMIT,
-)
 
 
 def format_files(job, io, dynamicio):
@@ -1203,10 +1188,6 @@ class Job(AbstractJob, SingleJobExecutorInterface):
     @property
     def name(self):
         return self.rule.name
-
-    @property
-    def priority(self):
-        return self.dag.priority(self)
 
     def products(self, include_logfiles=True):
         products = list(self.output)


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

This is a refactor of `JobExecutorInterface` affected snakemake/interfaces.py, snakemake/jobs.py, and snakemake/executors/*

Before, ExecutorJobInterface is nammed different from SingleJobExecutorInterface and GroupJobExecutorInterface.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
