### PR TITLE
Compiled  `workflow.include` should carry print_compilation keyword

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -71,6 +71,7 @@ class StopAutomaton(Exception):
 class TokenAutomaton:
     subautomata: Dict[str, Any] = {}
     deprecated: Dict[str, str] = {}
+    print_compilation = False
 
     def __init__(self, snakefile: "Snakefile", base_indent=0, dedent=0, root=True):
         self.root = root
@@ -239,7 +240,11 @@ class Envvars(GlobalKeywordState):
 
 
 class Include(GlobalKeywordState):
-    pass
+    def block_content(self, token):
+        if self.print_compilation:
+            yield f"{token.string}, print_compilation=True", token
+        else:
+            yield token.string, token
 
 
 class Workdir(GlobalKeywordState):
@@ -1202,8 +1207,9 @@ def format_tokens(tokens) -> Generator[str, None, None]:
         t_ = t
 
 
-def parse(path, workflow, overwrite_shellcmd=None, rulecount=0):
+def parse(path, workflow, overwrite_shellcmd=None, rulecount=0, print_compilation=False):
     Shell.overwrite_cmd = overwrite_shellcmd
+    TokenAutomaton.print_compilation = print_compilation
     with Snakefile(path, workflow, rulecount=rulecount) as snakefile:
         automaton = Python(snakefile)
         linemap = dict()

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1197,6 +1197,7 @@ class Workflow(WorkflowExecutorInterface):
             snakefile,
             self,
             rulecount=self._rulecount,
+            print_compilation=print_compilation,
         )
         self._rulecount = rulecount
 


### PR DESCRIPTION
### Description

As described here #1123, `--print-compilation` will display `workflow.include(<Snakefile>)` statements instead of the compiled code within these included Snakefiles as desired. We simply introduce `print_compilation` keywords to these compiled statements to fix this.

@johanneskoester can you please guide me as to the best place to introduce a test

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
