### PR TITLE
fix: ensure that envvars in local storage prefix are not prematurely expanded by the shell

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1419,7 +1419,7 @@ def get_argument_parser(profiles=None):
     group_behavior.add_argument(
         "--local-storage-prefix",
         default=".snakemake/storage",
-        type=expandvars(Path),
+        type=maybe_base64(expandvars(Path)),
         help="Specify prefix for storing local copies of storage files and folders. "
         "By default, this is a hidden subfolder in the workdir. It can however be "
         "freely chosen, e.g. in order to store those files on a local scratch disk. "
@@ -1427,7 +1427,7 @@ def get_argument_parser(profiles=None):
     )
     group_behavior.add_argument(
         "--remote-job-local-storage-prefix",
-        type=expandvars(Path),
+        type=maybe_base64(expandvars(Path)),
         help="Specify prefix for storing local copies of storage files and folders in "
         "case of remote jobs (e.g. cluster or cloud jobs). This may differ from "
         "--local-storage-prefix. If not set, uses value of --local-storage-prefix. "

--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -240,13 +240,16 @@ class SpawnedJobArgsFactory:
             in self.workflow.storage_settings.shared_fs_usage
         )
 
+        # base64 encode the prefix to ensure that eventually unexpanded env vars
+        # are not replaced with values (or become empty if missing) by the shell
         local_storage_prefix = (
             w2a(
                 "storage_settings.remote_job_local_storage_prefix",
                 flag="--local-storage-prefix",
+                base64_encode=True,
             )
             if executor_common_settings.non_local_exec
-            else w2a("storage_settings.local_storage_prefix")
+            else w2a("storage_settings.local_storage_prefix", base64_encode=True)
         )
 
         args = [


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
