### PR TITLE
fix: for local execution, always unrestrictedly assume shared FS

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -481,8 +481,17 @@ class DAGApi(ApiBase):
             executor_plugin.validate_settings(executor_settings)
 
         if executor_plugin.common_settings.implies_no_shared_fs:
-            # no shard FS at all
+            # no shared FS at all
             self.workflow_api.storage_settings.shared_fs_usage = frozenset()
+        if (
+            executor_plugin.common_settings.local_exec
+            and not executor_plugin.common_settings.dryrun_exec
+            and self.workflow_api.workflow_settings.exec_mode == ExecMode.DEFAULT
+        ):
+            logger.info(
+                "Assuming unrestricted shared filesystem usage for local execution."
+            )
+            self.workflow_api.storage_settings.shared_fs_usage = SharedFSUsage.all()
         if executor_plugin.common_settings.job_deploy_sources:
             remote_execution_settings.job_deploy_sources = True
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
