### PR TITLE
docs: update FAQ - recommend ensure function for failing on empty output

### DIFF
--- a/docs/project_info/faq.rst
+++ b/docs/project_info/faq.rst
@@ -456,14 +456,15 @@ Since bash otherwise automatically removes quotes, you have to also wrap the ent
 How do I make my rule fail if an output file is empty?
 ------------------------------------------------------
 
-Snakemake expects shell commands to behave properly, meaning that failures should cause an exit status other than zero. If a command does not exit with a status other than zero, Snakemake assumes everything worked fine, even if output files are empty. This is because empty output files are also a reasonable tool to indicate progress where no real output was produced. However, sometimes you will have to deal with tools that do not properly report their failure with an exit status. Here, the recommended way is to use bash to check for non-empty output files, e.g.:
+Snakemake expects shell commands to behave properly, meaning that failures should cause an exit status other than zero. If a command does not exit with a status other than zero, Snakemake assumes everything worked fine, even if output files are empty. This is because empty output files are also a reasonable tool to indicate progress where no real output was produced. However, sometimes you will have to deal with tools that do not properly report their failure with an exit status. Here, you can use the :ref:`ensure function <snakefiles_ensure>` to mark output files that should not be empty, e.g.:
 
 .. code-block:: python
-
-    rule:
+    rule NAME:
         input:  ...
-        output: "my/output/file.txt"
-        shell:  "somecommand {input} {output} && [[ -s {output} ]]"
+        output:
+            ensure("test.txt", non_empty=True)
+        shell:
+            "somecommand {input} {output}"
 
 
 How does Snakemake lock the working directory?


### PR DESCRIPTION
<!--Add a description of your PR here-->
Update the FAQ entry 'How do I make my rule fail if an output file is empty?' to point the user to the `ensure(... , non_empty=True)` function documentation.

Please check that the :ref: link (intended to point to https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#ensuring-output-file-properties-like-non-emptyness-or-checksum-compliance) is correct - I'm not familiar enough with sphinx to be 100% confident.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
