### PR TITLE
fix: failure message in cleanup_metadata

### DIFF
--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -815,7 +815,7 @@ class Workflow(WorkflowExecutorInterface):
         for path in paths:
             success = self.persistence.cleanup_metadata(path)
             if not success:
-                failed.append(path)
+                failed.append(str(path))
         if failed:
             raise WorkflowError(
                 "Failed to clean up metadata for the following files because the metadata was not present.\n"


### PR DESCRIPTION
### Description

`cleanup_metadata()` in `workflow.py` is passed a list of `pathlib.Path` objects. This leads to an error when it ought to raise a WorkflowError on cleanup failing for some paths. Given how the function is written, the `failed` list should consist of strings, rather than `Path` objects, otherwise we get:

```
TypeError: sequence item 0: expected str instance, PosixPath found
```
This seems the be a regression in 8.x. vis-a-vis 7.x. I haven't added any tests since the function seems not to be covered by tests so far.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
