### PR TITLE
fix: batch bug #2643

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -144,10 +144,10 @@ def parse_set_ints(arg, errmsg, fallback=None):
     return assignments
 
 
-def parse_batch(args):
+def parse_batch(arg):
     errmsg = "Invalid batch definition: batch entry has to be defined as RULE=BATCH/BATCHES (with integers BATCH <= BATCHES, BATCH >= 1)."
-    if args.batch is not None:
-        rule, batchdef = parse_key_value_arg(args.batch, errmsg=errmsg)
+    if arg is not None:
+        rule, batchdef = parse_key_value_arg(arg, errmsg=errmsg)
         try:
             batch, batches = batchdef.split("/")
             batch = int(batch)

--- a/snakemake/settings.py
+++ b/snakemake/settings.py
@@ -152,7 +152,11 @@ class Batch:
         return f"{self.idx}/{self.batches} (rule {self.rulename})"
 
     def __eq__(self, other):
-        return self.rulename == other.rulename and self.idx == other.idx and self.batches == other.batches
+        return (
+            self.rulename == other.rulename
+            and self.idx == other.idx
+            and self.batches == other.batches
+        )
 
 
 @dataclass

--- a/snakemake/settings.py
+++ b/snakemake/settings.py
@@ -151,6 +151,9 @@ class Batch:
     def __str__(self):
         return f"{self.idx}/{self.batches} (rule {self.rulename})"
 
+    def __eq__(self, other):
+        return self.rulename == other.rulename and self.idx == other.idx and self.batches == other.batches
+
 
 @dataclass
 class DAGSettings(SettingsBase):

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2024, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+
 def test_parse_batch():
     from snakemake.cli import parse_batch
     from snakemake.dag import Batch

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,10 @@
+__authors__ = ["K.D. Murray"]
+__copyright__ = "Copyright 2024, Johannes Köster"
+__email__ = "johannes.koester@uni-due.de"
+__license__ = "MIT"
+
+def test_parse_batch():
+    from snakemake.cli import parse_batch
+    from snakemake.dag import Batch
+
+    assert parse_batch("aggregate=1/2") == Batch("aggregate", 1, 2)


### PR DESCRIPTION
### Description

Fixes #2643. Seems to have been a refactor gone awry. Argparse "type" fuctions (*a la* `add_argument(type=XXXX)`) take str and produce some type. `parse_batch()` seems to expect an argparse namespace.

This wasn't caught in the unit tests, as they invoke `snakemake.run()` directly in a way that bypasses the CLI arg parsing, which is where this bug is. ~~Not sure what to do about that.~~ (wrote some tests)

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
