### PR TITLE
fix: return empty set if rate limiter at max

### DIFF
--- a/snakemake/scheduler.py
+++ b/snakemake/scheduler.py
@@ -479,6 +479,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         n_free_jobs = self.job_rate_limiter.get_free_jobs()
         if n_free_jobs == 0:
             logger.info("Job rate limit reached, waiting for free slots.")
+            return set()
         else:
             self.resources["_job_count"] = n_free_jobs
             selected = self._job_selector(jobs)


### PR DESCRIPTION
<!--Add a description of your PR here-->

When running locally with a rate limiter, if rate limiter reaches the max number of jobs `job_selector` function returns `None` and snakemake fails on line:

https://github.com/snakemake/snakemake/blob/f9554786e9d7f81c0195e0d9ab3c22b7fe611799/snakemake/scheduler.py#L278-L281

with error:
```
TypeError: object of type 'NoneType' has no len()
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved job selection logic to ensure an empty set is returned when no free jobs are available, enhancing system reliability and preventing unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->