### PR TITLE
fix: ensure that dynamic `resources:` determination can depend on dynamically determined `threads:`

### DIFF
--- a/tests/test_profile/config.yaml
+++ b/tests/test_profile/config.yaml
@@ -8,6 +8,6 @@ default-resources:
   - eggs_factor=twitter
 set-resources:
   a:
-    mem_mb: max(1024*24*input.size_mb * threads, 1)
+    mem_mb: max(1024*24*input.size_mb * threads, 3)
     spam_factor: X
     double_jeopardy: attempt

--- a/tests/test_profile/config.yaml
+++ b/tests/test_profile/config.yaml
@@ -8,6 +8,6 @@ default-resources:
   - eggs_factor=twitter
 set-resources:
   a:
-    mem_mb: max(1024*24*input.size_mb, 1)
+    mem_mb: max(1024*24*input.size_mb * threads, 1)
     spam_factor: X
     double_jeopardy: attempt

--- a/tests/test_profile/expected-results/test.out
+++ b/tests/test_profile/expected-results/test.out
@@ -1,5 +1,5 @@
 threads: 2
-mem_mb: 2
+mem_mb: 3
 eggs_factor: twitter
 spam_factor: X
 double_jeopardy: 1

--- a/tests/test_profile/expected-results/test.out
+++ b/tests/test_profile/expected-results/test.out
@@ -1,5 +1,5 @@
 threads: 2
-mem_mb: 1
+mem_mb: 2
 eggs_factor: twitter
 spam_factor: X
 double_jeopardy: 1


### PR DESCRIPTION
The first step is to include a testcase where `resources: mem_mb=` depend on dynamically determined `threads:`. If the test fails as expected, a fix should be easier to track.

### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
