### PR TITLE
docs: fix syntax in cluster example

### DIFF
--- a/docs/executing/cluster.rst
+++ b/docs/executing/cluster.rst
@@ -120,8 +120,8 @@ Each of these can be part of a rule, e.g.:
       input: ...
       output: ...
       resources:
-          partition: <partition name>
-          runtime: <some number>
+          partition=<partition name>,
+          runtime=<some number>
 
 Please note: as ``--mem`` and ``--mem-per-cpu`` are mutually exclusive on SLURM clusters, there corresponding resource flags ``mem_mb`` and ``mem_mb_per_cpu`` are mutually exclusive, too.
 You can only reserve memory a compute node has to provide or the memory required per CPU (SLURM does not make any distintion between real CPU cores and those provided by hyperthreads).


### PR DESCRIPTION
### Description

Fix misleading syntax in documentation example. See <https://www.biostars.org/p/9575301/>.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] ~~The PR contains a test case for the changes or the changes are already covered by an existing test case.~~ N.A.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
