### PR TITLE
docs: Add 'Editor integrations' section to Installation page

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -23,9 +23,9 @@ because it also enables Snakemake to :ref:`handle software dependencies of your
 workflow <integrated_package_management>`.
 
 First, you need to install a Conda-based Python3 distribution.
-The recommended choice is Miniforge_ which not only provides the required Python and Conda commands, 
+The recommended choice is Miniforge_ which not only provides the required Python and Conda commands,
 but also includes Mamba_ an extremely fast and robust replacement for the Conda_ package manager which is highly recommended.
-The default conda solver is a bit slow and sometimes has issues with `selecting the latest package releases <https://github.com/conda/conda/issues/9905>`_. 
+The default conda solver is a bit slow and sometimes has issues with `selecting the latest package releases <https://github.com/conda/conda/issues/9905>`_.
 Therefore, we recommend to in any case use Mamba_.
 
 In case you don't use Miniforge_ you can always install Mamba_ into any other Conda-based Python distribution with
@@ -86,3 +86,11 @@ If you want to quickly try out an unreleased version from the snakemake reposito
 
 You can also install the current state of another branch or the repository state at a particular commit.
 For information on the syntax for this, see `the pip documentation on git support <https://pip.pypa.io/en/stable/topics/vcs-support/#git>`_.
+
+
+Editor integrations
+===================
+
+* `VSCode <https://github.com/snakemake/snakemake-lang-vscode-plugin>`_
+* `Vim <https://github.com/snakemake/snakemake/tree/main/misc/vim>`_
+* `Zed <https://github.com/lvignoli/zed-snakemake>`_


### PR DESCRIPTION
The [Zed editor](https://github.com/zed-industries/zed) now has a [snakemake extension](https://github.com/lvignoli/zed-snakemake).
There was no dedicated place in the docs to link to it, so I added an editor integration section to the installation page, it seemed the best place.

It lacks some prose, I was unsure of what maintainers would like to have in this section.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the installation guide for Mamba with clearer instructions and recommendations.
	- Added a new section on "Editor integrations," providing links to plugins for Snakemake to enhance user workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->