### PR TITLE
fix: parse f-string as-is from source

### DIFF
--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -112,20 +112,20 @@ class TokenAutomaton:
         # parsing manner of f-string, see
         # [pep-0701](https://peps.python.org/pep-0701)
         isin_fstring = 1
-        t = token.string
         for t1 in self.snakefile:
             if t1.type == tokenize.FSTRING_START:
                 isin_fstring += 1
-                t += t1.string
             elif t1.type == tokenize.FSTRING_END:
                 isin_fstring -= 1
-                t += t1.string
-            elif t1.type == tokenize.FSTRING_MIDDLE:
-                t += t1.string.replace("{", "{{").replace("}", "}}")
-            else:
-                t += t1.string
             if isin_fstring == 0:
                 break
+        with open(self.snakefile.path) as fi:
+            for i, line in zip(range(token.start[0]), fi):
+                pass
+            s = line[token.start[1] :]
+            for i, line in zip(range(t1.end[0] - token.start[0]), fi):
+                s += line
+            t = s[: t1.end[1] - len(t1.line)]
         if hasattr(self, "cmd") and self.cmd[-1][1] == token:
             self.cmd[-1] = t, token
         return t
@@ -540,9 +540,11 @@ class Run(RuleKeywordState):
             "singularity_args, use_singularity, env_modules, bench_record, jobid, "
             "is_shell, bench_iteration, cleanup_scripts, shadow_dir, edit_notebook, "
             "conda_base_path, basedir, sourcecache_path, runtime_sourcecache_path, {rule_func_marker}=True):".format(
-                rulename=self.rulename
-                if self.rulename is not None
-                else self.snakefile.rulecount,
+                rulename=(
+                    self.rulename
+                    if self.rulename is not None
+                    else self.snakefile.rulecount
+                ),
                 rule_func_marker=common.RULEFUNC_CONTEXT_MARKER,
             )
         )

--- a/snakemake/parser.py
+++ b/snakemake/parser.py
@@ -119,7 +119,7 @@ class TokenAutomaton:
                 isin_fstring -= 1
             if isin_fstring == 0:
                 break
-        with open(self.snakefile.path) as fi:
+        with self.snakefile.sourcecache.open(self.snakefile._path) as fi:
             for i, line in zip(range(token.start[0]), fi):
                 pass
             s = line[token.start[1] :]
@@ -1261,11 +1261,16 @@ class Snakefile:
         workflow: "workflow.Workflow",
         rulecount=0,
     ):
-        self.path = path.get_path_or_uri()
-        self.file = workflow.sourcecache.open(path)
+        self._path = path
+        self.sourcecache = workflow.sourcecache
+        self.file = self.sourcecache.open(path)
         self.tokens = tokenize.generate_tokens(self.file.readline)
         self.rulecount = rulecount
         self.lines = 0
+
+    @property
+    def path(self):
+        return self._path.get_path_or_uri()
 
     def __next__(self):
         return next(self.tokens)

--- a/tests/test_fstring/Snakefile
+++ b/tests/test_fstring/Snakefile
@@ -51,3 +51,9 @@ assert f"FORMAT['{PREFIX}']['{{}}']" == "FORMAT['SID23454678']['{}']"
 assert f"FORMAT['{PREFIX}'][}}'{{'{{]" == "FORMAT['SID23454678'][}'{'{]"
 
 assert f"works in new version: {[(x, y) for x in [1,2,3] for y in [3,1,4]]}" == "works in new version: [(1, 3), (1, 1), (1, 4), (2, 3), (2, 1), (2, 4), (3, 3), (3, 1), (3, 4)]"
+
+
+part_one = "foo"
+an_fstring = f'{part_one}/{"bar" if True else "baz"}'
+another_fstring = f"{part_one.replace('foo', 'bar')}/{{escaped}}"
+multiple_parts_fstring = f"no_replacement_" "regular_string_" f"{'bar' if True else 'baz'}"

--- a/tests/test_fstring/Snakefile
+++ b/tests/test_fstring/Snakefile
@@ -49,3 +49,5 @@ hello, snakemake
 
 assert f"FORMAT['{PREFIX}']['{{}}']" == "FORMAT['SID23454678']['{}']"
 assert f"FORMAT['{PREFIX}'][}}'{{'{{]" == "FORMAT['SID23454678'][}'{'{]"
+
+assert f"works in new version: {[(x, y) for x in [1,2,3] for y in [3,1,4]]}" == "works in new version: [(1, 3), (1, 1), (1, 4), (2, 3), (2, 1), (2, 4), (3, 3), (3, 1), (3, 4)]"


### PR DESCRIPTION
<!--Add a description of your PR here-->

This is another (and hopefully the last) fix for f-string change in python3.12.

Now everthing inner f-string are ignored, and only care about where f-string start and end, and read it from snakefile as-is.

will fix #2881 and fix #2657
related PR: #2864, #2649

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
