### PR TITLE
fix: set ignore_incomplete to False in create_conda_envs 

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -988,7 +988,7 @@ class Workflow(WorkflowExecutorInterface):
     def conda_create_envs(self):
         self._prepare_dag(
             forceall=self.dag_settings.forceall,
-            ignore_incomplete=self.execution_settings.ignore_incomplete,
+            ignore_incomplete=False,
             lock_warn_only=False,
         )
         self._build_dag()

--- a/tests/common.py
+++ b/tests/common.py
@@ -192,6 +192,7 @@ def run(
     omit_from=frozenset(),
     forcerun=frozenset(),
     conda_list_envs=False,
+    conda_create_envs=False,
     conda_prefix=None,
     wrapper_prefix=None,
     printshellcmds=False,
@@ -379,6 +380,8 @@ def run(
                     dag_api.create_report(
                         path=Path(report), stylesheet=report_stylesheet
                     )
+                elif conda_create_envs:
+                    dag_api.conda_create_envs()
                 elif conda_list_envs:
                     dag_api.conda_list_envs()
                 elif archive is not None:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -447,6 +447,21 @@ def test_conda_list_envs():
     run(dpath("test_conda"), conda_list_envs=True, check_results=False)
 
 
+def test_conda_create_envs_only():
+    tmpdir = run(
+        dpath("test_conda"),
+        conda_create_envs=True,
+        check_results=False,
+        cleanup=False,
+        cleanup_scripts=False,
+    )
+    env_dir = next(
+        (p for p in Path(tmpdir, ".snakemake", "conda").iterdir() if p.is_dir()), None
+    )
+    assert env_dir is not None
+    shutil.rmtree(tmpdir)
+
+
 def test_upstream_conda():
     run(
         dpath("test_conda"),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -459,6 +459,7 @@ def test_conda_create_envs_only():
         (p for p in Path(tmpdir, ".snakemake", "conda").iterdir() if p.is_dir()), None
     )
     assert env_dir is not None
+    assert Path(env_dir, "env_setup_done").exists()
     shutil.rmtree(tmpdir)
 
 


### PR DESCRIPTION
### Description

Potential fix for #2637. 

Edit:
Also adds test case for `conda-create-envs-only`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
