### PR TITLE
docs: recommending raw strings to get rid of syntax warnings

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -106,7 +106,7 @@ Hence wildcards can be constrained to given regular expressions.
 Here we could restrict the wildcard ``dataset`` to consist of digits only using ``\d+`` as the corresponding regular expression.
 With Snakemake 3.8.0, there are three ways to constrain wildcards.
 First, a wildcard can be constrained within the file pattern, by appending a regular expression separated by a comma 
-(you might want to use the `r` prefix for a raw string to suppress syntax issues, particularly for more complex regular expressions):
+(you might want to use the `r` prefix for a raw string to avoid having to escape backslashes, particularly for more complex regular expressions):
 
 .. code-block:: python
 

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -105,11 +105,12 @@ It is not clear whether ``dataset=101.B`` and ``group=normal`` or ``dataset=101`
 Hence wildcards can be constrained to given regular expressions.
 Here we could restrict the wildcard ``dataset`` to consist of digits only using ``\d+`` as the corresponding regular expression.
 With Snakemake 3.8.0, there are three ways to constrain wildcards.
-First, a wildcard can be constrained within the file pattern, by appending a regular expression separated by a comma:
+First, a wildcard can be constrained within the file pattern, by appending a regular expression separated by a comma 
+(you might want to use the `r` prefix for a raw string to suppress syntax issues, particularly for more complex regular expressions):
 
 .. code-block:: python
 
-    output: "{dataset,\d+}.{group}.txt"
+    output: r"{dataset,\d+}.{group}.txt"
 
 Second, a wildcard can be constrained within the rule via the keyword ``wildcard_constraints``:
 


### PR DESCRIPTION
The PR updates docs/snakefiles/rules.rst - I recommend using raw strings for regexes in wildcards.

The PR only affects two lines in the documentation. No further tests are needed. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated documentation for Snakemake to clarify the use of the `r` prefix in regular expressions for output patterns, enhancing user understanding and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->