### PR TITLE
test: Add test for issue #1256 and #2574

### DIFF
--- a/tests/test_issue1256/Snakefile
+++ b/tests/test_issue1256/Snakefile
@@ -1,0 +1,10 @@
+rule all:
+    input:
+        'done.txt',
+        
+rule trim_transcripts:
+    output:
+        done.txt,
+    run:
+        if 1 = 2:  # Intentional syntax error
+            print('foo')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1930,3 +1930,14 @@ def test_missing_file_dryrun():
 
 def test_script_pre_py39():
     run(dpath("test_script_pre_py39"), deployment_method={DeploymentMethod.CONDA})
+
+
+def test_issue1256():
+    snakefile = os.path.join(dpath("test_issue1256"), "Snakefile")
+    p = subprocess.Popen(f"snakemake -s {snakefile}", 
+        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    stderr = stderr.decode()
+    assert p.returncode == 1
+    assert "SyntaxError" in stderr
+    assert "line 9" in stderr


### PR DESCRIPTION
### Description

Add test for issues #1256 and #2574.

The test Snakefile has a syntax error on line 9. Some versions of Snakemake, including 8.0.1, incorrectly report the error on line 20. I'm only submitting the test case, not the fix.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
