### PR TITLE
feat: Add --cache to general_args for jobscripts

### DIFF
--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -294,6 +294,7 @@ class SpawnedJobArgsFactory:
             w2a("output_settings.benchmark_extended"),
             w2a("execution_settings.latency_wait"),
             w2a("scheduling_settings.scheduler", flag="--scheduler"),
+            w2a("workflow_settings.cache"),
             local_storage_prefix,
             format_cli_arg(
                 "--scheduler-solver-path",


### PR DESCRIPTION
In this PR the `--cache` is added to the `general_args`. This passes `--cache` to any executor that builds a job execution command using this method. Thus the `--cache` functionality is not ignored any more in remote executed jobs.

### Background
Currently the `--cache` argument is not used and thus ignored when building the execution command for jobs depending on the `general_args` method of the `SpawnedJobArgsFactory`. Eg all executors depending on the  [`RealExecutor` implementation ](https://github.com/snakemake/snakemake-interface-executor-plugins/blob/56b8c84a18b3b8b6a0497201cf17defbbaffa425/snakemake_interface_executor_plugins/executors/real.py#L141-L177) depend on this.
This causes jobs executed via these executors to miss the `--cache` argument and thus ignore the caching functionality in generated jobs.

This has been noticed in the Slurm executor plugin: https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/46

### Additional considerations

1. Arguably it would be more optimal to actually check the cache before submitting a job (ie if the rule is already cached, dont submit a job but directly link the results locally). In such a case the `job_exec` command would not even be needed in cases the cache is available, thus I dont think the implementation in this PR interferes with executors implementing such as feautre.

2. Enabling the `--cache` mechanism on remote systems, assumes that the remote executor has access to the same filesystem the cache resides on. To me it is the obligation of the user to make sure the exector used is compatible with caching and in case it is not to diseable the caching functionality.

3. Testing: I am currently not sure where/how to best test this. One test would be to run `general_args` with a `workflow` setting containing cache and check if it ends up in the generated `args` string -  but this would require to mock lots of things, so would be quite a bit of effort.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow configuration by adding a new argument for caching settings, improving workflow management capabilities.
  
- **Bug Fixes**
	- Improved handling of workflow execution related to caching behavior, ensuring smoother operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->