### PR TITLE
tests: fix broken tests due to breaking changes in dependencies

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pysftp
   - requests
   - responses
-  - numpy
+  - numpy < 2
   - appdirs
   - pytools
   - docutils

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -59,6 +59,7 @@ dependencies:
   - nodejs # for cwltool
   - immutables
   - conda
+  - cryptography <43 # See GitHub issue 2988
   - pip
   - pip:
       - cwltool


### PR DESCRIPTION
<!--Add a description of your PR here-->
String representation of scalars changed in numpy 2 (https://numpy.org/doc/stable/release/2.0.0-notes.html#representation-of-numpy-scalars-changed), which causes tests to fail. This PR fixes the numpy version in the tests to the last pre-2.0 version for now in order for other PRs to be able to continue.
At a later stage the tests should probably be updated to work on more recent verions of numpy or contain explicit formatting.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
