### PR TITLE
fix: SyntaxWarning due to invalid escape sequences in non-raw regex pattern string

### DIFF
--- a/snakemake/ioutils.py
+++ b/snakemake/ioutils.py
@@ -12,7 +12,7 @@ from snakemake_interface_common.exceptions import WorkflowError
 
 
 class WildcardHandlerBase(ABC):
-    fmt_regex = re.compile("\{(?P<stmt>[^\{][^\{\}]+)\}[^\}]")
+    fmt_regex = re.compile(r"\{(?P<stmt>[^\{][^\{\}]+)\}[^\}]")
 
     def __init__(self, func, **namespace):
         self.func = func


### PR DESCRIPTION
### Description

A regex with a non-raw pattern string was introduced in ca7a6022bacae77be45068adbf4386c2c93fb481 that generates a `SyntaxWarning` about an invalid escape sequence `\{`.

This actually causes me to see test failures while trying to update the [`snakemake` package in Fedora Linux](https://src.fedoraproject.org/rpms/snakemake), e.g.:

```
______________________ test_lint[absolute_paths-positive] ______________________

lint = PosixPath('/builddir/build/BUILD/snakemake-8.4.3/tests/linting/absolute_paths')
case = 'positive'

    @pytest.mark.parametrize(
        "lint, case", product(os.listdir(LINT_DIR), ["positive", "negative"])
    )
    def test_lint(lint, case):
        lint = LINT_DIR.joinpath(lint)

        try:
            out = (
                sp.check_output(
                    [   
                        "/usr/bin/python3",
                        "-m",
                        "snakemake",
                        "--lint",
                        "--directory",
                        str(lint),
                        "--snakefile",
                        str(lint.joinpath(case).with_suffix(".smk")),
                    ],
                    stderr=sp.STDOUT,
                )
                .decode()
                .strip()
            )
            if case == "positive":
>               assert out == "Congratulations, your workflow is in a good condition!"
E               assert '/builddir/bu...od condition!' == 'Congratulati...od condition!'
E                 + /builddir/build/BUILD/snakemake-8.4.3/snakemake/ioutils.py:15: SyntaxWarning: invalid escape sequence '\{'
E                 +   fmt_regex = re.compile("\{(?P<stmt>[^\{][^\{\}]+)\}[^\}]")
E                   Congratulations, your workflow is in a good condition!

tests/test_linting.py:36: AssertionError
```

Either way, the problem can be fixed by escaping the backslashes, i.e. `"\\{(?P<stmt>[^\\{][^\\{\}]+)\\}[^\\}]"`, or less confusingly by just using a raw string, `r"\{(?P<stmt>[^\{][^\{\}]+)\}[^\}]"`, which is what this PR does.

See also https://github.com/snakemake/snakemake/pull/2359, which applied the same fix in several other places.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.

I don’t know if there’s a better way to catch this sort of thing in CI, but the change makes the `SyntaxWarning`s go away, and it fixes the test failures they were causing in the downstream package.

Note that I think you have to test on at least Python 3.12 in order to see the warnings.

* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

No documentation changes are required.