### PR TITLE
fix: do not constrain group jobs by threads when submitting to remote

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1351,6 +1351,9 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
     @property
     def resources(self):
         if self._resources is None:
+            skip_constraints = ["runtime"]
+            if not self.dag.workflow.remote_exec:
+                skip_constraints.append("_cores")
             try:
                 self._resources = GroupResources.basic_layered(
                     toposorted_jobs=self.toposorted,
@@ -1358,6 +1361,7 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
                     run_local=self.dag.workflow.local_exec,
                     additive_resources=["runtime"],
                     sortby=["runtime"],
+                    skip_constraints=skip_constraints,
                 )
             except WorkflowError as err:
                 raise WorkflowError(

--- a/snakemake/resources.py
+++ b/snakemake/resources.py
@@ -153,6 +153,7 @@ class GroupResources:
         run_local,
         additive_resources=None,
         sortby=None,
+        skip_constraints=None,
     ):
         """Basic implementation of group job resources calculation
 
@@ -302,7 +303,7 @@ class GroupResources:
             # For now, we are unable to handle a constraint on runtime, so ignore.
             # Jobs requesting too much runtime will still get flagged by the
             # scheduler
-            for res in additive_resources:
+            for res in skip_constraints:
                 if res in sorted_constraints:
                     sorted_constraints[res] = None
 
@@ -455,7 +456,7 @@ class GroupResources:
         """
 
         # Calculates the ratio of resource to constraint. E.g, if the resource is 12
-        #  cores, and the constraint is 16, it will return 0.75. This is done for
+        # cores, and the constraint is 16, it will return 0.75. This is done for
         # every resource type in the group, returning the result in a list
         def _proportion(group):
             return [r / c if c else 0 for r, c in zip(group, constraints)]

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -995,7 +995,9 @@ class Rule(RuleInterface):
                         "Resources with the same name need to have the same types (int, float, or str are allowed).",
                         rule=self,
                     )
-                if isinstance(res, int):
+                if isinstance(res, int) and (
+                    self.workflow.remote_exec or self.workflow.is_local(self)
+                ):
                     res = min(global_res, res)
             return res
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
