### PR TITLE
feat: add --sdm short opt for --deployment

### DIFF
--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -244,8 +244,8 @@ Integrated Package Management
 
 It is possible (and highly encouraged, see :ref:`snakefiles-best_practices`) to define isolated software environments per rule.
 Upon execution of a workflow, the `Conda package manager <https://conda.pydata.org>`_ is used to obtain and deploy the defined software packages in the specified versions. Packages will be installed into your working directory, without requiring any admin/root priviledges.
-Given that conda is available on your system (see `Miniconda <https://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--software-deployment-method conda`` flag to your workflow execution command, e.g. ``snakemake --cores 8 --software-deployment-method conda``.
-When ``--software-deployment-method conda`` is activated, Snakemake will automatically create software environments for any used wrapper (see :ref:`snakefiles-wrappers`).
+Given that conda is available on your system (see `Miniconda <https://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--software-deployment-method conda`` option (``-m`` for short) to your workflow execution command, e.g. ``snakemake --cores 8 -m conda``.
+When ``--software-deployment-method conda`` (``-m`` for short) is activated, Snakemake will automatically create software environments for any used wrapper (see :ref:`snakefiles-wrappers`).
 Further, you can manually define environments via the ``conda`` directive, e.g.:
 
 .. code-block:: python
@@ -295,7 +295,7 @@ At the moment, only a single, random conda environment is shown.
 Snakemake will store the environment persistently in ``.snakemake/conda/$hash`` with ``$hash`` being the MD5 hash of the environment definition file content. This way, updates to the environment definition are automatically detected.
 Note that you need to clean up environments manually for now. However, in many cases they are lightweight and consist of symlinks to your central conda installation.
 
-Conda deployment also works well for offline or air-gapped environments. Running ``snakemake --software-deployment-method conda --conda-create-envs-only`` will only install the required conda environments without running the full workflow. Subsequent runs with ``--software-deployment-method conda`` will make use of the local environments without requiring internet access.
+Conda deployment also works well for offline or air-gapped environments. Running ``snakemake -m conda --conda-create-envs-only`` will only install the required conda environments without running the full workflow. Subsequent runs with ``-m conda`` will make use of the local environments without requiring internet access.
 
 Freezing environments to exactly pinned packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -425,6 +425,8 @@ When executing Snakemake with
 .. code-block:: bash
 
     snakemake --software-deployment-method apptainer
+    # or the shorthand version
+    snakemake -m apptainer
 
 it will execute the job within a container that is spawned from the given image.
 Allowed image urls entail everything supported by apptainer (e.g., ``shub://`` and ``docker://``).
@@ -522,6 +524,8 @@ Then, upon invocation with
 .. code-block:: bash
 
     snakemake --software-deployment-method conda apptainer
+    # or the shorthand version
+    snakemake -m conda apptainer
 
 Snakemake will first pull the defined container image, and then create the requested conda environment from within the container.
 The conda environments will still be stored in your working environment, such that they don't have to be recreated unless they have changed.
@@ -635,3 +639,5 @@ has been installed.
 This mechanism requires that you use Mamba_ or Conda and activate conda-based software deployment via::
 
     --software-deployment-method conda
+    # or the shorthand version
+    -m conda

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -244,8 +244,8 @@ Integrated Package Management
 
 It is possible (and highly encouraged, see :ref:`snakefiles-best_practices`) to define isolated software environments per rule.
 Upon execution of a workflow, the `Conda package manager <https://conda.pydata.org>`_ is used to obtain and deploy the defined software packages in the specified versions. Packages will be installed into your working directory, without requiring any admin/root priviledges.
-Given that conda is available on your system (see `Miniconda <https://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--software-deployment-method conda`` option (``-m`` for short) to your workflow execution command, e.g. ``snakemake --cores 8 -m conda``.
-When ``--software-deployment-method conda`` (``-m`` for short) is activated, Snakemake will automatically create software environments for any used wrapper (see :ref:`snakefiles-wrappers`).
+Given that conda is available on your system (see `Miniconda <https://conda.pydata.org/miniconda.html>`_), to use the Conda integration, add the ``--software-deployment-method conda`` option (``--sdm`` for short) to your workflow execution command, e.g. ``snakemake --cores 8 --sdm conda``.
+When ``--software-deployment-method conda`` (``--sdm`` for short) is activated, Snakemake will automatically create software environments for any used wrapper (see :ref:`snakefiles-wrappers`).
 Further, you can manually define environments via the ``conda`` directive, e.g.:
 
 .. code-block:: python
@@ -295,7 +295,7 @@ At the moment, only a single, random conda environment is shown.
 Snakemake will store the environment persistently in ``.snakemake/conda/$hash`` with ``$hash`` being the MD5 hash of the environment definition file content. This way, updates to the environment definition are automatically detected.
 Note that you need to clean up environments manually for now. However, in many cases they are lightweight and consist of symlinks to your central conda installation.
 
-Conda deployment also works well for offline or air-gapped environments. Running ``snakemake -m conda --conda-create-envs-only`` will only install the required conda environments without running the full workflow. Subsequent runs with ``-m conda`` will make use of the local environments without requiring internet access.
+Conda deployment also works well for offline or air-gapped environments. Running ``snakemake --sdm conda --conda-create-envs-only`` will only install the required conda environments without running the full workflow. Subsequent runs with ``--sdm conda`` will make use of the local environments without requiring internet access.
 
 Freezing environments to exactly pinned packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -426,7 +426,7 @@ When executing Snakemake with
 
     snakemake --software-deployment-method apptainer
     # or the shorthand version
-    snakemake -m apptainer
+    snakemake --sdm apptainer
 
 it will execute the job within a container that is spawned from the given image.
 Allowed image urls entail everything supported by apptainer (e.g., ``shub://`` and ``docker://``).
@@ -525,7 +525,7 @@ Then, upon invocation with
 
     snakemake --software-deployment-method conda apptainer
     # or the shorthand version
-    snakemake -m conda apptainer
+    snakemake --sdm conda apptainer
 
 Snakemake will first pull the defined container image, and then create the requested conda environment from within the container.
 The conda environments will still be stored in your working environment, such that they don't have to be recreated unless they have changed.
@@ -640,4 +640,4 @@ This mechanism requires that you use Mamba_ or Conda and activate conda-based so
 
     --software-deployment-method conda
     # or the shorthand version
-    -m conda
+    --sdm conda

--- a/docs/snakefiles/modularization.rst
+++ b/docs/snakefiles/modularization.rst
@@ -86,7 +86,7 @@ A CWL tool definition can be used as follows.
 
 It is advisable to use a github URL that includes the commit as above instead of a branch name, in order to ensure reproducible results.
 Snakemake will execute the rule by invoking `cwltool`, which has to be available via your `$PATH` variable, and can be, e.g., installed via `conda` or `pip`.
-When using in combination with :ref:`--software-deployment-method apptainer <apptainer>` (``-m`` for short), Snakemake will instruct `cwltool` to execute the command via Singularity in user space.
+When using in combination with :ref:`--software-deployment-method apptainer <apptainer>` (``--sdm`` for short), Snakemake will instruct `cwltool` to execute the command via Singularity in user space.
 Otherwise, `cwltool` will in most cases use a Docker container, which requires Docker to be set up properly.
 
 The advantage is that predefined tools available via any `repository of CWL tool definitions <https://www.commonwl.org/#Repositories_of_CWL_Tools_and_Workflows>`_ can be used in any supporting workflow management system.

--- a/docs/snakefiles/modularization.rst
+++ b/docs/snakefiles/modularization.rst
@@ -86,7 +86,7 @@ A CWL tool definition can be used as follows.
 
 It is advisable to use a github URL that includes the commit as above instead of a branch name, in order to ensure reproducible results.
 Snakemake will execute the rule by invoking `cwltool`, which has to be available via your `$PATH` variable, and can be, e.g., installed via `conda` or `pip`.
-When using in combination with :ref:`--software-deployment-method apptainer <apptainer>`, Snakemake will instruct `cwltool` to execute the command via Singularity in user space.
+When using in combination with :ref:`--software-deployment-method apptainer <apptainer>` (``-m`` for short), Snakemake will instruct `cwltool` to execute the command via Singularity in user space.
 Otherwise, `cwltool` will in most cases use a Docker container, which requires Docker to be set up properly.
 
 The advantage is that predefined tools available via any `repository of CWL tool definitions <https://www.commonwl.org/#Repositories_of_CWL_Tools_and_Workflows>`_ can be used in any supporting workflow management system.

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1211,7 +1211,7 @@ For example, running
 
     snakemake --cores 1 --draft-notebook test.txt --software-deployment-method conda
     # or the short form
-    snakemake -c 1 --draft-notebook test.txt -m conda
+    snakemake -c 1 --draft-notebook test.txt --sdm conda
 
 will generate skeleton code in ``notebooks/hello.py.ipynb`` and additionally print instructions on how to open and execute the notebook in VSCode.
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1210,6 +1210,8 @@ For example, running
 .. code-block:: console
 
     snakemake --cores 1 --draft-notebook test.txt --software-deployment-method conda
+    # or the short form
+    snakemake -c 1 --draft-notebook test.txt -m conda
 
 will generate skeleton code in ``notebooks/hello.py.ipynb`` and additionally print instructions on how to open and execute the notebook in VSCode.
 

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -144,7 +144,7 @@ When Snakemake is executed with
 
   snakemake --software-deployment-method conda --cores 1
   # or the short form
-    snakemake -m conda -c 1
+    snakemake --sdm conda -c 1
 
 it will automatically create required environments and
 activate them before a job is executed.

--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -143,6 +143,8 @@ When Snakemake is executed with
 .. code:: console
 
   snakemake --software-deployment-method conda --cores 1
+  # or the short form
+    snakemake -m conda -c 1
 
 it will automatically create required environments and
 activate them before a job is executed.

--- a/docs/tutorial/short.rst
+++ b/docs/tutorial/short.rst
@@ -128,6 +128,11 @@ to perform a dry-run and
    snakemake --software-deployment-method conda results/mapped/A.bam --cores 1
 
 to perform the actual execution.
+
+.. sidebar:: Note
+
+    The ``--software-deployment-method`` option has a shorthand alias ``-m``, which we will use for brevity in the rest of this tutorial. There are two other long-form aliases ``--deployment-method`` and ``--deployment``.
+
  
 Step 3
 ------
@@ -164,13 +169,13 @@ Test your workflow with
 
 ::
 
-   snakemake --software-deployment-method conda -n results/mapped/A.sorted.bam
+   snakemake -m conda -n results/mapped/A.sorted.bam
 
 and
 
 ::
 
-   snakemake --software-deployment-method conda results/mapped/A.sorted.bam --cores 1
+   snakemake -m conda results/mapped/A.sorted.bam --cores 1
 
 Step 5
 ------
@@ -260,7 +265,7 @@ Then, we let Snakemake generate a skeleton notebook for us with
 
 .. code:: console
 
-    snakemake --draft-notebook results/plots/quals.svg --cores 1 --software-deployment-method conda
+    snakemake --draft-notebook results/plots/quals.svg --cores 1 -m conda
 
 Snakemake will print instructions on how to open, edit and execute the notebook.
 
@@ -290,7 +295,7 @@ Make sure to test your workflow with
 
 ::
 
-   snakemake --software-deployment-method conda --force results/plots/quals.svg --cores 1
+   snakemake -m conda --force results/plots/quals.svg --cores 1
 
 Here, the force ensures that the readily drafted notebook is re-executed even if you had already generated the output plot in the interactive mode.
  

--- a/docs/tutorial/short.rst
+++ b/docs/tutorial/short.rst
@@ -131,7 +131,7 @@ to perform the actual execution.
 
 .. sidebar:: Note
 
-    The ``--software-deployment-method`` option has a shorthand alias ``-m``, which we will use for brevity in the rest of this tutorial. There are two other long-form aliases ``--deployment-method`` and ``--deployment``.
+    The ``--software-deployment-method`` option has a shorthand alias ``--sdm``, which we will use for brevity in the rest of this tutorial. There are two other long-form aliases ``--deployment-method`` and ``--deployment``.
 
  
 Step 3
@@ -169,13 +169,13 @@ Test your workflow with
 
 ::
 
-   snakemake -m conda -n results/mapped/A.sorted.bam
+   snakemake --sdm conda -n results/mapped/A.sorted.bam
 
 and
 
 ::
 
-   snakemake -m conda results/mapped/A.sorted.bam --cores 1
+   snakemake --sdm conda results/mapped/A.sorted.bam --cores 1
 
 Step 5
 ------
@@ -265,7 +265,7 @@ Then, we let Snakemake generate a skeleton notebook for us with
 
 .. code:: console
 
-    snakemake --draft-notebook results/plots/quals.svg --cores 1 -m conda
+    snakemake --draft-notebook results/plots/quals.svg --cores 1 --sdm conda
 
 Snakemake will print instructions on how to open, edit and execute the notebook.
 
@@ -295,7 +295,7 @@ Make sure to test your workflow with
 
 ::
 
-   snakemake -m conda --force results/plots/quals.svg --cores 1
+   snakemake --sdm conda --force results/plots/quals.svg --cores 1
 
 Here, the force ensures that the readily drafted notebook is re-executed even if you had already generated the output plot in the interactive mode.
  

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1495,7 +1495,7 @@ def get_argument_parser(profiles=None):
 
     group_deployment = parser.add_argument_group("SOFTWARE DEPLOYMENT")
     group_deployment.add_argument(
-        "-m",
+        "--sdm",
         "--software-deployment-method",
         "--deployment-method",
         "--deployment",

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1495,6 +1495,7 @@ def get_argument_parser(profiles=None):
 
     group_deployment = parser.add_argument_group("SOFTWARE DEPLOYMENT")
     group_deployment.add_argument(
+        "-m",
         "--software-deployment-method",
         "--deployment-method",
         "--deployment",


### PR DESCRIPTION
### Description

The new `--software-deployment-method`/`--deployment-method`/`--deployment` is probably a heavily used option for most users, so I think it would benefit from a shorthand option as it is quite verbose. Seems `-m` is available and is kind of related.

I've also updated the docs with some references to this shorthand version and replaced some longform usage with the short option, ensuring it is made clear what the shorthand option is an alias for. Happy to change this though.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
