### PR TITLE
docs: Clarify the lookup function docstring

### DIFF
--- a/snakemake/ioutils.py
+++ b/snakemake/ioutils.py
@@ -141,7 +141,7 @@ def lookup(
     a single column, e.g.
     ``lookup(query="sample == '{sample}'", within=samples, cols="somecolumn")``.
     In the latter case, just a list of items in that column is returned.
-    Finally, if the interger argument ``is_nrows`` is used, this returns true
+    Finally, if the integer argument ``is_nrows`` is used, this returns true
     if there are that many rows in the query results, false otherwise.
     
     In case of a pandas series, the series is converted into a dataframe via

--- a/snakemake/ioutils.py
+++ b/snakemake/ioutils.py
@@ -119,7 +119,7 @@ def lookup(
     """Lookup values in a pandas dataframe, series, or python mapping (e.g. dict).
 
     Required argument ``within`` should be a pandas dataframe or series (in which
-    case use ``query``, and optionaly ``cols`` and ``is_nrows``), or a Python
+    case use ``query``, and optionally ``cols`` and ``is_nrows``), or a Python
     mapping like a dict (in which case use the ``dpath`` argument is used).
 
     In case of a pandas dataframe (see https://pandas.pydata.org),

--- a/snakemake/ioutils.py
+++ b/snakemake/ioutils.py
@@ -118,6 +118,10 @@ def lookup(
 ):
     """Lookup values in a pandas dataframe, series, or python mapping (e.g. dict).
 
+    Required argument ``within`` should be a pandas dataframe or series (in which
+    case use ``query``, and optionaly ``cols`` and ``is_nrows``), or a Python
+    mapping like a dict (in which case use the ``dpath`` argument is used).
+
     In case of a pandas dataframe (see https://pandas.pydata.org),
     the query parameter is passed to DataFrame.query().
     If the query results in multiple rows, the result is returned as a list of
@@ -137,13 +141,17 @@ def lookup(
     a single column, e.g.
     ``lookup(query="sample == '{sample}'", within=samples, cols="somecolumn")``.
     In the latter case, just a list of items in that column is returned.
-
-
+    Finally, if the interger argument ``is_nrows`` is used, this returns true
+    if there are that many rows in the query results, false otherwise.
+    
     In case of a pandas series, the series is converted into a dataframe via
     Series.to_frame() and the same logic as for a dataframe is applied.
 
-    In case of a python mapping, the dpath parameter is passed to dpath.values()
-    (see https://github.com/dpath-maintainers/dpath-python).
+    In case of a python mapping, the ``dpath`` parameter is passed to
+    ``dpath.values()`` (see https://github.com/dpath-maintainers/dpath-python),
+    and the ``query``, ``cols``, and ``is_nrows`` arguments are ignored. If the
+    dpath is not found, a ``LookupError`` is raised, unless a default fallback
+    value is provided via the ``default`` argument.
 
     Query, dpath and cols may contain wildcards (e.g. {sample}).
     In that case, this function returns a Snakemake input function which takes
@@ -154,9 +162,6 @@ def lookup(
     to auxiliary namespace arguments given to the lookup function, e.g.
     ``lookup(query="cell_type == '{sample.cell_type}'", within=samples, sample=lookup("sample == '{sample}'", within=samples))``
     This way, one can e.g. pass additional variables or chain lookups into more complex queries.
-
-    In case of dpath, if the dpath is not found, a LookupError is raised, unless a
-    default fallback value is provided via the ``default`` argument.
     """
     error = partial(LookupError, query=query, dpath=dpath)
 

--- a/snakemake/ioutils.py
+++ b/snakemake/ioutils.py
@@ -143,7 +143,7 @@ def lookup(
     In the latter case, just a list of items in that column is returned.
     Finally, if the integer argument ``is_nrows`` is used, this returns true
     if there are that many rows in the query results, false otherwise.
-    
+
     In case of a pandas series, the series is converted into a dataframe via
     Series.to_frame() and the same logic as for a dataframe is applied.
 


### PR DESCRIPTION
This described the is_nrows argument, and tries to make it clear what applies with a mapping input.

[It does seem this would be cleaner as two functions, one for pandas lookup, one for dpath]

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for the `lookup` function, clarifying parameter usage and behavior.
	- Added details on how to handle different input types and improved error handling guidance, including the introduction of a default fallback value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->