### PR TITLE
fix: output of rulegraph, closes #2656

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -899,7 +899,7 @@ class Workflow(WorkflowExecutorInterface):
             lock_warn_only=True,
         )
         self._build_dag()
-        self.dag.rule_dot()
+        print(self.dag.rule_dot())
 
     def printfilegraph(self):
         self._prepare_dag(


### PR DESCRIPTION
### Description

`--rulegraph` displays no output , the fix is to add print statement to `self.dag.rule_dot()`

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
