### PR TITLE
fix: local mtime handling in case of storage plugins and cleaner error message for parallel storage retrieval

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -479,7 +479,7 @@ class _IOFile(str, AnnotatedStringInterface):
                     mtime._local_target = mtime_local._local_target
                     mtime._local = mtime_local._local
             else:
-                cache[self] = mtime = await self.mtime_uncached()
+                cache.mtime[self] = mtime = await self.mtime_uncached()
             return mtime
         else:
             return await self.mtime_uncached()


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
