### PR TITLE
fix: use wrapt_timeout_decorator, instead of stopit 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ install_requires =
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
     snakemake-interface-report-plugins >=1.0.0,<2.0.0
-    timeout_decorator
     tabulate
     throttler
     toposort >=1.10,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
     snakemake-interface-report-plugins >=1.0.0,<2.0.0
-    stopit
+    async-timeout
     tabulate
     throttler
     toposort >=1.10,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
     snakemake-interface-report-plugins >=1.0.0,<2.0.0
-    wrapt_timeout_decorator
+    timeout_decorator
     tabulate
     throttler
     toposort >=1.10,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
     snakemake-interface-report-plugins >=1.0.0,<2.0.0
-    async-timeout
+    wrapt_timeout_decorator
     tabulate
     throttler
     toposort >=1.10,<2.0

--- a/snakemake/path_modifier.py
+++ b/snakemake/path_modifier.py
@@ -35,9 +35,6 @@ class PathModifier:
 
     def modify(self, path, property=None):
         if get_flag_value(path, PATH_MODIFIER_FLAG):
-            logger.debug(
-                f"Not modifying path of file {path}, as it has already been modified"
-            )
             # Path has been modified before and is reused now, no need to modify again.
             return path
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -266,7 +266,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
 
                     logger.debug(f"Resources before job selection: {self.resources}")
                     logger.debug(
-                        f"Jobs ready ({len(needrun)})",
+                        f"Ready jobs ({len(needrun)})",
                         # + "\n\t".join(map(str, needrun))
                     )
 
@@ -623,6 +623,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
             logger.debug("Falling back to greedy solver.")
             return self.job_selector_greedy(jobs)
 
+        [logger.debug(f"{job}: {variable.value()}") for job, variable in scheduled_jobs.items()]
         selected_jobs = set(
             job
             for job, variable in scheduled_jobs.items()

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -492,7 +492,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         """
         import pulp
         from pulp import lpSum
-        from async_timeout import timeout, TimeoutError
+        from wrapt_timeout_decorator import timeout, TimeoutError
 
         if len(jobs) == 1:
             logger.debug(
@@ -612,12 +612,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 )
 
         try:
-
-            async def _solve_ilp_timeout(self, prob: pulp.LpProblem, secs: int) -> None:
-                async with timeout(secs):
-                    await self._solve_ilp(prob)
-
-            async_run(self._solve_ilp_timeout(prob, 10))
+            self._solve_ilp(prob)
         except TimeoutError:
             logger.warning(
                 "Failed to solve scheduling problem with ILP solver in time (10s). "
@@ -645,6 +640,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         self.update_available_resources(selected_jobs)
         return selected_jobs
 
+    @timeout(10)
     def _solve_ilp(self, prob):
         import pulp
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -641,7 +641,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
 
     from timeout_decorator import timeout
 
-    @timeout(10, timeout_exception=TimeoutError)
+    @timeout(10, use_signals=False, timeout_exception=TimeoutError)
     def _solve_ilp(self, prob):
         import pulp
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -258,6 +258,13 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 if self.dryrun:
                     run = needrun
                 else:
+                    # Subsample jobs to be run (to speedup solver)
+                    n_total_needrun = len(needrun)
+                    solver_max_jobs = int(os.environ.get("SNAKEMAKE_SOLVER_MAX_JOBS", 1000))
+                    if n_total_needrun > solver_max_jobs:
+                        import random
+                        needrun = set(random.sample(tuple(needrun), k=solver_max_jobs))
+
                     # Reset params and resources because they might still contain TBDs
                     # or old values from before files have been regenerated.
                     # Now, they can be recalculated as all input is present and up to date.
@@ -266,7 +273,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
 
                     logger.debug(f"Resources before job selection: {self.resources}")
                     logger.debug(
-                        f"Ready jobs ({len(needrun)})"
+                        f"Ready jobs ({len(needrun)} out of {n_total_needrun})"
                         # + "\n\t".join(map(str, needrun))
                     )
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -623,7 +623,6 @@ class JobScheduler(JobSchedulerExecutorInterface):
             logger.debug("Falling back to greedy solver.")
             return self.job_selector_greedy(jobs)
 
-        [logger.debug(f"{job}: {variable.value()}") for job, variable in scheduled_jobs.items()]
         selected_jobs = set(
             job
             for job, variable in scheduled_jobs.items()

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -260,9 +260,12 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 else:
                     # Subsample jobs to be run (to speedup solver)
                     n_total_needrun = len(needrun)
-                    solver_max_jobs = int(os.environ.get("SNAKEMAKE_SOLVER_MAX_JOBS", 1000))
+                    solver_max_jobs = int(
+                        os.environ.get("SNAKEMAKE_SOLVER_MAX_JOBS", 1000)
+                    )
                     if n_total_needrun > solver_max_jobs:
                         import random
+
                         needrun = set(random.sample(tuple(needrun), k=solver_max_jobs))
 
                     # Reset params and resources because they might still contain TBDs

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -640,6 +640,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         return selected_jobs
 
     from wrapt_timeout_decorator import timeout
+
     @timeout(10)
     def _solve_ilp(self, prob):
         import pulp

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -612,8 +612,10 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 )
 
         try:
-            async with timeout(10):
-                await self._solve_ilp(prob)
+            async def _solve_ilp_timeout(self, prob, secs):
+                async with timeout(secs):
+                    await self._solve_ilp(prob)
+            async_run(self._solve_ilp_timeout(prob, 10))
         except TimeoutError as e:
             logger.warning(
                 "Failed to solve scheduling problem with ILP solver in time (10s). "

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -613,7 +613,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
 
         try:
 
-            async def _solve_ilp_timeout(self, prob, secs):
+            async def _solve_ilp_timeout(self, prob: pulp.LpProblem, secs: int) -> None:
                 async with timeout(secs):
                     await self._solve_ilp(prob)
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -493,9 +493,11 @@ class JobScheduler(JobSchedulerExecutorInterface):
         import pulp
         from pulp import lpSum
 
+        logger.debug("Selecting jobs to run using ILP solver.")
+
         if len(jobs) == 1:
             logger.debug(
-                "Using greedy selector because only single job has to be scheduled."
+                "Switching to greedy selector because only one job has to be scheduled."
             )
             return self.job_selector_greedy(jobs)
 
@@ -674,6 +676,8 @@ class JobScheduler(JobSchedulerExecutorInterface):
         Args:
             jobs (list):    list of jobs
         """
+        logger.debug("Selecting jobs to run using greedy solver.")
+
         with self._lock:
             if not self.resources["_cores"]:
                 return set()

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -614,7 +614,9 @@ class JobScheduler(JobSchedulerExecutorInterface):
         logger.debug(f"Problem is {pulp.LpStatus[status]}")
         if pulp.LpStatus[status] != "Optimal":
             if pulp.LpStatus[status] == "Not Solved":
-                logger.warning("Failed to solve scheduling problem with ILP solver in time (10s).")
+                logger.warning(
+                    "Failed to solve scheduling problem with ILP solver in time (10s)."
+                )
             elif pulp.LpStatus[status] == "Infeasible":
                 logger.warning("Failed to solve scheduling problem with ILP solver.")
 

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -621,7 +621,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         except TimeoutError:
             logger.warning(
                 "Failed to solve scheduling problem with ILP solver in time (10s). "
-                "Falling back to greedy solver."
+                "Falling back to greedy solver.",
             )
             return self.job_selector_greedy(jobs)
         except pulp.apis.core.PulpSolverError:

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -612,9 +612,11 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 )
 
         try:
+
             async def _solve_ilp_timeout(self, prob, secs):
                 async with timeout(secs):
                     await self._solve_ilp(prob)
+
             async_run(self._solve_ilp_timeout(prob, 10))
         except TimeoutError:
             logger.warning(

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -492,7 +492,6 @@ class JobScheduler(JobSchedulerExecutorInterface):
         """
         import pulp
         from pulp import lpSum
-        from wrapt_timeout_decorator import timeout, TimeoutError
 
         if len(jobs) == 1:
             logger.debug(
@@ -640,6 +639,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         self.update_available_resources(selected_jobs)
         return selected_jobs
 
+    from wrapt_timeout_decorator import timeout
     @timeout(10)
     def _solve_ilp(self, prob):
         import pulp

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -616,13 +616,13 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 async with timeout(secs):
                     await self._solve_ilp(prob)
             async_run(self._solve_ilp_timeout(prob, 10))
-        except TimeoutError as e:
+        except TimeoutError:
             logger.warning(
                 "Failed to solve scheduling problem with ILP solver in time (10s). "
                 "Falling back to greedy solver."
             )
             return self.job_selector_greedy(jobs)
-        except pulp.apis.core.PulpSolverError as e:
+        except pulp.apis.core.PulpSolverError:
             logger.warning(
                 "Failed to solve scheduling problem with ILP solver. Falling back to greedy solver. "
                 "Run Snakemake with --verbose to see the full solver output for debugging the problem."

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -68,4 +68,4 @@ dependencies:
       - snakemake-storage-plugin-http
       - snakemake-storage-plugin-s3
       - snakemake-storage-plugin-fs >=1.0.3
-      - wrapt_timeout_decorator
+      - timeout_decorator

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - mamba
   - yte
   - packaging
-  - async-timeout
+  - wrapt_timeout_decorator
   - datrie
   - boto3
   - httpretty

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -68,4 +68,3 @@ dependencies:
       - snakemake-storage-plugin-http
       - snakemake-storage-plugin-s3
       - snakemake-storage-plugin-fs >=1.0.3
-      - timeout_decorator

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - mamba
   - yte
   - packaging
-  - stopit
+  - async-timeout
   - datrie
   - boto3
   - httpretty

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - mamba
   - yte
   - packaging
-  - wrapt_timeout_decorator
   - datrie
   - boto3
   - httpretty
@@ -69,3 +68,4 @@ dependencies:
       - snakemake-storage-plugin-http
       - snakemake-storage-plugin-s3
       - snakemake-storage-plugin-fs >=1.0.3
+      - wrapt_timeout_decorator


### PR DESCRIPTION
<!--Add a description of your PR here-->

There are some issues of the solver stalling (or not behaving as expected) when running very large DAGs (e.g. #871, #1003, #1374, #1620, #2354).

To minimize those issues, I was wondering if it would make sense for the solver/scheduler to evaluate just a subset (randomly sampled) of the jobs waiting to run.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced job scheduling with improved timeout handling using asynchronous programming for better performance and responsiveness.
- **Chores**
	- Updated project dependencies, replacing `stopit` with `timeout_decorator` to support modern asynchronous handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->