### PR TITLE
docs: fix bugs of params in rule bwa_map

### DIFF
--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -52,7 +52,7 @@ We activate benchmarking for the rule ``bwa_map``:
         output:
             temp("mapped_reads/{sample}.bam")
         params:
-            rg="@RG\tID:{sample}\tSM:{sample}"
+            rg="@RG\\tID:{sample}\\tSM:{sample}"
         log:
             "logs/bwa_mem/{sample}.log"
         benchmark:
@@ -180,7 +180,7 @@ For example, the rule ``bwa_map`` could alternatively look like this:
     log:
         "logs/bwa_mem/{sample}.log"
     params:
-        "-R '@RG\tID:{sample}\tSM:{sample}'"
+        "-R '@RG\\tID:{sample}\\tSM:{sample}'"
     threads: 8
     wrapper:
         "0.15.3/bio/bwa/mem"

--- a/docs/tutorial/advanced.rst
+++ b/docs/tutorial/advanced.rst
@@ -185,7 +185,7 @@ We modify the rule ``bwa_map`` accordingly:
         output:
             "mapped_reads/{sample}.bam"
         params:
-            rg=r"@RG\tID:{sample}\tSM:{sample}"
+            rg="@RG\\tID:{sample}\\tSM:{sample}"
         threads: 8
         shell:
             "bwa mem -R '{params.rg}' -t {threads} {input} | samtools view -Sb - > {output}"
@@ -220,7 +220,7 @@ We modify our rule ``bwa_map`` as follows:
         output:
             "mapped_reads/{sample}.bam"
         params:
-            rg=r"@RG\tID:{sample}\tSM:{sample}"
+            rg="@RG\\tID:{sample}\\tSM:{sample}"
         log:
             "logs/bwa_mem/{sample}.log"
         threads: 8
@@ -264,7 +264,7 @@ We use this mechanism for the output file of the rule ``bwa_map``:
         output:
             temp("mapped_reads/{sample}.bam")
         params:
-            rg=r"@RG\tID:{sample}\tSM:{sample}"
+            rg="@RG\\tID:{sample}\\tSM:{sample}"
         log:
             "logs/bwa_mem/{sample}.log"
         threads: 8
@@ -333,7 +333,7 @@ With this, the final version of our workflow in the ``Snakefile`` looks like thi
         output:
             temp("mapped_reads/{sample}.bam")
         params:
-            rg=r"@RG\tID:{sample}\tSM:{sample}"
+            rg="@RG\\tID:{sample}\\tSM:{sample}"
         log:
             "logs/bwa_mem/{sample}.log"
         threads: 8


### PR DESCRIPTION
<!--Add a description of your PR here-->

The exampls of  "Benchmarking" and "Tool wrappers" in additional features tutorial  can't run correctly, the `\t` will be converted in `rg="@RG\tID:{sample}\tSM:{sample}"` and `"-R '@RG\tID:{sample}\tSM:{sample}'"`, I add a `\` to escpe them.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
