### PR TITLE
feat: allow skipping apptainer and conda tests if not available

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -69,6 +69,16 @@ def has_zenodo_token():
     return os.environ.get("ZENODO_SANDBOX_PAT")
 
 
+def has_apptainer():
+    return (shutil.which("apptainer") is not None) or (
+        shutil.which("singularity") is not None
+    )
+
+
+def has_conda():
+    return shutil.which("conda") is not None
+
+
 gcloud = pytest.mark.skipif(
     not is_connected() or not has_gcloud_service_key(),
     reason="Skipping GCLOUD tests because not on "
@@ -86,6 +96,17 @@ connected = pytest.mark.skipif(not is_connected(), reason="no internet connectio
 
 ci = pytest.mark.skipif(not is_ci(), reason="not in CI")
 not_ci = pytest.mark.skipif(is_ci(), reason="skipped in CI")
+
+apptainer = pytest.mark.skipif(
+    not has_apptainer(),
+    reason="Skipping Apptainer tests because no "
+    "apptainer/singularity executable available.",
+)
+
+conda = pytest.mark.skipif(
+    not has_conda(),
+    reason="Skipping Conda tests because no conda executable available.",
+)
 
 zenodo = pytest.mark.skipif(
     not has_zenodo_token(), reason="no ZENODO_SANDBOX_PAT provided"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,7 +18,7 @@ from snakemake.shell import shell
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from .common import run, dpath, connected
+from .common import run, dpath, apptainer, conda, connected
 from .conftest import skip_on_windows, only_on_windows, ON_WINDOWS, needs_strace
 
 from snakemake_interface_executor_plugins.settings import (
@@ -383,6 +383,7 @@ def test_empty_include():
 
 
 @skip_on_windows
+@conda
 def test_script():
     run(
         dpath("test_script"),
@@ -466,10 +467,12 @@ def test_protected_symlink_output():
     run(dpath("test_protected_symlink_output"))
 
 
+@conda
 def test_conda():
     run(dpath("test_conda"), deployment_method={DeploymentMethod.CONDA})
 
 
+@conda
 def test_conda_list_envs():
     run(dpath("test_conda"), conda_list_envs=True, check_results=False)
 
@@ -495,6 +498,7 @@ def test_conda_create_envs_only():
     shutil.rmtree(tmpdir)
 
 
+@conda
 def test_upstream_conda():
     run(
         dpath("test_conda"),
@@ -504,11 +508,13 @@ def test_upstream_conda():
 
 
 @skip_on_windows
+@conda
 def test_deploy_script():
     run(dpath("test_deploy_script"), deployment_method={DeploymentMethod.CONDA})
 
 
 @skip_on_windows
+@conda
 def test_deploy_hashing():
     tmpdir = run(
         dpath("test_deploy_hashing"),
@@ -518,6 +524,7 @@ def test_deploy_hashing():
     assert len(next(os.walk(os.path.join(tmpdir, ".snakemake/conda")))[1]) == 2
 
 
+@conda
 def test_conda_custom_prefix():
     run(
         dpath("test_conda_custom_prefix"),
@@ -528,6 +535,7 @@ def test_conda_custom_prefix():
 
 
 @only_on_windows
+@conda
 def test_conda_cmd_exe():
     # Tests the conda environment activation when cmd.exe
     # is used as the shell
@@ -535,11 +543,13 @@ def test_conda_cmd_exe():
 
 
 @skip_on_windows  # wrappers are for linux and macos only
+@conda
 def test_wrapper():
     run(dpath("test_wrapper"), deployment_method={DeploymentMethod.CONDA})
 
 
 @skip_on_windows  # wrappers are for linux and macos only
+@conda
 def test_wrapper_local_git_prefix():
     import git
 
@@ -754,12 +764,14 @@ def test_profile():
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_singularity():
     run(dpath("test_singularity"), deployment_method={DeploymentMethod.APPTAINER})
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_singularity_cluster():
     run(
@@ -771,6 +783,7 @@ def test_singularity_cluster():
 
 
 @skip_on_windows
+@apptainer
 def test_singularity_invalid():
     run(
         dpath("test_singularity"),
@@ -781,6 +794,7 @@ def test_singularity_invalid():
 
 
 @skip_on_windows
+@apptainer
 def test_singularity_module_invalid():
     run(
         dpath("test_singularity_module"),
@@ -791,7 +805,9 @@ def test_singularity_module_invalid():
 
 
 @skip_on_windows
+@apptainer
 @connected
+@conda
 def test_singularity_conda():
     run(
         dpath("test_singularity_conda"),
@@ -801,12 +817,14 @@ def test_singularity_conda():
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_singularity_none():
     run(dpath("test_singularity_none"), deployment_method={DeploymentMethod.APPTAINER})
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_singularity_global():
     run(
@@ -826,6 +844,7 @@ def test_inoutput_is_path():
     run(dpath("test_inoutput_is_path"))
 
 
+@conda
 def test_archive():
     run(dpath("test_archive"), archive="workflow-archive.tar.gz")
 
@@ -835,6 +854,7 @@ def test_log_input():
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_cwl_singularity():
     run(dpath("test_cwl"), deployment_method={DeploymentMethod.APPTAINER})
@@ -1219,6 +1239,7 @@ def test_issue930():
 
 
 @skip_on_windows
+@conda
 def test_issue635():
     run(
         dpath("test_issue635"),
@@ -1268,6 +1289,7 @@ def test_issue1092():
 
 
 @skip_on_windows
+@conda
 def test_issue1093():
     run(dpath("test_issue1093"), deployment_method={DeploymentMethod.CONDA})
 
@@ -1285,6 +1307,7 @@ def test_issue1085():
 
 
 @skip_on_windows
+@apptainer
 def test_issue1083():
     run(dpath("test_issue1083"), deployment_method={DeploymentMethod.APPTAINER})
 
@@ -1376,6 +1399,7 @@ def test_github_issue52():
 
 
 @skip_on_windows
+@apptainer
 def test_github_issue78():
     run(dpath("test_github_issue78"), deployment_method={DeploymentMethod.APPTAINER})
 
@@ -1457,6 +1481,7 @@ def test_env_modules():
 
 
 @skip_on_windows
+@apptainer
 @connected
 def test_container():
     run(dpath("test_container"), deployment_method={DeploymentMethod.APPTAINER})
@@ -1473,10 +1498,12 @@ def test_string_resources():
     )
 
 
+@conda
 def test_jupyter_notebook():
     run(dpath("test_jupyter_notebook"), deployment_method={DeploymentMethod.CONDA})
 
 
+@conda
 def test_jupyter_notebook_draft():
     from snakemake.settings.types import NotebookEditMode
 
@@ -1540,6 +1567,8 @@ def test_github_issue806():
 
 
 @skip_on_windows
+@apptainer
+@conda
 def test_containerized():
     run(
         dpath("test_containerized"),
@@ -1593,6 +1622,7 @@ def test_modules_specific():
 
 
 @skip_on_windows  # works in principle but the test framework modifies the target path separator
+@connected
 def test_modules_meta_wrapper():
     run(
         dpath("test_modules_meta_wrapper"),
@@ -1605,10 +1635,12 @@ def test_use_rule_same_module():
     run(dpath("test_use_rule_same_module"), targets=["test.out", "test2.out"])
 
 
+@connected
 def test_module_complex():
     run(dpath("test_module_complex"), executor="dryrun")
 
 
+@connected
 def test_module_complex2():
     run(dpath("test_module_complex2"), executor="dryrun")
 
@@ -1629,6 +1661,7 @@ def test_modules_prefix_local():
     )
 
 
+@connected
 def test_module_with_script():
     run(dpath("test_module_with_script"))
 
@@ -1638,6 +1671,7 @@ def test_module_worfklow_namespacing():
 
 
 @skip_on_windows  # No conda-forge version of pygraphviz for windows
+@connected
 def test_module_report():
     run(
         dpath("test_module_report"),
@@ -1704,6 +1738,7 @@ def test_github_issue1158():
     run(dpath("test_github_issue1158"), cluster="./qsub.py")
 
 
+@conda
 def test_converting_path_for_r_script():
     run(
         dpath("test_converting_path_for_r_script"),
@@ -1734,11 +1769,13 @@ def test_issue1331():
 
 
 @skip_on_windows
+@conda
 def test_conda_named():
     run(dpath("test_conda_named"), deployment_method={DeploymentMethod.CONDA})
 
 
 @skip_on_windows
+@conda
 def test_conda_function():
     run(
         dpath("test_conda_function"),
@@ -1904,6 +1941,7 @@ def test_module_input_func():
 
 
 @skip_on_windows  # the testcase only has a linux-64 pin file
+@conda
 def test_conda_pin_file():
     run(dpath("test_conda_pin_file"), deployment_method={DeploymentMethod.CONDA})
 
@@ -1913,10 +1951,12 @@ def test_github_issue1618():
     run(dpath("test_github_issue1618"), cores=5)
 
 
+@conda
 def test_conda_python_script():
     run(dpath("test_conda_python_script"), deployment_method={DeploymentMethod.CONDA})
 
 
+@conda
 def test_conda_python_3_7_script():
     run(
         dpath("test_conda_python_3_7_script"),
@@ -1924,6 +1964,7 @@ def test_conda_python_3_7_script():
     )
 
 
+@conda
 def test_prebuilt_conda_script():
     sp.run(
         f"conda env create -f {dpath('test_prebuilt_conda_script/env.yaml')}",
@@ -2012,11 +2053,13 @@ def test_config_yte():
     run(dpath("test_config_yte"))
 
 
+@connected
 def test_load_metawrapper():
     run(dpath("test_load_metawrapper"), executor="dryrun")
 
 
 @skip_on_windows
+@conda
 def test_conda_global():
     run(
         dpath("test_conda_global"),
@@ -2029,6 +2072,7 @@ def test_missing_file_dryrun():
     run(dpath("test_missing_file_dryrun"), executor="dryrun", shouldfail=True)
 
 
+@conda
 def test_script_pre_py39():
     run(dpath("test_script_pre_py39"), deployment_method={DeploymentMethod.CONDA})
 
@@ -2064,6 +2108,7 @@ def test_issue2574():
     assert "line 4," in stderr
 
 
+@conda
 def test_resource_string_in_cli_or_profile():
     test_path = dpath("test_resource_string_in_cli_or_profile")
     profile = os.path.join(test_path, "profiles")
@@ -2193,6 +2238,7 @@ def test_github_issue2732():
 
 
 @skip_on_windows
+@apptainer
 def test_shell_exec():
     run(dpath("test_shell_exec"), deployment_method={DeploymentMethod.APPTAINER})
 


### PR DESCRIPTION
There is no point to attempt testing apptainer and/or conda if they are not in the environment. This also marks few tests with `@connected`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced conditional test execution based on the availability of Apptainer and Conda environments.
	- Added new pytest markers to enhance test suite flexibility.

- **Bug Fixes**
	- Improved robustness of the testing framework by ensuring tests can be skipped if required tools are not present.

- **Documentation**
	- Updated test functions to reflect their association with specific deployment methods for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->