### PR TITLE
fix: f-string in a more robust style?

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -65,6 +65,8 @@ def is_string(token):
 def is_fstring(token):
     if sys.version_info >= (3, 12):
         return token.type == tokenize.FSTRING_START
+    return False
+
 
 def is_eof(token):
     return token.type == tokenize.ENDMARKER

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -62,7 +62,7 @@ def is_string(token):
     return token.type == tokenize.STRING
 
 
-def is_fstring(token):
+def is_fstring_start(token):
     return sys.version_info >= (3, 12) and token.type == tokenize.FSTRING_START
 
 
@@ -108,6 +108,9 @@ class TokenAutomaton:
             self.was_indented |= self.indent > 0
 
     def parse_fstring(self, token: tokenize.TokenInfo):
+        # only for python >= 3.12, since then python changed the
+        # parsing manner of f-string, see
+        # [pep-0701](https://peps.python.org/pep-0701)
         isin_fstring = 1
         t = token.string
         for t1 in self.snakefile:
@@ -132,7 +135,8 @@ class TokenAutomaton:
             self.indentation(token)
             try:
                 for t, orig in self.state(token):
-                    if is_fstring(token):
+                    # python >= 3.12 only
+                    if is_fstring_start(token):
                         t = self.parse_fstring(token)
                     if self.lasttoken == "\n" and not t.isspace():
                         yield INDENT * self.effective_indent, orig

--- a/tests/test_fstring/Snakefile
+++ b/tests/test_fstring/Snakefile
@@ -1,11 +1,11 @@
 shell.executable("bash")
 
 PREFIX = "SID23454678"
-
+mid = ".t"
 
 rule unit1:
     output:
-        f"{PREFIX}.txt",
+        f"{PREFIX}{mid}xt",
     shell:
         "echo '>'{output}'<'; touch {output}; sleep 1"
 


### PR DESCRIPTION
### Description

fix: #2648

now, the f-string will never be parsed by `self.state(token)`

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
