### PR TITLE
fix: lazy_property and not_iterable import are from common

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -41,7 +41,7 @@ from snakemake.io import (
     contains_wildcard,
     _IOFile,
 )
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 
 
 class CondaCleanupMode(Enum):

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -16,7 +16,7 @@ from snakemake.common import (
 )
 from snakemake.exceptions import WorkflowError
 from snakemake.logging import logger
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 
 
 SNAKEMAKE_MOUNTPOINT = "/mnt/snakemake"

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1007,7 +1007,7 @@ class AnnotatedString(str):
 
 
 def flag(value, flag_type, flag_value=True):
-    from snakemake_interface_executor_plugins.utils import not_iterable
+    from snakemake_interface_common.utils import not_iterable
 
     if isinstance(value, AnnotatedString):
         value.flags[flag_type] = flag_value
@@ -1103,7 +1103,7 @@ def dynamic(value):
     A flag for a file that shall be dynamic, i.e. the multiplicity
     (and wildcard values) will be expanded after a certain
     rule has been run"""
-    from snakemake_interface_executor_plugins.utils import not_iterable
+    from snakemake_interface_common.utils import not_iterable
 
     annotated = flag(value, "dynamic", True)
     tocheck = [annotated] if not_iterable(annotated) else annotated

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -17,7 +17,7 @@ from typing import Optional
 from abc import ABC, abstractmethod
 from snakemake.settings import DeploymentMethod
 
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 from snakemake_interface_executor_plugins.jobs import (
     JobExecutorInterface,
     GroupJobExecutorInterface,

--- a/snakemake/remote/EGA.py
+++ b/snakemake/remote/EGA.py
@@ -16,7 +16,7 @@ from snakemake.remote import (
     check_deprecated_retry,
 )
 from snakemake.exceptions import WorkflowError
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 
 
 EGAFileInfo = namedtuple("EGAFileInfo", ["size", "status", "id", "checksum"])

--- a/snakemake/remote/GS.py
+++ b/snakemake/remote/GS.py
@@ -11,7 +11,7 @@ import time
 from snakemake.remote import AbstractRemoteObject, AbstractRemoteProvider
 from snakemake.exceptions import WorkflowError, CheckSumMismatchException
 import snakemake.io
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 
 try:
     import google.cloud

--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -48,7 +48,7 @@ from snakemake import logging
 from snakemake.report import data
 from snakemake.report.rulegraph_spec import rulegraph_spec
 
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 
 
 class EmbeddedMixin(object):

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -60,7 +60,7 @@ from snakemake.common import (
 )
 from snakemake.common.tbdstring import TBDString
 from snakemake.resources import infer_resources
-from snakemake_interface_executor_plugins.utils import not_iterable, lazy_property
+from snakemake_interface_common.utils import not_iterable, lazy_property
 from snakemake_interface_common.rules import RuleInterface
 
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -35,7 +35,7 @@ from snakemake_interface_executor_plugins.workflow import WorkflowExecutorInterf
 from snakemake_interface_executor_plugins.cli import (
     SpawnedJobArgsFactoryExecutorInterface,
 )
-from snakemake_interface_executor_plugins.utils import lazy_property
+from snakemake_interface_common.utils import lazy_property
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from snakemake_interface_executor_plugins.registry.plugin import (
     Plugin as ExecutorPlugin,
@@ -86,7 +86,7 @@ from snakemake.notebook import notebook
 from snakemake.wrapper import wrapper
 from snakemake.cwl import cwl
 from snakemake.template_rendering import render_template
-from snakemake_interface_executor_plugins.utils import not_iterable
+from snakemake_interface_common.utils import not_iterable
 
 import snakemake.wrapper
 from snakemake.common import (


### PR DESCRIPTION
Problem: the lazy_property and not_iterable functions were previously imported from the executor plugin interface and now are a part of snakemake interface common.
Solution: update the import for each function

This will fix #2466 

I suspect there might be an order of operations or release issue here - e.g., maybe the common interface module isn't released yet so it is still falling back to the previous. For context I'm developing the updated flux executor plugin and I installed snakemake from master here and ran into this issue. I suspect we will find out what version(s) are being installed when tests run and can go from there! I can always try to install from my branch for the time being if needed.