### PR TITLE
fix: ignore errors when cleaning up runtime cache

### DIFF
--- a/snakemake/sourcecache.py
+++ b/snakemake/sourcecache.py
@@ -353,7 +353,9 @@ class SourceCache:
         if runtime_cache_path is None:
             runtime_cache_parent = self.cache_path / "runtime-cache"
             os.makedirs(runtime_cache_parent, exist_ok=True)
-            self.runtime_cache = tempfile.TemporaryDirectory(dir=runtime_cache_parent)
+            self.runtime_cache = tempfile.TemporaryDirectory(
+                dir=runtime_cache_parent, ignore_cleanup_errors=True
+            )
             self._runtime_cache_path = None
         else:
             self._runtime_cache_path = runtime_cache_path


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
