### PR TITLE
fix: Inconsistent Linting Output Formatting

### DIFF
--- a/snakemake/linting/__init__.py
+++ b/snakemake/linting/__init__.py
@@ -71,12 +71,16 @@ class Lint:
         self.body = body
         self.links = links or []
 
-    def __str__(self):
+    def __str__(self) -> str:
         width, _ = shutil.get_terminal_size()
-        return "{}:\n{}\n      Also see:\n{}".format(
+        output = "{}:\n{}".format(
             self.title,
             "\n".join(
                 map("      {}".format, textwrap.wrap(self.body, max(width - 6, 20)))
             ),
-            "\n".join(map("      {}".format, self.links)),
         )
+        if self.links:
+            output += "\n      Also see:\n{}".format(
+                "\n".join(map("      {}".format, self.links))
+            )
+        return output


### PR DESCRIPTION
While writing a parser for the output of `snakemake --lint`, I noticed that the output formatting is not always consistent. The hints usually end in `Also see:\n<topical link>\n`, however, for some, there are no links to be displayed, and then they end in `Also see:\n\n`.
This can be confusing to read depending on the context and it complicates parsing the linter output by adding stray newlines.

I fixed this by removing `Also see:\n` from the output if there are no links to display.

### QC
<!-- Make sure that you can tick the boxes below. -->
No changes to tests and docs, let me know if you deem this necessary.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved string representation for better clarity and readability in output.
	- Conditional display of links in the output format to avoid unnecessary blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->