### PR TITLE
fix: 'infinite' value cannot pass to R script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - series-7
   pull_request:
     branches_ignore: []
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+
+## [7.32.4](https://github.com/snakemake/snakemake/compare/v7.32.3...v7.32.4) (2023-08-18)
+
+
+### Bug Fixes
+
+* always sort report (sub-)categories in lexicographical order
+* also inherit rule proxies if there is no rulename modifier specified in a use rule statement
+* ensure that targetjob is always forced. This fixes a bug causing run-directive rules to not being executed even when enforced via e.g. -R.
+
+
 ## [7.32.3](https://github.com/snakemake/snakemake/compare/v7.32.2...v7.32.3) (2023-08-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [7.32.3](https://github.com/snakemake/snakemake/compare/v7.32.2...v7.32.3) (2023-08-07)
+
+
+### Bug Fixes
+
+* fix bug occuring when using multiple `use rule` statements in combination with the rules object for referring to output of already defined rules.
+
 ## [7.32.2](https://github.com/snakemake/snakemake/compare/v7.32.1...v7.32.2) (2023-08-07)
 
 

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -264,7 +264,10 @@ class Rules:
         try:
             return self._rules[name]
         except KeyError:
-            raise WorkflowError(f"Rule {name} is not defined in this workflow.")
+            raise WorkflowError(
+                f"Rule {name} is not defined in this workflow. "
+                f"Available rules: {', '.join(self._rules)}"
+            )
 
 
 class Scatter:

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -236,6 +236,7 @@ class DAG(DAGExecutorInterface):
                     create_inventory=True,
                 )
                 self.targetjobs.add(job)
+                self.forcefiles.update(job.output)
 
         self.cleanup()
 

--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -208,11 +208,10 @@ class WorkflowModifier:
         self.namespace = namespace
 
     def inherit_rule_proxies(self, child_modifier):
-        if child_modifier.local_rulename_modifier is not None:
-            for name, rule in child_modifier.rule_proxies._rules.items():
-                self.rule_proxies._register_rule(
-                    child_modifier.local_rulename_modifier(name), rule
-                )
+        for name, rule in child_modifier.rule_proxies._rules.items():
+            if child_modifier.local_rulename_modifier is not None:
+                name = child_modifier.local_rulename_modifier(name)
+            self.rule_proxies._register_rule(name, rule)
 
     def skip_rule(self, rulename):
         return (

--- a/snakemake/modules.py
+++ b/snakemake/modules.py
@@ -52,6 +52,7 @@ class ModuleInfo:
         self.config = config
         self.skip_validation = skip_validation
         self.parent_modifier = self.workflow.modifier
+        self.rule_proxies = Rules()
 
         if prefix is not None:
             if isinstance(prefix, Path):
@@ -97,6 +98,7 @@ class ModuleInfo:
             replace_prefix=self.replace_prefix,
             prefix=self.prefix,
             replace_wrapper_tag=self.get_wrapper_tag(),
+            rule_proxies=self.rule_proxies,
         )
         with modifier:
             self.workflow.include(snakefile, overwrite_default_target=True)
@@ -155,6 +157,7 @@ class WorkflowModifier:
         prefix=None,
         replace_wrapper_tag=None,
         namespace=None,
+        rule_proxies=None,
     ):
         if parent_modifier is not None:
             # init with values from parent modifier
@@ -174,6 +177,7 @@ class WorkflowModifier:
             self.namespace = parent_modifier.namespace
             self.wildcard_constraints = parent_modifier.wildcard_constraints
             self.rules = parent_modifier.rules
+            self.rule_proxies = parent_modifier.rule_proxies
         else:
             # default settings for globals if not inheriting from parent
             self.globals = (
@@ -181,14 +185,14 @@ class WorkflowModifier:
             )
             self.wildcard_constraints = dict()
             self.rules = set()
+            self.rule_proxies = rule_proxies or Rules()
+            self.globals["rules"] = self.rule_proxies
 
         self.workflow = workflow
         self.base_snakefile = base_snakefile
-        self.rule_proxies = Rules()
 
         if config is not None:
             self.globals["config"] = config
-        self.globals["rules"] = self.rule_proxies
 
         self.skip_configfile = skip_configfile
         self.resolved_rulename_modifier = resolved_rulename_modifier

--- a/snakemake/report/template/components/abstract_menu.js
+++ b/snakemake/report/template/components/abstract_menu.js
@@ -9,7 +9,6 @@ class AbstractMenu extends React.Component {
     }
 
     getMenuItem(label, iconName, onClick) {
-        console.log(label, onClick);
         return e(
             "li",
             { key: label },

--- a/snakemake/report/template/components/abstract_results.js
+++ b/snakemake/report/template/components/abstract_results.js
@@ -40,9 +40,7 @@ class AbstractResults extends React.Component {
 
     getLabels() {
         let first_index = {};
-        console.log(this.getResults());
         this.getResults().map(function ([path, result]) {
-            console.log(path, result);
             let i = 0;
             for (let key in result.labels) {
                 if (!(key in first_index)) {
@@ -56,7 +54,6 @@ class AbstractResults extends React.Component {
         return labels.sort(function (a, b) {
             return first_index[a] - first_index[b];
         });
-        //return Array.from(new Set(this.getResults().map(function ([path, result]) { return Object.keys(result.labels) }).flat())).sort();
     }
 
     isLabelled() {

--- a/snakemake/report/template/components/category.js
+++ b/snakemake/report/template/components/category.js
@@ -15,8 +15,9 @@ class Category extends AbstractMenu {
 
     getSubcategoryMenuitems() {
         let _this = this
-        return Object.keys(categories[this.props.category]).map(function (subcategory) {
+        let items = Object.keys(categories[this.props.category]).sort().map(function (subcategory) {
             return _this.getMenuItem(subcategory, "folder", () => _this.showSubcategory(subcategory));
         });
+        return items;
     }
 }

--- a/snakemake/report/template/components/common.js
+++ b/snakemake/report/template/components/common.js
@@ -13,6 +13,5 @@ function isSingleDefaultCategory() {
 }
 
 function isSingleSubcategory(category) {
-    console.log(categories, category);
     return Object.keys(categories[category]).length == 1;
 }

--- a/snakemake/report/template/components/menu.js
+++ b/snakemake/report/template/components/menu.js
@@ -52,7 +52,7 @@ class Menu extends AbstractMenu {
                 { key: "Results", text: "Result" }
             )];
 
-            items.push(...Object.keys(categories).map(function (category) {
+            items.push(...Object.keys(categories).sort().map(function (category) {
                 return _this.getMenuItem(category, "folder", () => app.showCategory(category));
             }));
 

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -181,6 +181,10 @@ class REncoder:
     def encode_value(cls, value):
         if value is None:
             return "NULL"
+        elif value == float("inf"):
+            return "Inf"
+        elif value == - float("inf"):
+            return "-Inf"
         elif isinstance(value, str):
             return repr(value)
         elif isinstance(value, Path):

--- a/tests/test_inf_to_R_script_issue2475/Snakefile
+++ b/tests/test_inf_to_R_script_issue2475/Snakefile
@@ -1,0 +1,7 @@
+configfile: "config.yaml"
+
+rule all:
+  output: "final.rst"
+  params:
+    threshold = [-float("inf"), float("inf")]
+  script: "test.R"

--- a/tests/test_inf_to_R_script_issue2475/config.yaml
+++ b/tests/test_inf_to_R_script_issue2475/config.yaml
@@ -1,0 +1,3 @@
+threshold:
+  - -.inf
+  - .inf

--- a/tests/test_inf_to_R_script_issue2475/expected-results/final.rst
+++ b/tests/test_inf_to_R_script_issue2475/expected-results/final.rst
@@ -1,0 +1,2 @@
+The type: numeric.
+The value: -Inf, Inf.

--- a/tests/test_inf_to_R_script_issue2475/test.R
+++ b/tests/test_inf_to_R_script_issue2475/test.R
@@ -1,0 +1,16 @@
+#! /opt/conda/envs/dev/bin/R
+
+run <- function (output, threshold){
+  log <- c(
+    paste("The type: ", class(threshold[1]), ".", sep = ""),
+    paste("The value: ", paste(threshold, collapse = ', '), ".", sep = "")
+  )
+  conn <- file(output, "w")
+  writeLines(log, conn)
+  close(conn)
+}
+
+run(
+  snakemake@output[[1]],
+  snakemake@params[["threshold"]]
+)


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->
An **Infinite** value will raise an error when evoking an external R script (#2475), because the current encoding schema ([snakemake/script.py REncoder::encode_value](https://github.com/snakemake/snakemake/blob/5e3a46476d78d5d52340a9ffa327d18a5e7e9828/snakemake/script.py#L181)) will translate Python `float("inf")` into `inf` for R, not the expected `Inf`.

To fix this, two specific encoding schemes are introduced to support the correct translation of Python `float("inf")` to R `Inf`, and Python `float("-inf")` to R `-Inf`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
