### PR TITLE
feat: add functionality for deploying sources if no shared FS is assumed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           # long tests
           pytest --show-capture=stderr --splits 10 --group ${{ matrix.test_group }} -v -x tests/tests.py
           # other tests
-          pytest --show-capture=stderr -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/test_executor_test_suite.py
+          pytest --show-capture=stderr -v -x tests/test_expand.py tests/test_io.py tests/test_schema.py tests/test_linting.py tests/test_executor_test_suite.py tests/test_api.py
 
   build-container-image:
     runs-on: ubuntu-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 zip_safe = False
 include_package_data = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.11
 install_requires =
     appdirs
     immutables

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1785,6 +1785,22 @@ def args_to_api(args, parser):
             deployment_method.add(DeploymentMethod.ENV_MODULES)
 
         try:
+            storage_settings = StorageSettings(
+                default_storage_provider=args.default_storage_provider,
+                default_storage_prefix=args.default_storage_prefix,
+                assume_shared_fs=not args.no_shared_fs,
+                keep_storage_local=args.keep_storage_local_copies,
+                notemp=args.notemp,
+                all_temp=args.all_temp,
+            )
+
+            if args.deploy_sources:
+                snakemake_api.deploy_sources(
+                    args.deploy_sources,
+                    storage_settings=storage_settings,
+                    storage_provider_settings=storage_provider_settings,
+                )
+
             workflow_api = snakemake_api.workflow(
                 resource_settings=ResourceSettings(
                     cores=args.cores,
@@ -1802,14 +1818,7 @@ def args_to_api(args, parser):
                     config=args.config,
                     configfiles=args.configfile,
                 ),
-                storage_settings=StorageSettings(
-                    default_storage_provider=args.default_storage_provider,
-                    default_storage_prefix=args.default_storage_prefix,
-                    assume_shared_fs=not args.no_shared_fs,
-                    keep_storage_local=args.keep_storage_local_copies,
-                    notemp=args.notemp,
-                    all_temp=args.all_temp,
-                ),
+                storage_settings=storage_settings,
                 storage_provider_settings=storage_provider_settings,
                 workflow_settings=WorkflowSettings(
                     wrapper_prefix=args.wrapper_prefix,

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1107,9 +1107,11 @@ def get_argument_parser(profiles=None):
     )
     group_utils.add_argument(
         "--deploy-sources",
-        metavar="QUERY",
-        help="Deploy sources from given storage provider query to the current working "
-        "directory. Meant for internal use only.",
+        nargs="2",
+        metavar=("QUERY", "CHECKSUM"),
+        help="Deploy sources archive from given storage provider query to the current "
+        "working sdirectory and control for archive checksum to proceed. Meant for "
+        "internal use only.",
     )
     group_utils.add_argument("--version", "-v", action="version", version=__version__)
 
@@ -1801,8 +1803,10 @@ def args_to_api(args, parser):
             )
 
             if args.deploy_sources:
+                query, checksum = args.deploy_sources
                 snakemake_api.deploy_sources(
-                    args.deploy_sources,
+                    query,
+                    checksum,
                     storage_settings=storage_settings,
                     storage_provider_settings=storage_provider_settings,
                 )

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1105,6 +1105,12 @@ def get_argument_parser(profiles=None):
         "Provenance-information based reports (e.g. --report and the "
         "--list_x_changes functions) will be empty or incomplete.",
     )
+    group_utils.add_argument(
+        "--deploy-sources",
+        metavar="QUERY",
+        help="Deploy sources from given storage provider query to the current working "
+        "directory. Meant for internal use only.",
+    )
     group_utils.add_argument("--version", "-v", action="version", version=__version__)
 
     group_output = parser.add_argument_group("OUTPUT")

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -4,16 +4,19 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 from dataclasses import dataclass, field
+import hashlib
 import re
 import os
 import subprocess
 import sys
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from collections.abc import Mapping
 from itertools import filterfalse, chain
 from functools import partial
 import copy
 from pathlib import Path
+import tarfile
+import tempfile
 from typing import Dict, List, Optional, Set
 from snakemake.common.workdir_handler import WorkdirHandler
 from snakemake.settings import (
@@ -117,6 +120,9 @@ from snakemake.deployment.conda import Conda
 from snakemake import api, sourcecache
 
 
+SourceArchiveInfo = namedtuple("SourceArchiveInfo", ("query", "checksum"))
+
+
 @dataclass
 class Workflow(WorkflowExecutorInterface):
     config_settings: ConfigSettings
@@ -179,6 +185,7 @@ class Workflow(WorkflowExecutorInterface):
         self._spawned_job_general_args = None
         self._executor_plugin = None
         self._storage_registry = StorageRegistry(self)
+        self._source_archive = None
 
         _globals = globals()
         from snakemake.shell import shell
@@ -203,6 +210,61 @@ class Workflow(WorkflowExecutorInterface):
     @property
     def storage_registry(self):
         return self._storage_registry
+
+    @property
+    def source_archive(self):
+        assert self._source_archive is not None, (
+            "bug: source archive info accessed but source archive has not been "
+            "uploaded to default storage provider before"
+        )
+        return self._source_archive
+
+    def upload_sources(self):
+        with tempfile.NamedTemporaryFile(suffix="snakemake-sources.tar.xz") as f:
+            self.write_source_archive(Path(f.name))
+            f.flush()
+            with open(f.name, "rb") as f:
+                checksum = hashlib.file_digest(f, "sha256").hexdigest()
+
+            prefix = self.storage_settings.default_storage_prefix
+            query = f"{prefix}/snakemake-workflow-sources.{checksum}.tar.xz"
+
+            self._source_archive = SourceArchiveInfo(query, checksum)
+
+            obj = self.storage_registry.default_storage_provider.object(query)
+            obj.set_local_path(f.name)
+            self.logger.info("Uploading source archive to storage provider...")
+            async_run(obj.managed_store())
+
+    def write_source_archive(self, path: Path):
+        def get_files():
+            for f in enumerate(self.dag.get_sources()):
+                if f.startswith(".."):
+                    self.logger.warning(
+                        "Ignoring source file {}. Only files relative "
+                        "to the working directory are allowed.".format(f)
+                    )
+                    continue
+
+                # The kubernetes API can't create secret files larger than 1MB.
+                source_file_size = os.path.getsize(f)
+                max_file_size = 10000000
+                if source_file_size > max_file_size:
+                    self.logger.warning(
+                        "Skipping the source file for upload {f}. Its size "
+                        "{source_file_size} exceeds "
+                        "the maximum file size (10MB). Consider to provide the file as "
+                        "input file instead.".format(
+                            f=f, source_file_size=source_file_size
+                        )
+                    )
+                    continue
+                yield f
+
+        assert path.suffix == "tar.xz"
+        with tarfile.open(path, "w:xz") as archive:
+            for f in get_files():
+                archive.add(f)
 
     @property
     def enable_cache(self):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -232,15 +232,15 @@ class Workflow(WorkflowExecutorInterface):
             self._source_archive = SourceArchiveInfo(query, checksum)
 
             obj = self.storage_registry.default_storage_provider.object(query)
-            obj.set_local_path(f.name)
-            self.logger.info("Uploading source archive to storage provider...")
+            obj.set_local_path(Path(f.name))
+            logger.info("Uploading source archive to storage provider...")
             async_run(obj.managed_store())
 
     def write_source_archive(self, path: Path):
         def get_files():
-            for f in enumerate(self.dag.get_sources()):
+            for f in self.dag.get_sources():
                 if f.startswith(".."):
-                    self.logger.warning(
+                    logger.warning(
                         "Ignoring source file {}. Only files relative "
                         "to the working directory are allowed.".format(f)
                     )
@@ -250,7 +250,7 @@ class Workflow(WorkflowExecutorInterface):
                 source_file_size = os.path.getsize(f)
                 max_file_size = 10000000
                 if source_file_size > max_file_size:
-                    self.logger.warning(
+                    logger.warning(
                         "Skipping the source file for upload {f}. Its size "
                         "{source_file_size} exceeds "
                         "the maximum file size (10MB). Consider to provide the file as "
@@ -261,7 +261,7 @@ class Workflow(WorkflowExecutorInterface):
                     continue
                 yield f
 
-        assert path.suffix == "tar.xz"
+        assert path.suffixes == [".tar", ".xz"]
         with tarfile.open(path, "w:xz") as archive:
             for f in get_files():
                 archive.add(f)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -2,7 +2,7 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - python >=3.7
+  - python >=3.11
   - yte
   - packaging
   - stopit

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,9 @@ def test_deploy_sources(s3_storage):
                 default_storage_prefix=s3_prefix,
                 default_storage_provider="s3",
             ),
+            resource_settings=settings.ResourceSettings(
+                cores=1,
+            ),
             storage_provider_settings=s3_settings,
             snakefile=dpath("test01/Snakefile"),
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,11 +26,19 @@ def test_deploy_sources(s3_storage):
                 cores=1,
             ),
             storage_provider_settings=s3_settings,
-            snakefile=dpath("test01/Snakefile"),
+            snakefile=Path(dpath("test01/Snakefile")),
         )
+        dag_api = workflow_api.dag()
 
-        workflow = workflow_api._get_workflow(check_envvars=False)
-        workflow._prepare_dag()
+        workflow = dag_api.workflow_api._workflow
+        # add dummy remote execution settings as we do not actually execute here
+        # (in reality they are present)
+        workflow.remote_execution_settings = settings.RemoteExecutionSettings()
+        workflow._prepare_dag(
+            forceall=False,
+            ignore_incomplete=False,
+            lock_warn_only=False,
+        )
         workflow._build_dag()
         workflow.upload_sources()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from .common import *
+
+from snakemake import api
+from snakemake import settings
+
+
+def test_deploy_sources(s3_storage):
+    s3_prefix, s3_settings = s3_storage
+
+    with api.SnakemakeApi(
+        settings.OutputSettings(
+            verbose=True,
+            show_failed_logs=True,
+        ),
+    ) as snakemake_api:
+        workflow_api = snakemake_api.workflow(
+            storage_settings=settings.StorageSettings(
+                default_storage_prefix=s3_prefix,
+                default_storage_provider="s3",
+            ),
+            storage_provider_settings=s3_settings,
+            snakefile=dpath("test01/Snakefile"),
+        )
+
+        workflow = workflow_api._get_workflow(check_envvars=False)
+        workflow._prepare_dag()
+        workflow._build_dag()
+        workflow.upload_sources()
+
+        cmd = workflow.spawned_job_args_factory.precommand()
+
+        origdir = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            try:
+                subprocess.run(cmd, shell=True, check=True)
+            finally:
+                os.chdir(origdir)


### PR DESCRIPTION
### TODO

* [x] add source deployment to precommand if no_shared_fs is True (in spawn_jobs.py)
* [x] upload sources before scheduler is started if no_shared_fs is True (in workflow.py)

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

@vsoch this should obviate the need to implement hand-made solutions for uploading source code in each executor plugin