### PR TITLE
fix: use base64 encoding for passing default resources args to jobs

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -580,7 +580,7 @@ def get_argument_parser(profiles=None):
         "--default-res",
         nargs="*",
         metavar="NAME=INT",
-        parse_func=DefaultResources,
+        parse_func=maybe_base64(DefaultResources),
         help=(
             "Define default values of resources for rules that do not define their own values. "
             "In addition to plain integers, python expressions over inputsize are allowed (e.g. '2*input.size_mb'). "

--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -307,7 +307,13 @@ class SpawnedJobArgsFactory:
         if executor_common_settings.pass_default_storage_provider_args:
             args.append(self.get_default_storage_provider_args())
         if executor_common_settings.pass_default_resources_args:
-            args.append(w2a("resource_settings.default_resources", attr="args"))
+            args.append(
+                w2a(
+                    "resource_settings.default_resources",
+                    attr="args",
+                    base64_encode=True,
+                )
+            )
         if executor_common_settings.pass_group_args:
             args.append(self.get_group_args())
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
