### PR TITLE
fix: use default group settings if not execution workflow (fixes attribute error occurring with --report)

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -152,7 +152,6 @@ class SnakemakeApi(ApiBase):
             workflow_settings=workflow_settings,
             deployment_settings=deployment_settings,
             storage_provider_settings=storage_provider_settings,
-            group_settings=GroupSettings(),  # just init with defaults, can be overwritten later
         )
         return self._workflow_api
 
@@ -379,6 +378,10 @@ class WorkflowApi(ApiBase):
 
     def _get_workflow(self, **kwargs):
         from snakemake.workflow import Workflow
+
+        if "group_settings" not in kwargs:
+            # just init with defaults, can be overwritten later
+            kwargs["group_settings"] = GroupSettings()
 
         return Workflow(
             config_settings=self.config_settings,

--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -152,6 +152,7 @@ class SnakemakeApi(ApiBase):
             workflow_settings=workflow_settings,
             deployment_settings=deployment_settings,
             storage_provider_settings=storage_provider_settings,
+            group_settings=GroupSettings(),  # just init with defaults, can be overwritten later
         )
         return self._workflow_api
 

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -138,7 +138,7 @@ class Workflow(WorkflowExecutorInterface):
     scheduling_settings: Optional[SchedulingSettings] = None
     output_settings: Optional[OutputSettings] = None
     remote_execution_settings: Optional[RemoteExecutionSettings] = None
-    group_settings: Optional[GroupSettings] = None
+    group_settings: GroupSettings = field(default_factory=GroupSettings)
     executor_settings: ExecutorSettingsBase = None
     storage_provider_settings: Optional[Mapping[str, TaggedSettings]] = None
     check_envvars: bool = True

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -138,7 +138,7 @@ class Workflow(WorkflowExecutorInterface):
     scheduling_settings: Optional[SchedulingSettings] = None
     output_settings: Optional[OutputSettings] = None
     remote_execution_settings: Optional[RemoteExecutionSettings] = None
-    group_settings: GroupSettings = field(default_factory=GroupSettings)
+    group_settings: Optional[GroupSettings] = None
     executor_settings: ExecutorSettingsBase = None
     storage_provider_settings: Optional[Mapping[str, TaggedSettings]] = None
     check_envvars: bool = True


### PR DESCRIPTION
This avoids the error `AttributeError: 'NoneType' object has no attribute 'local_groupid'`, e.g. occurring when trying to create a report

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
