### PR TITLE
fix: include more context to syntax errors when rule parsing fails (#2924)

### DIFF
--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -297,12 +297,13 @@ class Rule(RuleInterface):
             self._wildcard_names = wildcard_names
         else:
             if self.wildcard_names != wildcard_names:
-                raise SyntaxError(
+                raise RuleException(
                     "Not all output, log and benchmark files of "
                     "rule {} contain the same wildcards. "
                     "This is crucial though, in order to "
                     "avoid that two or more jobs write to the "
-                    "same file.".format(self.name)
+                    "same file.".format(self.name),
+                    rule=self
                 )
 
     @property
@@ -505,7 +506,7 @@ class Rule(RuleInterface):
                 inoutput._add_name(name)
         elif callable(item):
             if output:
-                raise SyntaxError("Only input files can be specified as functions")
+                raise RuleException("Only input files can be specified as functions", rule=self)
             inoutput.append(item)
             if name:
                 inoutput._add_name(name)
@@ -518,8 +519,9 @@ class Rule(RuleInterface):
                     # if the list was named, make it accessible
                     inoutput._set_name(name, start, end=len(inoutput))
             except TypeError:
-                raise SyntaxError(
-                    "Input and output files have to be specified as strings or lists of strings."
+                raise RuleException(
+                    "Input and output files have to be specified as strings or lists of strings.",
+                    rule=self
                 )
 
     @property
@@ -577,7 +579,7 @@ class Rule(RuleInterface):
                 if name:
                     self.log._set_name(name, start, end=len(self.log))
             except TypeError:
-                raise SyntaxError("Log files have to be specified as strings.")
+                raise RuleException("Log files have to be specified as strings.", rule=self)
 
     def check_wildcards(self, wildcards):
         missing_wildcards = self.wildcard_names - set(wildcards.keys())

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -303,7 +303,7 @@ class Rule(RuleInterface):
                     "This is crucial though, in order to "
                     "avoid that two or more jobs write to the "
                     "same file.".format(self.name),
-                    rule=self
+                    rule=self,
                 )
 
     @property
@@ -506,7 +506,9 @@ class Rule(RuleInterface):
                 inoutput._add_name(name)
         elif callable(item):
             if output:
-                raise RuleException("Only input files can be specified as functions", rule=self)
+                raise RuleException(
+                    "Only input files can be specified as functions", rule=self
+                )
             inoutput.append(item)
             if name:
                 inoutput._add_name(name)
@@ -521,7 +523,7 @@ class Rule(RuleInterface):
             except TypeError:
                 raise RuleException(
                     "Input and output files have to be specified as strings or lists of strings.",
-                    rule=self
+                    rule=self,
                 )
 
     @property
@@ -579,7 +581,9 @@ class Rule(RuleInterface):
                 if name:
                     self.log._set_name(name, start, end=len(self.log))
             except TypeError:
-                raise RuleException("Log files have to be specified as strings.", rule=self)
+                raise RuleException(
+                    "Log files have to be specified as strings.", rule=self
+                )
 
     def check_wildcards(self, wildcards):
         missing_wildcards = self.wildcard_names - set(wildcards.keys())


### PR DESCRIPTION
Updated three errors in rule parsing to throw `RuleException` instead of `SyntaxError` - that way the user feedback includes line numbers to help them identify the source of the error. Fixes issue #2924 

### QC
* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
