### PR TITLE
fix: use temporary directory (faster, more likely local, always writable) for persistence and source cache in case of remote execution without shared fs

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -159,10 +159,7 @@ class SnakemakeApi(ApiBase):
         if self._workflow_api is not None:
             self._workflow_api._workdir_handler.change_back()
             if self._workflow_api._workflow_store is not None:
-                for conda_env in self._workflow_api._workflow_store.injected_conda_envs:
-                    conda_env.remove()
-                if self._workflow_api._workflow._workdir_handler is not None:
-                    self._workflow_api._workflow._workdir_handler.change_back()
+                self._workflow_api._workflow_store.tear_down()
 
     def deploy_sources(
         self,

--- a/snakemake/cwl.py
+++ b/snakemake/cwl.py
@@ -32,6 +32,7 @@ def cwl(
     use_singularity,
     bench_record,
     jobid,
+    sourcecache_path,
     runtime_sourcecache_path,
 ):
     """

--- a/snakemake/executors/local.py
+++ b/snakemake/executors/local.py
@@ -165,6 +165,7 @@ class Executor(RealExecutor):
             else None,
             self.workflow.conda_base_path,
             job.rule.basedir,
+            self.workflow.sourcecache.cache_path,
             self.workflow.sourcecache.runtime_cache_path,
         )
 
@@ -298,6 +299,7 @@ def run_wrapper(
     edit_notebook,
     conda_base_path,
     basedir,
+    sourcecache_path,
     runtime_sourcecache_path,
 ):
     """
@@ -377,6 +379,7 @@ def run_wrapper(
                             edit_notebook,
                             conda_base_path,
                             basedir,
+                            sourcecache_path,
                             runtime_sourcecache_path,
                         )
                     else:
@@ -407,6 +410,7 @@ def run_wrapper(
                                 edit_notebook,
                                 conda_base_path,
                                 basedir,
+                                sourcecache_path,
                                 runtime_sourcecache_path,
                             )
                     # Store benchmark record for this iteration
@@ -435,6 +439,7 @@ def run_wrapper(
                     edit_notebook,
                     conda_base_path,
                     basedir,
+                    sourcecache_path,
                     runtime_sourcecache_path,
                 )
     except (KeyboardInterrupt, SystemExit) as e:

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -250,6 +250,7 @@ def notebook(
     cleanup_scripts,
     shadow_dir,
     edit,
+    sourcecache_path,
     runtime_sourcecache_path,
 ):
     """
@@ -285,7 +286,11 @@ def notebook(
 
     if not draft:
         path, source, language, is_local, cache_path = get_source(
-            path, SourceCache(runtime_sourcecache_path), basedir, wildcards, params
+            path,
+            SourceCache(sourcecache_path, runtime_sourcecache_path),
+            basedir,
+            wildcards,
+            params,
         )
     else:
         source = None

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -507,7 +507,7 @@ class Run(RuleKeywordState):
             "resources, log, rule, conda_env, container_img, "
             "singularity_args, use_singularity, env_modules, bench_record, jobid, "
             "is_shell, bench_iteration, cleanup_scripts, shadow_dir, edit_notebook, "
-            "conda_base_path, basedir, runtime_sourcecache_path, {rule_func_marker}=True):".format(
+            "conda_base_path, basedir, sourcecache_path, runtime_sourcecache_path, {rule_func_marker}=True):".format(
                 rulename=self.rulename
                 if self.rulename is not None
                 else self.snakefile.rulecount,
@@ -608,7 +608,8 @@ class Script(AbstractCmd):
         yield (
             ", basedir, input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, conda_base_path, container_img, singularity_args, env_modules, "
-            "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir, runtime_sourcecache_path"
+            "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir, sourcecache_path, "
+            "runtime_sourcecache_path"
         )
 
 
@@ -621,7 +622,7 @@ class Notebook(Script):
             ", basedir, input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, conda_base_path, container_img, singularity_args, env_modules, "
             "bench_record, jobid, bench_iteration, cleanup_scripts, shadow_dir, "
-            "edit_notebook, runtime_sourcecache_path"
+            "edit_notebook, sourcecache_path, runtime_sourcecache_path"
         )
 
 
@@ -634,7 +635,7 @@ class Wrapper(Script):
             ", input, output, params, wildcards, threads, resources, log, "
             "config, rule, conda_env, conda_base_path, container_img, singularity_args, env_modules, "
             "bench_record, workflow.workflow_settings.wrapper_prefix, jobid, bench_iteration, "
-            "cleanup_scripts, shadow_dir, runtime_sourcecache_path"
+            "cleanup_scripts, shadow_dir, sourcecache_path, runtime_sourcecache_path"
         )
 
 
@@ -653,7 +654,8 @@ class CWL(Script):
     def args(self):
         yield (
             ", basedir, input, output, params, wildcards, threads, resources, log, "
-            "config, rule, use_singularity, bench_record, jobid, runtime_sourcecache_path"
+            "config, rule, use_singularity, bench_record, jobid, sourcecache_path, "
+            "runtime_sourcecache_path"
         )
 
 

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -41,6 +41,7 @@ class Persistence(PersistenceExecutorInterface):
         singularity_prefix=None,
         shadow_prefix=None,
         warn_only=False,
+        path: Path = None,
     ):
         import importlib.util
 
@@ -52,7 +53,10 @@ class Persistence(PersistenceExecutorInterface):
 
         self._max_len = None
 
-        self._path = Path(os.path.abspath(".snakemake"))
+        if path is None:
+            self._path = Path(os.path.abspath(".snakemake"))
+        else:
+            self._path = path
         os.makedirs(self.path, exist_ok=True)
 
         self._lockdir = os.path.join(self.path, "locks")

--- a/snakemake/script.py
+++ b/snakemake/script.py
@@ -1491,6 +1491,7 @@ def script(
     bench_iteration,
     cleanup_scripts,
     shadow_dir,
+    sourcecache_path,
     runtime_sourcecache_path,
 ):
     """
@@ -1500,7 +1501,11 @@ def script(
         path = str(path)
 
     path, source, language, is_local, cache_path = get_source(
-        path, SourceCache(runtime_sourcecache_path), basedir, wildcards, params
+        path,
+        SourceCache(sourcecache_path, runtime_sourcecache_path),
+        basedir,
+        wildcards,
+        params,
     )
 
     exec_class = {

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -15,6 +15,7 @@ import io
 from abc import ABC, abstractmethod
 from urllib.parse import unquote
 
+from snakemake_interface_executor_plugins.settings import ExecMode
 from snakemake.common import (
     ON_WINDOWS,
     is_local_file,
@@ -346,10 +347,8 @@ class SourceCache:
         r"https://raw.githubusercontent.com/snakemake/snakemake-wrappers/\d+\.\d+.\d+"
     ]  # TODO add more prefixes for uris that are save to be cached
 
-    def __init__(self, runtime_cache_path=None):
-        self.cache = Path(
-            os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache")
-        )
+    def __init__(self, cache_path: Path, runtime_cache_path: Path = None):
+        self.cache = cache_path
         os.makedirs(self.cache, exist_ok=True)
         if runtime_cache_path is None:
             runtime_cache_parent = self.cache / "runtime-cache"

--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -348,10 +348,10 @@ class SourceCache:
     ]  # TODO add more prefixes for uris that are save to be cached
 
     def __init__(self, cache_path: Path, runtime_cache_path: Path = None):
-        self.cache = cache_path
-        os.makedirs(self.cache, exist_ok=True)
+        self.cache_path = cache_path
+        os.makedirs(self.cache_path, exist_ok=True)
         if runtime_cache_path is None:
-            runtime_cache_parent = self.cache / "runtime-cache"
+            runtime_cache_parent = self.cache_path / "runtime-cache"
             os.makedirs(runtime_cache_parent, exist_ok=True)
             self.runtime_cache = tempfile.TemporaryDirectory(dir=runtime_cache_parent)
             self._runtime_cache_path = None
@@ -388,7 +388,7 @@ class SourceCache:
         # TODO add git support to smart_open!
         if source_file.is_persistently_cacheable():
             # check cache
-            return self.cache / file_cache_path
+            return self.cache_path / file_cache_path
         else:
             # check runtime cache
             return Path(self.runtime_cache_path) / file_cache_path

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -227,7 +227,7 @@ class Workflow(WorkflowExecutorInterface):
         if self.remote_exec_no_shared_fs:
             return self.snakemake_tmp_dir / "source-cache"
         else:
-            Path(os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache"))
+            return Path(os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache"))
 
     @property
     def storage_registry(self):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -227,7 +227,9 @@ class Workflow(WorkflowExecutorInterface):
         if self.remote_exec_no_shared_fs:
             return self.snakemake_tmp_dir / "source-cache"
         else:
-            return Path(os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache"))
+            return Path(
+                os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache")
+            )
 
     @property
     def storage_registry(self):

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -96,6 +96,7 @@ import snakemake.wrapper
 from snakemake.common import (
     ON_WINDOWS,
     async_run,
+    get_appdirs,
     is_local_file,
     Rules,
     Scatter,
@@ -180,7 +181,10 @@ class Workflow(WorkflowExecutorInterface):
         self._resource_scopes = ResourceScopes.defaults()
         self._resource_scopes.update(self.resource_settings.overwrite_resource_scopes)
         self.modules = dict()
-        self._sourcecache = SourceCache()
+        self._snakemake_tmp_dir = tempfile.TemporaryDirectory(prefix="snakemake")
+
+        self._sourcecache = SourceCache(self.source_cache_path)
+
         self._scheduler = None
         self._spawned_job_general_args = None
         self._executor_plugin = None
@@ -206,6 +210,24 @@ class Workflow(WorkflowExecutorInterface):
         self.cache_rules = dict()
 
         self.globals["config"] = copy.deepcopy(self.config_settings.overwrite_config)
+
+    def tear_down(self):
+        for conda_env in self.injected_conda_envs:
+            conda_env.remove()
+        if self._workdir_handler is not None:
+            self._workdir_handler.change_back()
+        self._snakemake_tmp_dir.cleanup()
+
+    @property
+    def snakemake_tmp_dir(self) -> Path:
+        return Path(self._snakemake_tmp_dir.name)
+
+    @property
+    def source_cache_path(self) -> Path:
+        if self.remote_exec_no_shared_fs:
+            return self.snakemake_tmp_dir / "source-cache"
+        else:
+            Path(os.path.join(get_appdirs().user_cache_dir, "snakemake/source-cache"))
 
     @property
     def storage_registry(self):
@@ -718,6 +740,12 @@ class Workflow(WorkflowExecutorInterface):
             ignore_incomplete=ignore_incomplete,
         )
 
+        persistence_path = (
+            self.snakemake_tmp_dir / "persistence"
+            if self.remote_exec_no_shared_fs
+            else None
+        )
+
         self._persistence = Persistence(
             nolock=nolock,
             dag=self._dag,
@@ -725,6 +753,7 @@ class Workflow(WorkflowExecutorInterface):
             singularity_prefix=self.deployment_settings.apptainer_prefix,
             shadow_prefix=shadow_prefix,
             warn_only=lock_warn_only,
+            path=persistence_path,
         )
 
     def generate_unit_tests(self, path: Path):

--- a/snakemake/wrapper.py
+++ b/snakemake/wrapper.py
@@ -89,6 +89,7 @@ def wrapper(
     bench_iteration,
     cleanup_scripts,
     shadow_dir,
+    sourcecache_path,
     runtime_sourcecache_path,
 ):
     """
@@ -97,7 +98,9 @@ def wrapper(
     """
     assert path is not None
     script_source = get_script(
-        path, SourceCache(runtime_cache_path=runtime_sourcecache_path), prefix=prefix
+        path,
+        SourceCache(sourcecache_path, runtime_cache_path=runtime_sourcecache_path),
+        prefix=prefix,
     )
     if script_source is None:
         raise WorkflowError(
@@ -126,5 +129,6 @@ def wrapper(
         bench_iteration,
         cleanup_scripts,
         shadow_dir,
+        sourcecache_path,
         runtime_sourcecache_path,
     )


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
