### PR TITLE
fix: single line f-string format error in py3.12

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -1314,7 +1314,6 @@ def parse(path, workflow, overwrite_shellcmd=None, rulecount=0):
                     )
                 )
             )
-            print(f">{t}<", orig_token)
             snakefile.lines += t.count("\n")
             compilation.append((t, orig_token))
     compilation = "".join(format_tokens(format_f_tokens(compilation)))

--- a/tests/test_fstring/Snakefile
+++ b/tests/test_fstring/Snakefile
@@ -10,6 +10,10 @@ rule unit1:
         "echo '>'{output}'<'; touch {output}; sleep 1"
 
 
+rule unit2:
+    shell:
+        f"ls"
+
 assert (
     f"""
 {


### PR DESCRIPTION
### Description

fix #2586 for some cases do not considered in #2485

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
