### PR TITLE
fix: use conda as the default frontend

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1570,10 +1570,9 @@ def get_argument_parser(profiles=None):
     )
     group_conda.add_argument(
         "--conda-frontend",
-        default="mamba",
+        default="conda",
         choices=["conda", "mamba"],
         help="Choose the conda frontend for installing environments. "
-        "Mamba is much faster and highly recommended.",
     )
 
     group_singularity = parser.add_argument_group("APPTAINER/SINGULARITY")


### PR DESCRIPTION
### Description

With conda's October 2023 release¹, the default solver uses the same backend as mamba, making it equally fast.

¹ https://github.com/conda/conda/blob/f9fe520956490f7d218abbe6f6fdc0c361535847/CHANGELOG.md#23100-2023-10-30

### QC
<!-- Make sure that you can tick the boxes below. -->

_This PR has been opened for discussion. Further changes can be made if this seems like a good direction._

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
