### PR TITLE
fix: download report assets upon package build such that reports become possible offline (cont. of #2904)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dist/
 tests/test*/*
 playground/*
 tutorial/*
+
+snakemake/assets/data

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 
 [options]
 zip_safe = False
-include_package_data = False
+include_package_data = True
 packages = find:
 python_requires = >=3.11
 install_requires =
@@ -63,58 +63,7 @@ install_requires =
     yte >=1.5.1,<2.0
     dpath >=2.1.6,<3.0.0
     conda-inject >=1.3.1,<2.0
-setup_requires = setuptools-download >= 1.1.0
 
-[setuptools_download]
-download_data_files =
-    [share/snakemake/assets/snakemake/LICENSE.md]
-    url = https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md
-    sha256 = 84a1a82b05c80637744d3fe8257235c15380efa6cc32608adf4b21f17af5d2b8
-    [share/snakemake/assets/pygments/LICENSE]
-    url = https://raw.githubusercontent.com/pygments/pygments/master/LICENSE
-    sha256 = a9d66f1d526df02e29dce73436d34e56e8632f46c275bbdffc70569e882f9f17
-    [share/snakemake/assets/tailwindcss/LICENSE]
-    url = https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/LICENSE
-    sha256 = 60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985
-    [share/snakemake/assets/tailwindcss/tailwind.css]
-    url = https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2
-    sha256 = 8a597dc918fb62e05db23a5f810327a045a62c57cfda16646075138a6ac696fa
-    [share/snakemake/assets/react/LICENSE]
-    url = https://raw.githubusercontent.com/facebook/react/main/LICENSE
-    sha256 = da6d3703ed11cbe42bd212c725957c98da23cbff1998c05fa4b3d976d1a58e93
-    [share/snakemake/assets/react/react.production.min.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js
-    sha256 = 4b4969fa4ef3594324da2c6d78ce8766fbbc2fd121fff395aedf997db0a99a06
-    [share/snakemake/assets/react/react-dom.production.min.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js
-    sha256 = 21758ed084cd0e37e735722ee4f3957ea960628a29dfa6c3ce1a1d47a2d6e4f7
-    [share/snakemake/assets/vega/vega.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/vega/5.21.0/vega.js
-    sha256 = b34c43055ef5d39a093e937522955dc359fbaec6c5b0259ae2de4c9da698e9fe
-    [share/snakemake/assets/vega/LICENSE]
-    url = https://raw.githubusercontent.com/vega/vega/main/LICENSE
-    sha256 = 63727832aaf62004a2b249c933e327f3c90caf49e41a72f4bf436edf632cbda8
-    [share/snakemake/assets/vega-lite/vega-lite.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.js
-    sha256 = 6eb7f93121cd9f44cf8640244f87c5e143f87c7a0b6cd113da4a9e41e3adf0aa
-    [share/snakemake/assets/vega-lite/LICENSE]
-    url = https://raw.githubusercontent.com/vega/vega-lite/next/LICENSE
-    sha256 = f618900fd0d64046963b29f40590cdd1e341a2f41449f99110d82fd81fea808c
-    [share/snakemake/assets/vega-embed/vega-embed.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.js
-    sha256 = 4e546c1f86eb200333606440e92f76e2940b905757018d9672cd1708e4e6ff0a
-    [share/snakemake/assets/vega-embed/LICENSE]
-    url = https://raw.githubusercontent.com/vega/vega-embed/next/LICENSE
-    sha256 = 32df67148f0fc3db0eb9e263a7b75d07f1eb14c61955005a4a39c6918d10d137
-    [share/snakemake/assets/heroicons/LICENSE]
-    url = https://raw.githubusercontent.com/tailwindlabs/heroicons/master/LICENSE
-    sha256 = 60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985
-    [share/snakemake/assets/prop-types/prop-types.min.js]
-    url = https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.7.2/prop-types.min.js
-    sha256 = 4c88350517ee82aa4f3368e67ef1a453ca6636dcfa6449b4e3d6faa5c877066e
-    [share/snakemake/assets/prop-types/LICENSE]
-    url = https://raw.githubusercontent.com/facebook/prop-types/main/LICENSE
-    sha256 = f657f99d3fb9647db92628e96007aabb46e5f04f33e49999075aab8e250ca7ce
 [options.extras_require]
 messaging = slack_sdk
 pep =

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     pyyaml
     requests >=2.8.1,<3.0
     reretry
-    smart-open >=4.0,<8.0 
+    smart-open >=4.0,<8.0
     snakemake-interface-executor-plugins >=9.2.0,<10.0
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
@@ -63,7 +63,58 @@ install_requires =
     yte >=1.5.1,<2.0
     dpath >=2.1.6,<3.0.0
     conda-inject >=1.3.1,<2.0
+setup_requires = setuptools-download >= 1.1.0
 
+[setuptools_download]
+download_data_files =
+    [share/snakemake/assets/snakemake/LICENSE.md]
+    url = https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md
+    sha256 = 84a1a82b05c80637744d3fe8257235c15380efa6cc32608adf4b21f17af5d2b8
+    [share/snakemake/assets/pygments/LICENSE]
+    url = https://raw.githubusercontent.com/pygments/pygments/master/LICENSE
+    sha256 = a9d66f1d526df02e29dce73436d34e56e8632f46c275bbdffc70569e882f9f17
+    [share/snakemake/assets/tailwindcss/LICENSE]
+    url = https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/LICENSE
+    sha256 = 60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985
+    [share/snakemake/assets/tailwindcss/tailwind.css]
+    url = https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2
+    sha256 = 8a597dc918fb62e05db23a5f810327a045a62c57cfda16646075138a6ac696fa
+    [share/snakemake/assets/react/LICENSE]
+    url = https://raw.githubusercontent.com/facebook/react/main/LICENSE
+    sha256 = da6d3703ed11cbe42bd212c725957c98da23cbff1998c05fa4b3d976d1a58e93
+    [share/snakemake/assets/react/react.production.min.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js
+    sha256 = 4b4969fa4ef3594324da2c6d78ce8766fbbc2fd121fff395aedf997db0a99a06
+    [share/snakemake/assets/react/react-dom.production.min.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js
+    sha256 = 21758ed084cd0e37e735722ee4f3957ea960628a29dfa6c3ce1a1d47a2d6e4f7
+    [share/snakemake/assets/vega/vega.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/vega/5.21.0/vega.js
+    sha256 = b34c43055ef5d39a093e937522955dc359fbaec6c5b0259ae2de4c9da698e9fe
+    [share/snakemake/assets/vega/LICENSE]
+    url = https://raw.githubusercontent.com/vega/vega/main/LICENSE
+    sha256 = 63727832aaf62004a2b249c933e327f3c90caf49e41a72f4bf436edf632cbda8
+    [share/snakemake/assets/vega-lite/vega-lite.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.js
+    sha256 = 6eb7f93121cd9f44cf8640244f87c5e143f87c7a0b6cd113da4a9e41e3adf0aa
+    [share/snakemake/assets/vega-lite/LICENSE]
+    url = https://raw.githubusercontent.com/vega/vega-lite/next/LICENSE
+    sha256 = f618900fd0d64046963b29f40590cdd1e341a2f41449f99110d82fd81fea808c
+    [share/snakemake/assets/vega-embed/vega-embed.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.js
+    sha256 = 4e546c1f86eb200333606440e92f76e2940b905757018d9672cd1708e4e6ff0a
+    [share/snakemake/assets/vega-embed/LICENSE]
+    url = https://raw.githubusercontent.com/vega/vega-embed/next/LICENSE
+    sha256 = 32df67148f0fc3db0eb9e263a7b75d07f1eb14c61955005a4a39c6918d10d137
+    [share/snakemake/assets/heroicons/LICENSE]
+    url = https://raw.githubusercontent.com/tailwindlabs/heroicons/master/LICENSE
+    sha256 = 60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985
+    [share/snakemake/assets/prop-types/prop-types.min.js]
+    url = https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.7.2/prop-types.min.js
+    sha256 = 4c88350517ee82aa4f3368e67ef1a453ca6636dcfa6449b4e3d6faa5c877066e
+    [share/snakemake/assets/prop-types/LICENSE]
+    url = https://raw.githubusercontent.com/facebook/prop-types/main/LICENSE
+    sha256 = f657f99d3fb9647db92628e96007aabb46e5f04f33e49999075aab8e250ca7ce
 [options.extras_require]
 messaging = slack_sdk
 pep =

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ from setuptools import setup
 # when pip uses PEP 517/518 build rules.
 # https://github.com/python-versioneer/python-versioneer/issues/193
 
-
-sys.path.append(str(Path(__file__).parent))
+source_dir = Path(__file__).parent
+sys.path.append(str(source_dir))
 import versioneer  # noqa: E402
 
 # import Assets, while avoiding that the rest of snakemake is imported here before
 # setup has been called.
-sys.path.append(str(Path(__file__).parent / "snakemake"))
+sys.path.append(str(source_dir / "snakemake"))
 from assets import Assets
 
 # download online assets

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,14 @@ from setuptools import setup
 sys.path.append(os.path.dirname(__file__))
 
 import versioneer  # noqa: E402
+from snakemake.assets import Assets
 
+# download online assets
+Assets.deploy()
 
 setup(
     name="snakemake",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
+    package_data={"snakemake": ["assets/data/**/*"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import sys
 
 from setuptools import setup
@@ -6,10 +7,15 @@ from setuptools import setup
 # ensure the current directory is on sys.path so versioneer can be imported
 # when pip uses PEP 517/518 build rules.
 # https://github.com/python-versioneer/python-versioneer/issues/193
-sys.path.append(os.path.dirname(__file__))
 
+
+sys.path.append(str(Path(__file__).parent))
 import versioneer  # noqa: E402
-from snakemake.assets import Assets
+
+# import Assets, while avoiding that the rest of snakemake is imported here before
+# setup has been called.
+sys.path.append(str(Path(__file__).parent / "snakemake"))
+from assets import Assets
 
 # download online assets
 Assets.deploy()

--- a/snakemake/__init__.py
+++ b/snakemake/__init__.py
@@ -4,7 +4,13 @@ __email__ = "johannes.koester@protonmail.com"
 __license__ = "MIT"
 
 import sys
-from snakemake.common import __version__, PIP_DEPLOYMENTS_PATH
+
+from snakemake._version import get_versions
+
+__version__ = get_versions()["version"]
+del get_versions
+
+PIP_DEPLOYMENTS_PATH = ".snakemake/pip-deployments"
 
 sys.path.append(PIP_DEPLOYMENTS_PATH)
 

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+import hashlib
+from pathlib import Path
+import shutil
+import importlib.resources
+
+import requests
+
+from snakemake.logging import logger
+
+
+@dataclass
+class Asset:
+    url: str
+    sha256: str
+
+    def get_content(self) -> bytes:
+        """Get and validate asset content."""
+        content = requests.get(self.url).content
+        if self.sha256 != hashlib.sha256(content).hexdigest():
+            raise ValueError(f"Checksum mismatch when downloading asset {self.url}")
+        return content
+
+
+class Assets:
+    base_path = importlib.resources.files("snakemake.assets") / "data"
+    spec = {
+        "snakemake/LICENSE.md": Asset(
+            url="https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md",
+            sha256="84a1a82b05c80637744d3fe8257235c15380efa6cc32608adf4b21f17af5d2b8",
+        ),
+        "pygments/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/pygments/pygments/master/LICENSE",
+            sha256="a9d66f1d526df02e29dce73436d34e56e8632f46c275bbdffc70569e882f9f17",
+        ),
+        "tailwindcss/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/LICENSE",
+            sha256="60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985",
+        ),
+        "tailwindcss/tailwind.css": Asset(
+            url="https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2",
+            sha256="8a597dc918fb62e05db23a5f810327a045a62c57cfda16646075138a6ac696fa",
+        ),
+        "react/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/facebook/react/main/LICENSE",
+            sha256="da6d3703ed11cbe42bd212c725957c98da23cbff1998c05fa4b3d976d1a58e93",
+        ),
+        "react/react.production.min.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js",
+            sha256="4b4969fa4ef3594324da2c6d78ce8766fbbc2fd121fff395aedf997db0a99a06",
+        ),
+        "react/react-dom.production.min.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js",
+            sha256="21758ed084cd0e37e735722ee4f3957ea960628a29dfa6c3ce1a1d47a2d6e4f7",
+        ),
+        "vega/vega.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/vega/5.21.0/vega.js",
+            sha256="b34c43055ef5d39a093e937522955dc359fbaec6c5b0259ae2de4c9da698e9fe",
+        ),
+        "vega/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/vega/vega/main/LICENSE",
+            sha256="63727832aaf62004a2b249c933e327f3c90caf49e41a72f4bf436edf632cbda8",
+        ),
+        "vega-lite/vega-lite.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.js",
+            sha256="6eb7f93121cd9f44cf8640244f87c5e143f87c7a0b6cd113da4a9e41e3adf0aa",
+        ),
+        "vega-lite/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/vega/vega-lite/next/LICENSE",
+            sha256="f618900fd0d64046963b29f40590cdd1e341a2f41449f99110d82fd81fea808c",
+        ),
+        "vega-embed/vega-embed.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.js",
+            sha256="4e546c1f86eb200333606440e92f76e2940b905757018d9672cd1708e4e6ff0a",
+        ),
+        "vega-embed/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/vega/vega-embed/next/LICENSE",
+            sha256="32df67148f0fc3db0eb9e263a7b75d07f1eb14c61955005a4a39c6918d10d137",
+        ),
+        "heroicons/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/tailwindlabs/heroicons/master/LICENSE",
+            sha256="60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985",
+        ),
+        "prop-types/prop-types.min.js": Asset(
+            url="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.7.2/prop-types.min.js",
+            sha256="4c88350517ee82aa4f3368e67ef1a453ca6636dcfa6449b4e3d6faa5c877066e",
+        ),
+        "prop-types/LICENSE": Asset(
+            url="https://raw.githubusercontent.com/facebook/prop-types/main/LICENSE",
+            sha256="f657f99d3fb9647db92628e96007aabb46e5f04f33e49999075aab8e250ca7ce",
+        ),
+    }
+
+    @classmethod
+    def deploy(cls) -> None:
+        for asset_path, asset in cls.spec.items():
+            target_path = cls.base_path / asset_path
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(target_path, "wb") as fout:
+                fout.write(asset.get_content())
+
+    @classmethod
+    def get_content(cls, asset_path: str) -> str:
+        try:
+            return (cls.base_path / asset_path).read_text()
+        except FileNotFoundError:
+            logger.warning(
+                f"Asset {asset_path} not found (development setup?), downloading..."
+            )
+            return cls.spec[asset_path].get_content().decode()

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -103,6 +103,8 @@ class Assets:
 
     @classmethod
     def deploy(cls) -> None:
+        # this has to work from setup.py without being able to load the snakemake
+        # modules.
         base_path = Path(__file__).parent / "data"
         for asset_path, asset in cls.spec.items():
             target_path = base_path / asset_path
@@ -113,7 +115,7 @@ class Assets:
     @classmethod
     def get_content(cls, asset_path: str) -> str:
         try:
-            return (cls.base_path / asset_path).read_text()
+            return (cls.base_path() / asset_path).read_text()
         except FileNotFoundError:
             from snakemake.logging import logger
 
@@ -124,6 +126,7 @@ class Assets:
 
     @classmethod
     def base_path(cls) -> Path:
+        # this is called from within snakemake, so we can use importlib.resources
         if cls._base_path is None:
             cls._base_path = importlib.resources.files("snakemake.assets") / "data"
         return cls._base_path

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import hashlib
 import importlib.resources
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 import urllib.request
 import urllib.error
 
@@ -33,7 +33,7 @@ class Asset:
 
 
 class Assets:
-    base_path: Path = importlib.resources.files("snakemake.assets") / "data"
+    _base_path: Optional[Path] = None
     spec: Dict[str, Asset] = {
         "snakemake/LICENSE.md": Asset(
             url="https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md",
@@ -103,8 +103,9 @@ class Assets:
 
     @classmethod
     def deploy(cls) -> None:
+        base_path = Path(__file__).parent / "data"
         for asset_path, asset in cls.spec.items():
-            target_path = cls.base_path / asset_path
+            target_path = base_path / asset_path
             target_path.parent.mkdir(parents=True, exist_ok=True)
             with open(target_path, "wb") as fout:
                 fout.write(asset.get_content())
@@ -120,3 +121,9 @@ class Assets:
                 f"Asset {asset_path} not found (development setup?), downloading..."
             )
             return cls.spec[asset_path].get_content().decode()
+
+    @classmethod
+    def base_path(cls) -> Path:
+        if cls._base_path is None:
+            cls._base_path = importlib.resources.files("snakemake.assets") / "data"
+        return cls._base_path

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -1,12 +1,8 @@
 from dataclasses import dataclass
 import hashlib
-from pathlib import Path
-import shutil
 import importlib.resources
 
 import requests
-
-from snakemake.logging import logger
 
 
 @dataclass
@@ -104,6 +100,7 @@ class Assets:
         try:
             return (cls.base_path / asset_path).read_text()
         except FileNotFoundError:
+            from snakemake.logging import logger
             logger.warning(
                 f"Asset {asset_path} not found (development setup?), downloading..."
             )

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -3,8 +3,12 @@ import hashlib
 import importlib.resources
 from pathlib import Path
 from typing import Dict
+import urllib.request
+import urllib.error
 
-import requests
+
+class AssetDownloadError(Exception):
+    pass
 
 
 @dataclass
@@ -14,14 +18,17 @@ class Asset:
 
     def get_content(self) -> bytes:
         """Get and validate asset content."""
+
+        req = urllib.request.Request(self.url, headers={"User-Agent": "snakemake"})
         try:
-            response = requests.get(self.url)
-            response.raise_for_status()
-            content = response.content
-        except requests.RequestException as e:
-            raise ValueError(f"Failed to download asset {self.url}: {e}")
+            resp = urllib.request.urlopen(req)
+            content = resp.read()
+        except urllib.error.URLError as e:
+            raise AssetDownloadError(f"Failed to download asset {self.url}: {e}")
         if self.sha256 != hashlib.sha256(content).hexdigest():
-            raise ValueError(f"Checksum mismatch when downloading asset {self.url}")
+            raise AssetDownloadError(
+                f"Checksum mismatch when downloading asset {self.url}"
+            )
         return content
 
 

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 import hashlib
 import importlib.resources
+from pathlib import Path
+from typing import Dict
 
 import requests
 
@@ -19,8 +21,8 @@ class Asset:
 
 
 class Assets:
-    base_path = importlib.resources.files("snakemake.assets") / "data"
-    spec = {
+    base_path: Path = importlib.resources.files("snakemake.assets") / "data"
+    spec: Dict[str, Asset] = {
         "snakemake/LICENSE.md": Asset(
             url="https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md",
             sha256="84a1a82b05c80637744d3fe8257235c15380efa6cc32608adf4b21f17af5d2b8",
@@ -101,6 +103,7 @@ class Assets:
             return (cls.base_path / asset_path).read_text()
         except FileNotFoundError:
             from snakemake.logging import logger
+
             logger.warning(
                 f"Asset {asset_path} not found (development setup?), downloading..."
             )

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -115,14 +115,14 @@ class Assets:
     @classmethod
     def get_content(cls, asset_path: str) -> str:
         try:
-            return (cls.base_path() / asset_path).read_text()
+            return (cls.base_path() / asset_path).read_text(encoding="utf-8")
         except FileNotFoundError:
             from snakemake.logging import logger
 
             logger.warning(
                 f"Asset {asset_path} not found (development setup?), downloading..."
             )
-            return cls.spec[asset_path].get_content().decode()
+            return cls.spec[asset_path].get_content().decode("utf-8")
 
     @classmethod
     def base_path(cls) -> Path:

--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -17,12 +17,8 @@ import asyncio
 import collections
 from pathlib import Path
 
-from snakemake._version import get_versions
-
+from snakemake import __version__
 from snakemake_interface_common.exceptions import WorkflowError
-
-__version__ = get_versions()["version"]
-del get_versions
 
 
 MIN_PY_VERSION = (3, 7)
@@ -46,7 +42,6 @@ SNAKEFILE_CHOICES = list(
         ),
     )
 )
-PIP_DEPLOYMENTS_PATH = ".snakemake/pip-deployments"
 
 
 def get_snakemake_searchpaths():

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -76,7 +76,7 @@ class Package:
     def __init__(
         self, version=None, license_path=None, source_path=None, **source_paths
     ):
-        def read_source(path: Path):
+        def read_source(path: Path) -> str:
             with path.open() as file:
                 return file.read()
 

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 from snakemake.exceptions import WorkflowError
-from snakemake.report.html_reporter.common import get_resource_as_string
 import snakemake
 import sys
 import os

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from snakemake.exceptions import WorkflowError
 import snakemake
 import sys

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -2,7 +2,8 @@ import json
 from pathlib import Path
 from snakemake.exceptions import WorkflowError
 import snakemake
-import sys
+
+from snakemake.assets import Assets
 
 
 def get_packages():
@@ -74,20 +75,14 @@ class Package:
     def __init__(
         self, version=None, license_path=None, source_path=None, **source_paths
     ):
-        def read_source(path: Path) -> str:
-            with path.open() as file:
-                return file.read()
-
         self.version = version
-        asset_prefix = Path(sys.prefix) / "share" / "snakemake" / "assets"
 
-        self.license = read_source(asset_prefix / license_path)
+        self.license = Assets.get_content(license_path)
         if source_path is not None:
-            self.source = read_source(asset_prefix / source_path)
+            self.source = Assets.get_content(source_path)
         else:
             self.sources = {
-                name: read_source(asset_prefix / path)
-                for name, path in source_paths.items()
+                name: Assets.get_content(path) for name, path in source_paths.items()
             }
 
     def get_record(self):

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -1,6 +1,4 @@
 import json
-from pathlib import Path
-from snakemake.exceptions import WorkflowError
 import snakemake
 
 from snakemake.assets import AssetDownloadError, Assets

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from snakemake.exceptions import WorkflowError
 import snakemake
 import sys

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from snakemake.exceptions import WorkflowError
 import snakemake
 import sys
-import os
 
 
 def get_packages():

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -3,7 +3,8 @@ from pathlib import Path
 from snakemake.exceptions import WorkflowError
 import snakemake
 
-from snakemake.assets import Assets
+from snakemake.assets import AssetDownloadError, Assets
+from snakemake_interface_common.exceptions import WorkflowError
 
 
 def get_packages():
@@ -77,13 +78,17 @@ class Package:
     ):
         self.version = version
 
-        self.license = Assets.get_content(license_path)
-        if source_path is not None:
-            self.source = Assets.get_content(source_path)
-        else:
-            self.sources = {
-                name: Assets.get_content(path) for name, path in source_paths.items()
-            }
+        try:
+            self.license = Assets.get_content(license_path)
+            if source_path is not None:
+                self.source = Assets.get_content(source_path)
+            else:
+                self.sources = {
+                    name: Assets.get_content(path)
+                    for name, path in source_paths.items()
+                }
+        except AssetDownloadError as e:
+            raise WorkflowError(e)
 
     def get_record(self):
         return {"version": self.version, "license": self.license}

--- a/snakemake/report/html_reporter/data/packages.py
+++ b/snakemake/report/html_reporter/data/packages.py
@@ -1,7 +1,10 @@
 import json
+from pathlib import Path
 from snakemake.exceptions import WorkflowError
 from snakemake.report.html_reporter.common import get_resource_as_string
 import snakemake
+import sys
+import os
 
 
 def get_packages():
@@ -12,50 +15,45 @@ def get_packages():
             "Python package pygments must be installed to create reports."
         )
 
+    # packages declared here must be downloaded to the prefix share/snakemake/assets
+    # via setuptools_download in setup.cfg
     return Packages(
         {
             "snakemake": Package(
                 version=snakemake.__version__.split("+")[0],
-                license_url="https://raw.githubusercontent.com/snakemake/snakemake/main/LICENSE.md",
+                license_path="snakemake/LICENSE.md",
             ),
             "pygments": Package(
                 version=pygments.__version__,
-                license_url="https://raw.githubusercontent.com/pygments/pygments/master/LICENSE",
+                license_path="pygments/LICENSE",
             ),
             "tailwindcss": Package(
-                version="3.0",
-                license_url="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/master/LICENSE",
-                url="https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2",
+                license_path="tailwindcss/LICENSE",
+                source_path="tailwindcss/tailwind.css",
             ),
             "react": Package(
-                version="18",
-                license_url="https://raw.githubusercontent.com/facebook/react/main/LICENSE",
-                main="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js",
-                dom="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js",
+                license_path="react/LICENSE",
+                main="react/react.production.min.js",
+                dom="react/react-dom.production.min.js",
             ),
             "vega": Package(
-                version="5.21",
-                url="https://cdnjs.cloudflare.com/ajax/libs/vega/5.21.0/vega.js",
-                license_url="https://raw.githubusercontent.com/vega/vega/main/LICENSE",
+                source_path="vega/vega.js",
+                license_path="vega/LICENSE",
             ),
             "vega-lite": Package(
-                version="5.2",
-                url="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/5.2.0/vega-lite.js",
-                license_url="https://raw.githubusercontent.com/vega/vega-lite/next/LICENSE",
+                source_path="vega-lite/vega-lite.js",
+                license_path="vega-lite/LICENSE",
             ),
             "vega-embed": Package(
-                version="6.20",
-                url="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/6.20.8/vega-embed.js",
-                license_url="https://raw.githubusercontent.com/vega/vega-embed/next/LICENSE",
+                source_path="vega-embed/vega-embed.js",
+                license_path="vega-embed/LICENSE",
             ),
             "heroicons": Package(
-                version="1.0.6",
-                license_url="https://raw.githubusercontent.com/tailwindlabs/heroicons/master/LICENSE",
+                license_path="heroicons/LICENSE",
             ),
             "prop-types": Package(
-                version="15.7.2",
-                url="https://cdnjs.cloudflare.com/ajax/libs/prop-types/15.7.2/prop-types.min.js",
-                license_url="https://raw.githubusercontent.com/facebook/prop-types/main/LICENSE",
+                source_path="prop-types/prop-types.min.js",
+                license_path="prop-types/LICENSE",
             ),
         }
     )
@@ -75,13 +73,24 @@ class Packages:
 
 
 class Package:
-    def __init__(self, version=None, license_url=None, url=None, **urls):
+    def __init__(
+        self, version=None, license_path=None, source_path=None, **source_paths
+    ):
+        def read_source(path: Path):
+            with path.open() as file:
+                return file.read()
+
         self.version = version
-        self.license = get_resource_as_string(license_url)
-        if url is not None:
-            self.url = url
+        asset_prefix = Path(sys.prefix) / "share" / "snakemake" / "assets"
+
+        self.license = read_source(asset_prefix / license_path)
+        if source_path is not None:
+            self.source = read_source(asset_prefix / source_path)
         else:
-            self.urls = urls
+            self.sources = {
+                name: read_source(asset_prefix / path)
+                for name, path in source_paths.items()
+            }
 
     def get_record(self):
         return {"version": self.version, "license": self.license}

--- a/snakemake/report/html_reporter/template/index.html.jinja2
+++ b/snakemake/report/html_reporter/template/index.html.jinja2
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <title>Snakemake Report</title>
 
-    <script>{{ packages["tailwindcss"].url|get_resource_as_string }}</script>
+    <script>{{ packages["tailwindcss"].source }}</script>
     <style>{{ pygments_css|safe }}</style>
     <style>{{ "style.css"|get_resource_as_string }}</style>
 
@@ -31,12 +31,12 @@
     <div id="app">
     </div>
 
-    <script>{{packages["react"].urls["main"]|get_resource_as_string}}</script>
-    <script>{{packages["react"].urls["dom"]|get_resource_as_string}}</script>
-    <script>{{packages["prop-types"].url|get_resource_as_string}}</script>
-    <script>{{packages["vega"].url|get_resource_as_string}}</script>
-    <script>{{packages["vega-lite"].url|get_resource_as_string}}</script>
-    <script>{{packages["vega-embed"].url|get_resource_as_string}}</script>
+    <script>{{packages["react"].sources["main"]}}</script>
+    <script>{{packages["react"].sources["dom"]}}</script>
+    <script>{{packages["prop-types"].source}}</script>
+    <script>{{packages["vega"].source}}</script>
+    <script>{{packages["vega-lite"].source}}</script>
+    <script>{{packages["vega-embed"].source}}</script>
 
     <script id="workflow-desc">
     var workflow_desc = {{workflow_desc}};


### PR DESCRIPTION
The original PR has been reverted in main because it does not seem to work will with developer installation mode (assets are not installed in the right place in that case).

cc @fs82 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced structured asset management within the Snakemake framework, allowing for better handling and deployment of external resources.

- **Improvements**
  - Enhanced package metadata handling for improved maintainability and accessibility of license and source files.
  - Enabled the inclusion of additional package data during installation, ensuring necessary files are available.

- **Bug Fixes**
  - Improved reliability by transitioning to local paths for resource referencing, enhancing accessibility and reducing dependency on external URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->