### PR TITLE
fix: pip deployment path

### DIFF
--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -8,7 +8,7 @@ from snakemake_interface_executor_plugins.settings import CommonSettings
 from snakemake.resources import ParsedResource
 from snakemake_interface_storage_plugins.registry import StoragePluginRegistry
 
-from snakemake import common
+from snakemake import PIP_DEPLOYMENTS_PATH
 from snakemake.io import get_flag_value, is_flagged
 from snakemake.settings.types import SharedFSUsage
 
@@ -205,7 +205,7 @@ class SpawnedJobArgsFactory:
                 self.workflow.storage_settings.default_storage_provider
             )
             precommand.append(
-                f"pip install --target '{common.PIP_DEPLOYMENTS_PATH}' {package_name}"
+                f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {package_name}"
             )
 
         if (


### PR DESCRIPTION
<!--Add a description of your PR here-->

 - Fixes pip deployment import path in spawn_jobs.py because PIP_DEPLOYMENT_PATH was moved to snakemake/__init__.py in #3056

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified import statements for better clarity in the deployment path reference.
	- Improved readability of the code without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->