### PR TITLE
fix: small typo in error

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -209,7 +209,7 @@ class SnakemakeApi(ApiBase):
             raise ApiError(
                 f"Error when applying default storage provider "
                 f"{storage_settings.default_storage_provider} to upload workflow "
-                "sources. {query_validity}"
+                f"sources. {query_validity}"
             )
         storage_object = provider_instance.object(query)
         async_run(storage_object.managed_retrieve())


### PR DESCRIPTION
<!--Add a description of your PR here-->
This is just a small typo fix. 
Working on a fix for https://github.com/snakemake/snakemake-executor-plugin-kubernetes/issues/19 and eventually ended up at the following error when deploying to kubernetes:
```
Error: Error when applying default storage provider gcs to upload workflow sources. {query_validity}
```
Fixing this here so the error is more clear since it looks like kubernetes uses the docker container from main. 
