### PR TITLE
docs: add snakemake and reportplugins to req.txt to show all cli options

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,6 +7,8 @@ configargparse
 appdirs
 immutables
 sphinxawesome-theme
+snakemake
 snakemake-interface-common
 snakemake-interface-executor-plugins
 snakemake-interface-storage-plugins
+snakemake-interface-report-plugins

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ configargparse
 appdirs
 immutables
 sphinxawesome-theme
-snakemake
 snakemake-interface-common
 snakemake-interface-executor-plugins
 snakemake-interface-storage-plugins


### PR DESCRIPTION
### Description

Fixes #2813. `snakemake` and `snakemake-interface-report-plugins` were missing from the req.txt, which are needed to get the argument parser from `snakemake.cli`.

Note: it seems the default report plugin's arguments leak into the docs (see below)
<img width="1018" alt="Screenshot 2024-04-16 at 2 48 53 PM" src="https://github.com/snakemake/snakemake/assets/44762354/ff349a81-0ccc-40d5-99b1-05b959ff1f34">


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
