### PR TITLE
feat: allow input url passthrough to executor backend

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -351,7 +351,7 @@ class DAG(DAGExecutorInterface):
                 f
                 for job in self.needrun_jobs()
                 for f in job.input
-                if f.is_storage and self.is_external_input(f, job)
+                if f.is_storage and self.is_external_input(f, job) and not is_flagged(f, "passthrough")
             }
 
             try:
@@ -990,6 +990,10 @@ class DAG(DAGExecutorInterface):
         producer = dict()
         exceptions = dict()
         for res in potential_dependencies:
+            if is_flagged(res.file, "passthrough"):
+                # passthrough files are not considered for dependency resolution
+                continue
+
             if create_inventory:
                 # If possible, obtain inventory information starting from
                 # given file and store it in the IOCache.

--- a/snakemake/path_modifier.py
+++ b/snakemake/path_modifier.py
@@ -105,6 +105,7 @@ class PathModifier:
             or is_flagged(path, "local")
             or is_flagged(path, "sourcecache_entry")
             or is_annotated_callable(path)
+            or is_flagged(path, "passthrough")
         ):
             # no default remote needed
             return path

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -64,6 +64,7 @@ from snakemake.scheduler import JobScheduler
 from snakemake.parser import parse
 import snakemake.io
 from snakemake.io import (
+    passthrough,
     protected,
     temp,
     temporary,


### PR DESCRIPTION
### Description

This PR adds an additional 'passthrough' flag for input files. The flag makes it possible to pass the URL directly to the executor backend, which downloads the file instead of Snakemake. This is especially useful when running the job on a custom executor implementation that handles additional protocols not implemented as Snakemake storage plugins.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
