### PR TITLE
remove extra call to setup_logger()

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -523,12 +523,6 @@ class DAGApi(ApiBase):
                 "For local execution, --shared-fs-usage has to be unrestricted."
             )
 
-        self.snakemake_api.setup_logger(
-            stdout=executor_plugin.common_settings.dryrun_exec,
-            mode=self.workflow_api.workflow_settings.exec_mode,
-            dryrun=executor_plugin.common_settings.dryrun_exec,
-        )
-
         if executor_plugin.common_settings.local_exec:
             if (
                 not executor_plugin.common_settings.dryrun_exec


### PR DESCRIPTION
### Description

Removes seemingly extra call to setup_logger() in api, see #2797 for details. 

Still not super familiar with API changes, so @johanneskoester please advise.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
