### PR TITLE
fix: bug with preemptible rules

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -563,7 +563,6 @@ def get_argument_parser(profiles=None):
             "Define which rules shall use a preemptible machine which can be prematurely killed by e.g. a cloud provider (also called spot instances). "
             "This is currently only supported by the Google Life Sciences executor and ignored by all other executors. "
             "If no rule names are provided, all rules are considered to be preemptible. "
-            "The "
         ),
     )
 
@@ -1902,9 +1901,11 @@ def args_to_api(args, parser):
                         ),
                     )
 
+                    # None indicates that the flag is not being used, a set indicates used
                     if args.preemptible_rules is not None:
-                        if not preemptible_rules:
-                            # no specific rule given, consider all to be made preemptible
+                        # If no explicit rules provided (empty set) we assume all preemptible
+                        # Checking for "not" evaluates for an empty set
+                        if not args.preemptible_rules:
                             preemptible_rules = PreemptibleRules(all=True)
                         else:
                             preemptible_rules = PreemptibleRules(


### PR DESCRIPTION
The second check in cli.py needs to be also looking at args.preemptible_rules, and not the (not defined yet) variable that is intended to be set.

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
