### PR TITLE
fix: Migrate away from deprecated pulp API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     nbformat
     packaging
     psutil
-    pulp >=2.0
+    pulp >=2.3.1
     pyyaml
     requests
     reretry

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     nbformat
     packaging
     psutil
-    pulp >=2.3.1
+    pulp >=2.3.1,<2.9 # pulp introduced a breaking change from 2.7 to 2.8. Hence we should always pin to the minor version.
     pyyaml
     requests
     reretry

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -767,7 +767,7 @@ def get_argument_parser(profiles=None):
     try:
         import pulp
 
-        lp_solvers = pulp.list_solvers(onlyAvailable=True)
+        lp_solvers = pulp.listSolvers(onlyAvailable=True)
     except ImportError:
         # Dummy list for the case that pulp is not available
         # This only happened when building docs.

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -607,7 +607,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
             )
         try:
             solver = (
-                pulp.get_solver(self.workflow.scheduling_settings.ilp_solver)
+                pulp.getSolver(self.workflow.scheduling_settings.ilp_solver)
                 if self.workflow.scheduling_settings.ilp_solver
                 else pulp.apis.LpSolverDefault
             )

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - jsonschema
   - pandas
   - gitpython
-  - pulp >=2.0
+  - pulp >=2.3.1
   - environment-modules
   - nbformat
   - toposort >=1.10


### PR DESCRIPTION
### Description

The latest update of pulp 2.8.0 removed deprecated API calls still used by snakemake.
This PR updates the calls to their modern equivalents, as well as constrains the pulp version to the moment these got introduced (v2.3.1).

Fixes the issues described in #2607 and #2606.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
