### PR TITLE
feat: Allow smart_open 7.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pyyaml
     requests >=2.8.1,<3.0
     reretry
-    smart-open >=3.0,<7.0
+    smart-open >=3.0,<8.0
     snakemake-interface-executor-plugins >=9.0.0,<10.0
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.1.0,<4.0


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

Increases the maximum version bound on `smart_open` to `<8.0` to allow the current `7.x` releases.

https://github.com/piskvorky/smart_open/releases/tag/v7.0.1

The release notes don’t seem to call out any significant breaking changes.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. **Regression-testing should be covered by the existing tests.**
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **I don’t think any documentation changes are needed.**

It’s difficult for me to run the full set of tests offline, so I’m relying on CI to double-check this.