### PR TITLE
fix: return set instead of list when just --quiet

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1761,7 +1761,7 @@ def parse_args(argv):
 def parse_quietness(quietness) -> Set[Quietness]:
     if quietness is not None and len(quietness) == 0:
         # default case, set quiet to progress and rule
-        quietness = [Quietness.PROGRESS, Quietness.RULES]
+        quietness = {Quietness.PROGRESS, Quietness.RULES}
     else:
         quietness = Quietness.parse_choices_set(quietness)
     return quietness

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -746,7 +746,7 @@ def setup_logger(
             quiet = set()
     elif not isinstance(quiet, set):
         raise ValueError(
-            "Unsupported value provided for quiet mode (either bool, None or list allowed)."
+            "Unsupported value provided for quiet mode (either bool, None or set allowed)."
         )
 
     logger.log_handler.extend(handler)


### PR DESCRIPTION
### Description

Fixes #2825. `parse_quietness` should return a set since that is what `setup_logger()` expects.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
