### PR TITLE
fix: fix command in short.rst

### DIFF
--- a/docs/tutorial/short.rst
+++ b/docs/tutorial/short.rst
@@ -236,7 +236,7 @@ Instead of a shell command, we use Snakemake's Jupyter notebook integration by s
 .. code:: python
 
        notebook:
-           "notebooks/plot-quals.py"
+           "notebooks/plot-quals.py.ipynb"
 
 instead of using the ``shell`` directive as before.
 


### PR DESCRIPTION
### Description

Notebook has to end on .py.ipynb or .r.ipynb but in step 6 of the short docs it says:

"
Instead of a shell command, we use Snakemake's Jupyter notebook integration by specifying

notebook:
    "notebooks/plot-quals.py"
"

causing the following error:

"
RuleException:
WorkflowError in file _path-to-project_/workflow/Snakefile, line 43:
Notebook to edit has to end on .py.ipynb or .r.ipynb in order to decide which programming language shall be used.
  File "_path-to-project_/workflow/Snakefile", line 43, in __rule_plot_quals
  File "/home/_username_/miniconda3/envs/snakemake/lib/python3.11/concurrent/futures/thread.py", line 58, in run
"

A simple fix was to use a name ending with .py.ipynb