### PR TITLE
fix: issue #2701

### DIFF
--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -523,7 +523,7 @@ def eval_resource_expression(val, threads_arg=True):
         # the form of '--flag=arg' non-Snakemake parameters
         # require parsing, which is not possible. They also do
         # not play any role after submission. Hence, we do:
-        if val.startswith("-"):
+        if "-" in val:
             return None
         if threads_arg:
             args["threads"] = kwargs["threads"]

--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -523,7 +523,7 @@ def eval_resource_expression(val, threads_arg=True):
         # the form of '--flag=arg' non-Snakemake parameters
         # require parsing, which is not possible. They also do
         # not play any role after submission. Hence, we do:
-        if "-" in val:
+        if val.lstrip().startswith('-'):
             return None
         if threads_arg:
             args["threads"] = kwargs["threads"]

--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -518,6 +518,13 @@ def eval_resource_expression(val, threads_arg=True):
             "attempt": kwargs["attempt"],
             "system_tmpdir": tempfile.gettempdir(),
         }
+        # As the 'slurm_extra' parameter from the SLURM
+        # executor plugin permits full strings flags in
+        # the form of '--flag=arg' non-Snakemake parameters
+        # require parsing, which is not possible. They also do
+        # not play any role after submission. Hence, we do:
+        if val.startswith("-"):
+            return None
         if threads_arg:
             args["threads"] = kwargs["threads"]
         try:

--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -523,7 +523,7 @@ def eval_resource_expression(val, threads_arg=True):
         # the form of '--flag=arg' non-Snakemake parameters
         # require parsing, which is not possible. They also do
         # not play any role after submission. Hence, we do:
-        if val.lstrip().startswith('-'):
+        if val.lstrip().startswith("-"):
             return None
         if threads_arg:
             args["threads"] = kwargs["threads"]


### PR DESCRIPTION
### Description

## Description

The issue is caused by the attempt to parse CLI strings like

'--set-resources "<rule>:slurm_extra='--flag=arg'"'

The solution is simply to ignore all values starting with a hyphen.

Will also fix issues #18 and #19 of the SLURM executor plugin.

### QC

The PR should be covered by the tests - unsure why it has not been spotted, so far.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
