### PR TITLE
fix: skip asset download if files are already present

### DIFF
--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -118,6 +118,13 @@ class Assets:
         base_path = Path(__file__).parent / "data"
         for asset_path, asset in cls.spec.items():
             target_path = base_path / asset_path
+
+            if target_path.exists():
+                with open(target_path, "rb") as fin:
+                    # file is already present, check if it is up to date
+                    if asset.sha256 == hashlib.sha256(fin.read()).hexdigest():
+                        continue
+
             target_path.parent.mkdir(parents=True, exist_ok=True)
             with open(target_path, "wb") as fout:
                 fout.write(asset.get_content())


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment process by adding a check for existing asset files, improving efficiency by skipping unnecessary writes for unchanged assets.
  
- **Bug Fixes**
	- Resolved potential issues related to overwriting existing asset files during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->