### PR TITLE
fix: ensure that targetjob is always forced. This fixes a bug causing run-directive rules to not being executed even when enforced via e.g. -R.

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -177,6 +177,7 @@ class DAG(DAGExecutorInterface):
                 create_inventory=True,
             )
             self.targetjobs.add(job)
+            self.forcefiles.update(job.output)
 
         self.cleanup()
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
