### PR TITLE
fix: azbatch pool create

### DIFF
--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -479,6 +479,7 @@ class AzBatchExecutor(RemoteExecutor):
         self,
         job: ExecutorJobInterface,
         callback=None,
+        submit_callback=None,
         error_callback=None,
     ):
         import azure.batch._batch_service_client as batch

--- a/snakemake/executors/azure_batch.py
+++ b/snakemake/executors/azure_batch.py
@@ -754,6 +754,7 @@ class AzBatchExecutor(RemoteExecutor):
             NodeCommunicationMode,
             Pool,
             PoolIdentityType,
+            ContainerType,
             ResourceFile,
             ScaleSettings,
             StartTask,
@@ -780,6 +781,7 @@ class AzBatchExecutor(RemoteExecutor):
             )
 
         container_config = ContainerConfiguration(
+            type=ContainerType.DOCKER_COMPATIBLE,
             container_image_names=[self.container_image],
         )
 
@@ -801,22 +803,6 @@ class AzBatchExecutor(RemoteExecutor):
                 user_assigned_identities={mrid: UserAssignedIdentities()},
             )
 
-        if self.batch_config.container_registry_url is not None:
-            if (
-                self.batch_config.container_registry_user is not None
-                and self.batch_config.container_registry_pass is not None
-            ):
-                user = self.batch_config.container_registry_user
-                passw = self.batch_config.container_registry_pass
-            else:
-                raise WorkflowError(
-                    "Invalid container registry authentication. "
-                    "BATCH_CONTAINER_REGISTRY_USER and "
-                    "BATCH_CONTAINER_REGISTRY_PASS or "
-                    "MANAGED_IDENTITY_CLIENT_ID and "
-                    "MANAGED_IDENTITY_RESOURCE_ID are required"
-                )
-
             registry_conf = [
                 ContainerRegistry(
                     registry_server=self.batch_config.container_registry_url,
@@ -827,6 +813,7 @@ class AzBatchExecutor(RemoteExecutor):
             ]
 
             container_config = ContainerConfiguration(
+                type="DockerCompatible",
                 container_image_names=[self.container_image],
                 container_registries=registry_conf,
             )

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -93,7 +93,10 @@ def test_slurm_extra_arguments():
         show_failed_logs=True,
         use_conda=True,
         default_resources=DefaultResources(
-            ["slurm_account=runner", "slurm_partition=debug",
-             "slurm_extra='--mail-type=none'"]
+            [
+                "slurm_account=runner",
+                "slurm_partition=debug",
+                "slurm_extra='--mail-type=none'",
+            ]
         ),
     )


### PR DESCRIPTION
### Description

1. Overhauls the batch pool creation to use only the azure-mgmt-batch sdk. 

The azure-mgmt-batch SDK now supports all the features of pool creation that we need (namely the addition of the managed identity to the batch pool). Using the azure-mgmt-batch SDK entirely now for pool creation prevents the weird work around with adding the identity to the pool after creation, it can now done all at once. Cleaner, and also prevents a nasty edge case bug with the managed identity not being picked up on the batch nodes.

2. Cleanup 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
