### PR TITLE
fix: unnecessary set Snakefile in AzBatch executor

### DIFF
--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -29,7 +29,6 @@ from snakemake.interfaces import (
     WorkflowExecutorInterface,
 )
 from snakemake.logging import logger
-from snakemake.resources import DefaultResources
 
 AzBatchJob = namedtuple("AzBatchJob", "job jobid task_id callback error_callback")
 

--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -295,7 +295,6 @@ class AzBatchExecutor(ClusterExecutor):
             dirname = dirname.removeprefix(osxprefix)
 
         self.workdir = dirname
-        # self.workflow._default_resources = DefaultResources(mode="bare")
 
         # Prepare workflow sources for build package
         self._set_workflow_sources()

--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -8,6 +8,7 @@ import io
 import os
 import re
 import shutil
+import shlex
 import sys
 import tarfile
 import tempfile
@@ -294,6 +295,7 @@ class AzBatchExecutor(ClusterExecutor):
             dirname = dirname.removeprefix(osxprefix)
 
         self.workdir = dirname
+        # self.workflow._default_resources = DefaultResources(mode="bare")
 
         # Prepare workflow sources for build package
         self._set_workflow_sources()
@@ -401,7 +403,7 @@ class AzBatchExecutor(ClusterExecutor):
     # token information from being printed to the logs
     def mask_sas_urls(self, attrs: dict):
         attrs_new = attrs.copy()
-        sas_pattern = r"\?s[v|p]=.+(\'|\"|$)"
+        sas_pattern = r"\?[^=]+=([^?'\"]+)"
         mask = 10 * "*"
 
         for k, value in attrs.items():
@@ -443,7 +445,7 @@ class AzBatchExecutor(ClusterExecutor):
                 continue
 
         exec_job = self.format_job_exec(job)
-        exec_job = f"/bin/sh -c 'tar xzf {self.resource_file.file_path} && {exec_job}'"
+        exec_job = f"/bin/bash -c 'tar xzf {self.resource_file.file_path} && {shlex.quote(exec_job)}'"
 
         # A string that uniquely identifies the Task within the Job.
         task_uuid = str(uuid.uuid1())

--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -295,9 +295,6 @@ class AzBatchExecutor(ClusterExecutor):
 
         self.workdir = dirname
 
-        # Relative path for running on instance
-        self._set_snakefile()
-
         # Prepare workflow sources for build package
         self._set_workflow_sources()
 
@@ -854,14 +851,6 @@ class AzBatchExecutor(ClusterExecutor):
                 raise WorkflowError(
                     "AZ_BLOB_CREDENTIAL is not a valid storage account SAS token."
                 )
-
-    def _set_snakefile(self):
-        """The snakefile must be a relative path, which cannot be reliably
-        derived from the self.workflow.snakefile as we might have moved
-        execution into a temporary directory, and the initial Snakefile
-        was somewhere else on the system.
-        """
-        self.snakefile = os.path.basename(self.workflow.main_snakefile)
 
     # from google_lifesciences.py
     def _set_workflow_sources(self):


### PR DESCRIPTION
### Description

- Removes unnecessary setting of Snakefile in AzBatch executor. This was 1. not necessary, and 2. was causing a failure to resolve the Snakefile path when it was located at `workflow/Snakefile`.
- Since default resources is now included in the command per #2395 , I needed to update the shell quoting so the command doesn't fail because of the parentheses in the default resources. Used the same solution as #2043 and it works nicely.
- Updated the masking regex to be more generic for SAS token possibilities

### QC

<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
