### PR TITLE
feat: allow default storage provider to be explicitly set to none

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -83,6 +83,13 @@ def expandvars(atype):
     return inner
 
 
+def optional_str(arg):
+    if arg is None or arg == "none":
+        return None
+    else:
+        return arg
+
+
 def parse_set_threads(args):
     return parse_set_ints(
         args,
@@ -1369,10 +1376,12 @@ def get_argument_parser(profiles=None):
     )
     group_behavior.add_argument(
         "--default-storage-provider",
+        type=optional_str,
         help="Specify default storage provider to be used for "
         "all input and output files that don't yet specify "
         "one (e.g. 's3'). See https://snakemake.github.io/snakemake-plugin-catalog "
-        "for available storage provider plugins.",
+        "for available storage provider plugins. If not set or explicitly 'none', no "
+        "default storage provider will be used.",
     )
     group_behavior.add_argument(
         "--default-storage-prefix",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1990,7 +1990,7 @@ def test_resource_string_in_cli_or_profile():
     )
 
 
-@skip_on_windows # not platform dependent, only cli
+@skip_on_windows  # not platform dependent, only cli
 def test_default_storage_provider_none():
     run(dpath("test01"), shellcmd="snakemake --default-storage-provider none -c3")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1990,6 +1990,10 @@ def test_resource_string_in_cli_or_profile():
     )
 
 
+def test_default_storage_provider_none():
+    run(dpath("test01"), shellcmd="snakemake --default-storage-provider none -c3")
+
+
 def test_resource_tbdstring():
     test_path = dpath("test_resource_tbdstring")
     results_dir = Path(test_path) / "expected-results"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1990,6 +1990,7 @@ def test_resource_string_in_cli_or_profile():
     )
 
 
+@skip_on_windows # not platform dependent, only cli
 def test_default_storage_provider_none():
     run(dpath("test01"), shellcmd="snakemake --default-storage-provider none -c3")
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
