### PR TITLE
Bulk, cached DAG update for multiple finished cluster jobs

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1621,24 +1621,26 @@ class DAG(DAGExecutorInterface):
         """Finish a given job (e.g. remove from ready jobs, mark depending jobs
         as ready)."""
 
-        self._running.remove(job)
+        jobs = []
+        for job_ in job:
+            self._running.remove(job_)
 
-        # turn off this job's Reason
-        if job.is_group():
-            for j in job:
-                self.reason(j).mark_finished()
-        else:
-            self.reason(job).mark_finished()
+            # turn off this job's Reason
+            if job_.is_group():
+                for j in job_:
+                     self.reason(j).mark_finished()
+            else:
+                self.reason(job_).mark_finished()
 
-        try:
-            self._ready_jobs.remove(job)
-        except KeyError:
-            pass
+            try:
+                self._ready_jobs.remove(job_)
+            except KeyError:
+                pass
 
-        if job.is_group():
-            jobs = job
-        else:
-            jobs = [job]
+            if job_.is_group():
+                jobs.extend(job_)
+            else:
+                jobs.append(job_)
 
         self._finished.update(jobs)
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1435,7 +1435,14 @@ class DAG(DAGExecutorInterface):
         if update_needrun:
             self.update_container_imgs()
             self.update_conda_envs()
-            self.update_needrun()
+            try:
+                self.workflow.iocache.active = True
+                self.workflow.persistence.activate_cache()
+                self.update_needrun()
+            finally:
+                self.workflow.iocache.deactivate()
+                self.workflow.persistence.deactivate_cache()
+
         self.update_priority()
         self.handle_pipes_and_services()
         self.update_groups()

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -623,6 +623,8 @@ class Persistence(PersistenceExecutorInterface):
         self._read_record = self._read_record_uncached
         self._incomplete_cache = False
 
+    def activate_cache(self):
+        self._read_record = self._read_record_cached
 
 def _bool_or_gen(func, job, file=None):
     if file is None:

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -703,10 +703,11 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 value = self.calc_resource(name, value)
                 self.resources[name] += value
 
-    def _proceed(self, job):
+    def _proceed(self, job, release=True):
         """Do stuff after job is finished."""
         with self._lock:
-            self._tofinish.append(job)
+            if job is not None:
+                self._tofinish.append(job)
 
             if self.dryrun:
                 if len(self.running) - len(self._tofinish) - len(self._toerror) <= 0:
@@ -716,7 +717,8 @@ class JobScheduler(JobSchedulerExecutorInterface):
                     self._open_jobs.release()
             else:
                 # go on scheduling if there is any free core
-                self._open_jobs.release()
+                if release:
+                    self._open_jobs.release()
 
     def _error(self, job):
         with self._lock:

--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -669,7 +669,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
                     logger.job_finished(jobid=job.jobid)
                 self.progress()
 
-            self.dag.finish(job, update_dynamic=self.update_dynamic)
+        self.dag.finish(self._tofinish, update_dynamic=self.update_dynamic)
         self._tofinish.clear()
 
     def _error_jobs(self):


### PR DESCRIPTION
I've been having performance issues with 7.32.4 where the checkpoint update in the DAG becomes a bottleneck and I cannot even supply a single cluster node with jobs. This patch series ameliorates the problem for me by

a) Enabling the persistence cache and the iocache for the duration of one `dag.postprocess()` pass 
b) Allowing the scheduler to process multiple finished jobs at once

I'm seeing a performance improvement >60 fold (i.e. I'm once again submitting faster than the cluster can work the jobs). 

The rationale for a) is that changing state of `mtime`, `file_exists` or metadata during the course of a `update_needrun()` DAG update is probably a recipe for disaster anyway. By enabling the cache exactly for one pass, then clearing it, we get a consistent state and avoid the multiple reads of metadata files (up to 5 times if all triggers are enabled) and repeated calls to `stat()`. I've conservatively limited the caching to the scope of one `update_needrun()` call from `postprocess()` to avoid side effects, which seems to work, but I can't claim I understand all the code that might be affected.

The implementation for b) was surprisingly simple as most of the capability is already there. This merely makes it so that the scan of active jobs in the `GenericClusterExecutor` doesn't release the `_open_jobs` semaphore for each job immediately, but waits to do this at the end of a full scan of the active jobs. Since the DAG can already handle multiple jobs at once as required by the group-job feature, only minor changes where needed there to make it so a large number of completed jobs can be addressed with one DAG update and thus one scan of the time stamps and metadata.

Caveats: 
- This only implements the change for `GenericClusterExecutor`
- It's a patch against the series-7. I checked the 8 only briefly, but it looks like this may at least conceptually be applicable there as well. 
- I've not written any unit tests because I'm not even sure whether you accept patches for series-7/
- I'm also not sure how much of my degradation issue is really caused by a different problem. I'm not sure why it's scanning all those files with every job finish (>100,000 stat calls for me). This works for me though.

Related issues:
#2967  #2969


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
