### PR TITLE
fix: ensure that CLI help is formatted deterministically and set defaults are displayed properly (based on preliminary work by @keszybz)

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -331,27 +331,6 @@ def get_profile_dir(profile: str) -> (Path, Path):
                 return profile_candidate, profile_candidate / config_file
 
 
-class ArgumentDefaultsHelpFormatter(argparse.HelpFormatter):
-    """Help message formatter which adds default values to argument help.
-
-    Like argparse.ArgumentDefaultsHelpFormatter, but doesn't print
-    None/dataclasses._MISSING_TYPE/etc.
-    """
-
-    def _get_help_string(self, action):
-        if (
-            (
-                action.option_strings
-                or action.nargs in [argparse.OPTIONAL, argparse.ZERO_OR_MORE]
-            )
-            and action.default not in (None, "", set(), argparse.SUPPRESS)
-            and not isinstance(action.default, dataclasses._MISSING_TYPE)
-        ):
-            return action.help + " (default: %(default)s)"
-        else:
-            return action.help
-
-
 def get_argument_parser(profiles=None):
     """Generate and return argument parser."""
     from snakemake.profiles import ProfileConfigFileParser
@@ -383,7 +362,7 @@ def get_argument_parser(profiles=None):
     parser = snakemake.common.argparse.ArgumentParser(
         description="Snakemake is a Python based language and execution "
         "environment for GNU Make-like workflows.",
-        formatter_class=ArgumentDefaultsHelpFormatter,
+        formatter_class=snakemake.common.argparse.ArgumentDefaultsHelpFormatter,
         default_config_files=config_files,
         config_file_parser_class=ProfileConfigFileParser,
     )

--- a/snakemake/common/argparse.py
+++ b/snakemake/common/argparse.py
@@ -1,4 +1,5 @@
 import argparse
+import collections
 import dataclasses
 
 import configargparse
@@ -74,13 +75,15 @@ class ArgumentDefaultsHelpFormatter(argparse.HelpFormatter):
             and action.default not in (None, "", set(), argparse.SUPPRESS)
             and not isinstance(action.default, dataclasses._MISSING_TYPE)
         ):
-            if isinstance(action.default, frozenset):
-                # ensure deterministic sorting and proper display without braces
-                # and commas
-                return (
-                    action.help
-                    + f" (default: {' '.join(sorted(map(str, action.default)))})"
-                )
+            if isinstance(action.default, collections.abc.Iterable) and not isinstance(
+                action.default, str
+            ):
+
+                if isinstance(action.default, (frozenset, set)):
+                    default = sorted(map(str, action.default))
+                else:
+                    default = map(str, action.default)
+                return action.help + f" (default: {' '.join(default)})"
             else:
                 return action.help + " (default: %(default)s)"
         else:


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved command-line help messages by including default values for arguments, enhancing usability.
- **Bug Fixes**
	- Streamlined the argument parser by removing a custom formatter and adopting a standardized implementation, ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->