### PR TITLE
fix: detect job paths that leave and then enter a group. Such paths are invalid because then the group depends on itself.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,10 +128,22 @@ html_theme_options = {
     "light_logo": "logo-snake.svg",
     "navigation_style": "plain",
     "sidebar_links": [
-        {"text": "Snakemake plugin catalog", "alt": "Snakemake plugin catalog", "href": "https://snakemake.github.io/snakemake-plugin-catalog"},
-        {"text": "Snakemake workflow catalog", "alt": "Snakemake workflow catalog", "href": "https://snakemake.github.io/snakemake-workflow-catalog"},
-        {"text": "Snakemake wrappers", "alt": "Snakemake wrappers", "href": "https://snakemake-wrappers.readthedocs.io"},
-    ]
+        {
+            "text": "Snakemake plugin catalog",
+            "alt": "Snakemake plugin catalog",
+            "href": "https://snakemake.github.io/snakemake-plugin-catalog",
+        },
+        {
+            "text": "Snakemake workflow catalog",
+            "alt": "Snakemake workflow catalog",
+            "href": "https://snakemake.github.io/snakemake-workflow-catalog",
+        },
+        {
+            "text": "Snakemake wrappers",
+            "alt": "Snakemake wrappers",
+            "href": "https://snakemake-wrappers.readthedocs.io",
+        },
+    ],
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -45,16 +45,21 @@ def get_exception_origin(ex, linemaps):
 
 
 def cut_traceback(ex):
+    lines = []
     snakemake_path = os.path.dirname(__file__)
-    for line in traceback.extract_tb(ex.__traceback__):
+    not_seen_snakemake = True
+    for line in traceback.extract_tb(ex.__traceback__)[::-1]:
         dir = os.path.dirname(line[0])
         if not dir:
             dir = "."
         is_snakemake_dir = lambda path: os.path.realpath(path).startswith(
             os.path.realpath(snakemake_path)
         )
-        if not os.path.isdir(dir) or not is_snakemake_dir(dir):
-            yield line
+        if is_snakemake_dir(dir):
+            not_seen_snakemake = False
+        if not os.path.isdir(dir) or not_seen_snakemake:
+            lines.append(line)
+    return lines[::-1]
 
 
 def format_traceback(tb, linemaps):

--- a/tests/test_groups_out_of_jobs/Snakefile
+++ b/tests/test_groups_out_of_jobs/Snakefile
@@ -1,0 +1,42 @@
+rule all:
+    input:
+        "results/e.txt",
+
+
+rule e:
+    input:
+        "results/d.txt",
+        "results/a.txt"
+    output:
+        "results/e.txt"
+    group:
+        "group1"
+    shell:
+        "touch {output}"
+
+
+rule c:
+    input:
+        "results/a.txt"
+    output:
+        "results/c.txt",
+    shell:
+        "touch {output}"
+
+
+rule d:
+    input:
+        "results/c.txt"
+    output:
+        "results/d.txt"
+    shell:
+        "touch {output}"
+
+
+rule a:
+    output:
+        "results/a.txt"
+    group:
+        "group1"
+    shell:
+        "touch {output}"

--- a/tests/test_groups_out_of_jobs/qsub
+++ b/tests/test_groups_out_of_jobs/qsub
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo `date` >> qsub.log
+tail -n1 $1 >> qsub.log
+# simulate printing of job id by a random number
+echo $RANDOM
+sh $1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -790,6 +790,15 @@ def assert_resources(resources: dict, **expected_resources):
 
 
 @skip_on_windows
+def test_groups_out_of_jobs():
+    run(
+        dpath("test_groups_out_of_jobs"),
+        cluster="./qsub",
+        shouldfail=True,
+    )
+
+
+@skip_on_windows
 def test_group_jobs_resources(mocker):
     spy = mocker.spy(GroupResources, "basic_layered")
     run(


### PR DESCRIPTION
Many thanks to @christopher.schroeder for providing the test case

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
