### PR TITLE
docs: document name directive with example

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -16,6 +16,16 @@ Most commonly, rules consist of a name, input files, output files, and a shell c
 
 The name is optional and can be left out, creating an anonymous rule. It can also be overridden by setting a rule's ``name`` attribute.
 
+.. code-block:: python
+
+    for tool in ["bcftools", "freebayes"]:
+        rule:
+            name: f"call_variants_{tool}"
+            input: f"path/to/{tool}/inputfile"
+            output: f"path/to/{tool}/outputfile"
+            shell: f"{tool} {{input}} > {{output}}"
+
+
 .. sidebar:: Note
 
     Note that any placeholders in the shell command (like ``{input}``) are always evaluated and replaced


### PR DESCRIPTION
### Description

The `name` directive is super helpful but felt it wasn't very obvious in the docs. I added an example usage based on my own usage of it as I think a lot of others use it in the same manner.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
