### PR TITLE
Print to standard error instead of printing sys.stderr itself

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -2032,7 +2032,7 @@ def main(argv=None):
         args.cores = cores
         args.jobs = jobs
     except CliException as err:
-        print(err.msg, sys.stderr)
+        print(err.msg, file=sys.stderr)
         sys.exit(1)
 
     if args.drmaa_log_dir is not None and not os.path.isabs(args.drmaa_log_dir):
@@ -2129,7 +2129,8 @@ def main(argv=None):
             sys.exit(1)
         elif not url_can_parse(args.az_batch_account_url):
             print(
-                "Error: invalide azure batch account url, please use format: https://{account_name}.{location}.batch.azure.com."
+                "Error: invalide azure batch account url, please use format: https://{account_name}.{location}.batch.azure.com.",
+                file=sys.stderr,
             )
             sys.exit(1)
         elif os.getenv("AZ_BATCH_ACCOUNT_KEY") is None:
@@ -2447,6 +2448,7 @@ def bash_completion(snakefile="Snakefile"):
     if len(sys.argv) < 2:
         print(
             "Calculate bash completion for snakemake. This tool shall not be invoked by hand."
+            file=sys.stderr,
         )
         sys.exit(1)
 


### PR DESCRIPTION
### Description

When running `snakemake` with no `--cores` option, the output looks like this:

```
Error: you need to specify the maximum number of CPU cores to be used at the same time. If you want to use N cores, say --cores N or -cN. For all cores on your system (be sure that this is appropriate) use --cores all. For no parallelization use --cores 1 or -c1. <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
```

This pr prints _to_ standard error instead of printing `sys.stderr` itself. And I added `file=sys.stderr` to a couple other `print` statements in `snakemake/cli.py`.