### PR TITLE
fix: avoid downloading if assets are provided

### DIFF
--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -119,8 +119,9 @@ class Assets:
         for asset_path, asset in cls.spec.items():
             target_path = base_path / asset_path
             target_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(target_path, "wb") as fout:
-                fout.write(asset.get_content())
+            if not target_path.exists():
+                with open(target_path, "wb") as fout:
+                    fout.write(asset.get_content())
 
     @classmethod
     def get_content(cls, asset_path: str) -> str:


### PR DESCRIPTION
The `Assets.deploy()` is invoked unconditionally by the setup.py, which forces download, even if files already present (e.g. in the source tarball). Those downloads are unnecessary and fail in sandboxed builds.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the deployment process to prevent accidental overwrites of existing files by introducing a conditional check before writing asset content.

- **Bug Fixes**
	- Improved safety and integrity of the deployment process through updated logic in the asset writing method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->