### PR TITLE
fix: do not pass snakefile as metadata when wms monitor flag is used

### DIFF
--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -184,7 +184,6 @@ class WMSLogger:
 
         # Prepare a request that has metadata about the job
         metadata = {
-            "snakefile": os.path.join(workdir, self.metadata.get("snakefile")),
             "command": self.metadata.get("command"),
             "workdir": workdir,
         }


### PR DESCRIPTION
### Description

Fixes #2390 by not providing a Snakefile as it is anyway not used in the web server.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
