### PR TITLE
fix: replace pkg_resources for python 3.12

### DIFF
--- a/snakemake/utils.py
+++ b/snakemake/utils.py
@@ -468,10 +468,10 @@ def read_job_properties(
 
 def min_version(version):
     """Require minimum snakemake version, raise workflow error if not met."""
-    import pkg_resources
+    from packaging.version import parse
     from snakemake.common import __version__
 
-    if pkg_resources.parse_version(__version__) < pkg_resources.parse_version(version):
+    if parse(__version__) < parse(version):
         raise WorkflowError(
             "Expecting Snakemake version {} or higher (you are currently using {}).".format(
                 version, __version__


### PR DESCRIPTION
### Description

Follow up to #2312, Python 3.12 also [removed](https://docs.python.org/3.12/whatsnew/3.12.html#removed) bundled `setuptools` (aka `pkg_resources`)

### QC

<!-- Make sure that you can tick the boxes below. -->

- [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
- [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
