### PR TITLE
fix: remove default packages from conda envs

### DIFF
--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -271,7 +271,7 @@ with the following `environment definition <https://conda.io/projects/conda/en/l
      - r=3.3.1
      - r-ggplot2=2.1.0
 
-Please note that in the environment definition, conda determines the priority of channels depending on their order of appearance in the channels list. For instance, the channel that comes first in the list gets the highest priority.
+Please note that in the environment definition, conda determines the priority of channels depending on their order of appearance in the channels list. For instance, the channel that comes first in the list gets the highest priority. Default packages defined in the user configuration of conda (`.condarc`)) are ignored by Snakemake.
 
 The path to the environment definition is interpreted as **relative to the Snakefile that contains the rule** (unless it is an absolute path, which is discouraged).
 

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -480,6 +480,7 @@ class Env:
                             "--quiet",
                             "--no-shortcuts" if ON_WINDOWS else "",
                             "--yes",
+                            "--no-default-packages",
                             f"--prefix '{env_path}'",
                         ]
                         + packages
@@ -522,6 +523,7 @@ class Env:
                             + [
                                 "create",
                                 "--quiet",
+                                "--no-default-packages",
                                 f'--file "{target_env_file}"',
                                 f'--prefix "{env_path}"',
                             ]


### PR DESCRIPTION
Fixes #2748.

### Description

Ensure that conda's default packages are not installed by Snakemake.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
