### PR TITLE
Panoptes fix

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -158,9 +158,7 @@ class WMSLogger:
         # And then that it's ready to be interacted with
         if response.json().get("status") != "running":
             sys.stderr.write(
-                "The status of the server {} is not in 'running' mode {}".format(
-                    self.address, os.linesep
-                )
+                f"The status of the server {self.address} is not in 'running' mode {os.linesep}"
             )
             sys.exit(-1)
 
@@ -246,8 +244,7 @@ class WMSLogger:
 
         # Any other response code is not acceptable
         sys.stderr.write(
-            f"The status of the server {self.address} is not in 'running' mode {os.linesep}"
-        )
+            f"The {endpoint} response code {response.status_code} is not recognized."        )
 
     @property
     def _headers(self):

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -152,7 +152,6 @@ class WMSLogger:
         )
         if response.status_code != 200:
             sys.stderr.write(f"Problem with server: {self.address} {os.linesep}")
-
             sys.exit(-1)
 
         # And then that it's ready to be interacted with

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -148,12 +148,11 @@ class WMSLogger:
 
         # We first ensure that the server is running, period
         response = requests.get(
-            self.address + "/api/service-info", headers=self._headers
+            f"{self.address}/api/service-info", headers=self._headers
         )
         if response.status_code != 200:
-            sys.stderr.write(
-                "Problem with server: {} {}".format(self.address, os.linesep)
-            )
+            sys.stderr.write(f"Problem with server: {self.address} {os.linesep}")
+
             sys.exit(-1)
 
         # And then that it's ready to be interacted with
@@ -187,7 +186,7 @@ class WMSLogger:
         }
 
         response = requests.get(
-            self.address + "/create_workflow",
+            f"{self.address}/create_workflow",
             headers=self._headers,
             params=self.args,
             data=metadata,
@@ -208,7 +207,7 @@ class WMSLogger:
 
         # Send the workflow name to the server
         response_change_workflow_name = requests.put(
-            self.address + f"/api/workflow/{id}",
+            f"{self.address }/api/workflow/{id}",
             headers=headers,
             data=json.dumps(self.args),
         )
@@ -217,20 +216,18 @@ class WMSLogger:
 
         # Provide server parameters to the logger
         self.server = {"url": self.address, "id": id}
-
     def check_response(self, response, endpoint="wms monitor request"):
         """A helper function to take a response and check for an expected set of
         error codes, 404 (not found), 401 (requires authorization), 403 (permission
         denied), 500 (server error) and 200 (success).
         """
         status_code = response.status_code
-
         # Cut out early on success
         if status_code == 200:
             return
 
         if status_code == 404:
-            sys.stderr.write("The wms %s endpoint was not found" % endpoint)
+            sys.stderr.write(f"The wms {endpoint} endpoint was not found")
             sys.exit(-1)
         elif status_code == 401:
             sys.stderr.write(
@@ -239,7 +236,7 @@ class WMSLogger:
             sys.exit(-1)
         elif status_code == 500:
             sys.stderr.write(
-                "There was a server error when trying to access %s" % endpoint
+                f"There was a server error when trying to access {endpoint}"
             )
             sys.exit(-1)
         elif status_code == 403:
@@ -248,8 +245,7 @@ class WMSLogger:
 
         # Any other response code is not acceptable
         sys.stderr.write(
-            "The %s response code %s is not recognized."
-            % (endpoint, response.status_code)
+            f"The {endpoint} response code {response.status_code} is not recognized."
         )
 
     @property
@@ -301,7 +297,6 @@ class WMSLogger:
             "timestamp": time.asctime(),
             "id": self.server["id"],
         }
-        print(server_info)
         response = requests.post(url, data=server_info, headers=self._headers)
         self.check_response(response, "/update_workflow_status")
 

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -216,6 +216,7 @@ class WMSLogger:
 
         # Provide server parameters to the logger
         self.server = {"url": self.address, "id": id}
+
     def check_response(self, response, endpoint="wms monitor request"):
         """A helper function to take a response and check for an expected set of
         error codes, 404 (not found), 401 (requires authorization), 403 (permission
@@ -245,7 +246,7 @@ class WMSLogger:
 
         # Any other response code is not acceptable
         sys.stderr.write(
-            f"The {endpoint} response code {response.status_code} is not recognized."
+            f"The status of the server {self.address} is not in 'running' mode {os.linesep}"
         )
 
     @property

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -244,7 +244,8 @@ class WMSLogger:
 
         # Any other response code is not acceptable
         sys.stderr.write(
-            f"The {endpoint} response code {response.status_code} is not recognized."        )
+            f"The {endpoint} response code {response.status_code} is not recognized."
+        )
 
     @property
     def _headers(self):


### PR DESCRIPTION
### Description

This PR fix panoptes --wms-monitor-arg snakemake option. --wms-monitor-arg was then not being processed by the requests, it is now possible to change the name of the run using `--wms-monitor-arg name=TEST_RUN` in the panoptes DB.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
