### PR TITLE
fix: fix quoting issues when passing complex apptainer args to spawned jobs

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1676,6 +1676,7 @@ def get_argument_parser(profiles=None):
         "--singularity-args",
         default="",
         metavar="ARGS",
+        parse_func=maybe_base64(str),
         help="Pass additional args to apptainer/singularity.",
     )
 

--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -275,7 +275,7 @@ class SpawnedJobArgsFactory:
                 skip=not shared_deployment,
             ),
             w2a("deployment_settings.apptainer_prefix"),
-            w2a("deployment_settings.apptainer_args"),
+            w2a("deployment_settings.apptainer_args", base64_encode=True),
             w2a("resource_settings.max_threads"),
             self.get_shared_fs_usage_arg(executor_common_settings),
             w2a(

--- a/tests/common.py
+++ b/tests/common.py
@@ -227,6 +227,7 @@ def run(
     storage_provider_settings=None,
     shared_fs_usage=None,
     benchmark_extended=False,
+    apptainer_args="",
 ):
     """
     Test the Snakefile in the path.
@@ -366,6 +367,7 @@ def run(
                         conda_frontend=conda_frontend,
                         conda_prefix=conda_prefix,
                         deployment_method=deployment_method,
+                        apptainer_args=apptainer_args,
                     ),
                     snakefile=Path(original_snakefile if no_tmpdir else snakefile),
                     workdir=Path(path if no_tmpdir else tmpdir),

--- a/tests/test_singularity/qsub
+++ b/tests/test_singularity/qsub
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo `date` >> qsub.log
+tail -n1 $1 >> qsub.log
+# simulate printing of job id by a random number
+echo $RANDOM
+sh $1

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -762,6 +762,16 @@ def test_singularity():
 
 
 @skip_on_windows
+@connected
+def test_singularity_cluster():
+    run(
+        dpath("test_singularity"),
+        deployment_method={DeploymentMethod.APPTAINER},
+        cluster="./qsub",
+    )
+
+
+@skip_on_windows
 def test_singularity_invalid():
     run(
         dpath("test_singularity"),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -768,6 +768,7 @@ def test_singularity_cluster():
         dpath("test_singularity"),
         deployment_method={DeploymentMethod.APPTAINER},
         cluster="./qsub",
+        apptainer_args="--bind /tmp:/tmp",
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/snakemake/snakemake/issues/2808 and https://github.com/snakemake/snakemake/issues/2872 by using base64 encoding when passing apptainer args to spawned jobs.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
