### PR TITLE
fix: shadow "full" mode ignore symlinks

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -785,7 +785,8 @@ class Job(AbstractJob, SingleJobExecutorInterface):
                 os.symlink(os.path.abspath(source), link)
         elif self.rule.shadow_depth == "full":
             snakemake_dir = os.path.join(cwd, ".snakemake")
-            for dirpath, dirnames, filenames in os.walk(cwd):
+            for dirpath, dirnames, filenames in os.walk(cwd, followlinks=True):
+                # a link should not point to a parent directory of itself, else can cause infinite recursion
                 # Must exclude .snakemake and its children to avoid infinite
                 # loop of symlinks.
                 if os.path.commonprefix([snakemake_dir, dirpath]) == snakemake_dir:


### PR DESCRIPTION
### Description
#2511
Using "full" mode of shadow will skip files in symbolic link dirs

### QC
<!-- Make sure that you can tick the boxes below. -->

* [✔ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ✔] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
