### PR TITLE
added support for comma in wildcards

### DIFF
--- a/snakemake/target_jobs.py
+++ b/snakemake/target_jobs.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import typing
-
+import re
 from snakemake_interface_executor_plugins.utils import TargetSpec
 
 from snakemake.common import parse_key_value_arg
@@ -14,12 +14,12 @@ def parse_target_jobs_cli_args(target_jobs_args):
             rulename, wildcards = entry.split(":", 1)
             if wildcards:
 
-                def parse_wildcard(entry):
-                    return parse_key_value_arg(entry, errmsg)
+                def remove_len_zero(tpl):
+                    return tuple(val for val in tpl if len(val)>0)
 
-                wildcards = dict(
-                    parse_wildcard(entry) for entry in wildcards.split(",")
-                )
+                matches = re.findall(r'(\w+)="([^"]*)",|(\w+)=([^,]*),', wildcards+",")
+                wildcards = dict(map(remove_len_zero, matches))
+                target_jobs.append(TargetSpec(rulename, wildcards))
                 target_jobs.append(TargetSpec(rulename, wildcards))
             else:
                 target_jobs.append(TargetSpec(rulename, dict()))

--- a/tests/test_comma_in_wildcard/Snakefile
+++ b/tests/test_comma_in_wildcard/Snakefile
@@ -1,0 +1,9 @@
+
+
+rule all:
+    input: "a_wildcard_with,.out"
+
+
+rule a:
+    output: "{prefix}.out"
+    shell: "touch {output}"


### PR DESCRIPTION
### Description

This is one part of two PR necessary to allow for commas in wildcards. This PR introduces the necessary decoding changes. 

The test case will currently fail as the other PR is necessary to properly handle the encoding.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
