### PR TITLE
docs: fix typo in `rules.py`

### DIFF
--- a/snakemake/linting/rules.py
+++ b/snakemake/linting/rules.py
@@ -115,7 +115,7 @@ class RuleLinter(Linter):
                     body="While environment modules allow to document and deploy the required software on a certain "
                     "platform, they lock your workflow in there, disabling easy reproducibility on other machines "
                     "that don't have exactly the same environment modules. Hence env modules (which might be beneficial "
-                    "in certain cluster environments), should allways be complemented with equivalent conda "
+                    "in certain cluster environments), should always be complemented with equivalent conda "
                     "environments.",
                     links=[links.package_management, links.containers],
                 )


### PR DESCRIPTION
### Description

Simple typo fix in `rules.py`

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
