### PR TITLE
feat: allow wildcards in captions of files marked for report inclusion

### DIFF
--- a/snakemake/report/__init__.py
+++ b/snakemake/report/__init__.py
@@ -552,13 +552,14 @@ async def auto_report(
                         name=report_obj.subcategory, wildcards=wildcards, job=job
                     )
                     labels = expand_labels(report_obj.labels, wildcards, job)
+                    caption = expand_report_argument(report_obj.caption, wildcards, job)
 
                     results[category][subcategory].append(
                         FileRecord(
                             path=Path(f),
                             job=job,
                             category=category,
-                            raw_caption=report_obj.caption,
+                            raw_caption=caption,
                             wildcards_overwrite=wildcards_overwrite,
                             aux_files=aux_files,
                             name_overwrite=name_overwrite,

--- a/tests/test_report/Snakefile
+++ b/tests/test_report/Snakefile
@@ -7,7 +7,7 @@ shell.executable("bash")
 
 rule all:
     input:
-        ["fig1.svg", "testmodel.fig2.png", "test.csv", "testdir"],
+        ["fig1.svg", "fig2.svg", "testmodel.fig2.png", "test.csv", "testdir"],
 
 
 rule c:
@@ -28,10 +28,10 @@ rule a:
         expand("test.{i}.out", i=range(10)),
     output:
         report(
-            "fig1.svg",
-            caption="report/fig1.rst",
+            "{fig}.svg",
+            caption="report/{fig}.rst",
             category="Step 1",
-            labels=lambda w, params: {"type": "figure", "num": "1"},
+            labels=lambda w, params: {"type": "figure", "num": "{fig}"},
         ),
     shell:
         "sleep `shuf -i 1-3 -n 1`; cp data/fig1.svg {output}"


### PR DESCRIPTION
This tries to address #235, by parsing wildcards in the `caption=` argument of `report()` calls on files that should be included in the report.

Note: In this first commit, the test has to fail, as I have not yet updated the `expected_output`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced report caption processing for dynamic and context-relevant strings.
	- Improved workflow flexibility with the addition of a new input file (`fig2.svg`) and dynamic output file naming using placeholders.

- **Bug Fixes**
	- Updated labels and output specifications in workflow rules for better metadata management and adaptability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->