### PR TITLE
fix: retrieve files from storage if necessary when calling their open method (e.g. when accessing output files from a checkpoint)

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -325,7 +325,10 @@ class _IOFile(str, AnnotatedStringInterface):
         """Open this file.
 
         This can (and should) be used in a `with`-statement.
+        If the file is a remote storage file, retrieve it first if necessary.
         """
+        if self.is_storage and not self.exists_local():
+            async_run(self.retrieve_from_storage())
         f = open(self)
         try:
             yield f


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
