### PR TITLE
docs: Update lookup signature

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -368,10 +368,12 @@ The ``lookup`` function has the signature
         dpath: Optional[str | Callable] = None, 
         query: Optional[str | Callable] = None, 
         cols: Optional[List[str]] = None, 
-        is_nrows: Optional[int], within=None
+        is_nrows: Optional[int],
+        within=None,
+        default=NODEFAULT
     )
 
-The ``within`` parameter takes either a python mapping, a pandas dataframe, or a pandas series.
+The required ``within`` parameter takes either a python mapping, a pandas dataframe, or a pandas series.
 For the former case, it expects the ``dpath`` argument, for the latter two cases, it expects the ``query`` argument to be given.
 
 In case of a pandas dataframe,


### PR DESCRIPTION
This does two things, first it moves the required ``within`` argument to its own line - previously it was too easily overlooked. See change in bdd732d1f98d0af0362115f74baa728bfc976851

Second, it adds the ``default`` argument from 08e88e27f9e5ddcd5d9ebce7f79f45436262fddc on PR #2907.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation to clarify that the `within` parameter is now required for the `lookup` function.
	- Introduced a new default value, `NODEFAULT`, for the `default` parameter, enhancing clarity on function usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->