### PR TITLE
chore: Update min version requirement for smart-open

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pyyaml
     requests >=2.8.1,<3.0
     reretry
-    smart-open >=3.0,<8.0
+    smart-open >=4.0,<8.0
     snakemake-interface-executor-plugins >=9.1.0,<10.0
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.1.0,<4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pyyaml
     requests >=2.8.1,<3.0
     reretry
-    smart-open >=4.0,<8.0
+    smart-open >=4.0,<8.0 
     snakemake-interface-executor-plugins >=9.1.0,<10.0
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.1.0,<4.0


### PR DESCRIPTION
### Description

Update the minimum version requirement for "smart-open" to ">=4.0". This will prevent #2765 when using smart-open 3. 

I have also made a PR to the bioconda recipe with a similar change. 
https://github.com/bioconda/bioconda-recipes/pull/47374


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
