### PR TITLE
fix: Flatten conda pip dependencies for report rule info

### DIFF
--- a/snakemake/report/html_reporter/template/components/rule_info.js
+++ b/snakemake/report/html_reporter/template/components/rule_info.js
@@ -1,5 +1,27 @@
 'use strict';
 
+function flattenList(inputList) {
+    let flattened = [];
+
+    inputList.forEach(item => {
+        if (typeof item === 'object' && !Array.isArray(item)) {
+            for (let key in item) {
+                if (Array.isArray(item[key])) {
+                    item[key].forEach(subItem => {
+                        flattened.push(`${key}: ${subItem}`);
+                    });
+                } else {
+                    flattened.push(`${key}: ${item[key]}`);
+                }
+            }
+        } else {
+            flattened.push(item);
+        }
+    });
+
+    return flattened;
+}
+
 class RuleInfo extends React.Component {
     static propTypes = {
         rule: PropTypes.object.isRequired,
@@ -29,7 +51,7 @@ class RuleInfo extends React.Component {
     renderSoftware() {
         let rule = rules[this.props.rule];
         if (rule.conda_env) {
-            return this.renderItems("Software", rule.conda_env.dependencies);
+            return this.renderItems("Software", flattenList(rule.conda_env.dependencies));
         } else {
             return [];
         }

--- a/snakemake/report/html_reporter/template/components/rule_info.js
+++ b/snakemake/report/html_reporter/template/components/rule_info.js
@@ -1,23 +1,21 @@
 'use strict';
 
 function flattenList(inputList) {
-    let flattened = [];
+    const flattened = [];
 
-    inputList.forEach(item => {
+    for (const item of inputList) {
         if (typeof item === 'object' && !Array.isArray(item)) {
-            for (let key in item) {
-                if (Array.isArray(item[key])) {
-                    item[key].forEach(subItem => {
-                        flattened.push(`${key}: ${subItem}`);
-                    });
+            for (const [key, value] of Object.entries(item)) {
+                if (Array.isArray(value)) {
+                    flattened.push(...value.map(subItem => `${key}: ${subItem}`));
                 } else {
-                    flattened.push(`${key}: ${item[key]}`);
+                    flattened.push(`${key}: ${value}`);
                 }
             }
         } else {
             flattened.push(item);
         }
-    });
+    }
 
     return flattened;
 }


### PR DESCRIPTION
Currently pip dependencies specified in conda environments break the rule_info of the snakemake html report as reported in #3084


This works around this issue by flattening the pip secion as:
pip: <dependency 1>
pip: <dependency 2>

before displaying which fixes this issue.


### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


### Additional considerations
- I am not a React/Javascript expert at all, so it is very well possible my fix is not very ideomatic - I am mainly interested in getting the `report.html` working, so any alternative/better solution would be very welcome as well
- Only manual testing was done as I dont know how to test javascript rendering
- Aesthetics: currently I am simply flattening the entries of the `pip` section of the conda envrionment:
```
dependencies:
- python
- pip
- pip:
   - dependencya
   - dependencyb
```
will be rendered as:
 ```
 python
 pip
 pip: dependencya
 pip: dependencyb
 ```
 Potentially one could do this nicer with indenting. 

Example rendering: 
![image](https://github.com/user-attachments/assets/faa9f167-bb24-415c-a136-b5cae3e73206)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Improved rendering of software dependencies in the RuleInfo component, allowing for better handling of complex nested data structures.
- **Bug Fixes**
	- Enhanced processing of input lists containing objects and arrays, ensuring accurate representation of dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->