### PR TITLE
use keyword arguments in `_IOFile.open`

### DIFF
--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -329,7 +329,7 @@ class _IOFile(str, AnnotatedStringInterface):
         """
         if self.is_storage and not self.exists_local():
             async_run(self.retrieve_from_storage())
-        f = open(self)
+        f = open(self, mode=mode, buffering=buffering, encoding=encoding, errors=errors, newline=newline)
         try:
             yield f
         finally:


### PR DESCRIPTION
fixes #2846

Previously, keword arguments to `.open` were not actually used leading to unexpected (by me) behaviour. I don't think the documentation needs to change to reflect this, because it's what one would expect in the first place.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
