### PR TITLE
feat: Add commentstring for vim plugin

### DIFF
--- a/misc/vim/ftplugin/snakemake/comment.vim
+++ b/misc/vim/ftplugin/snakemake/comment.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s


### PR DESCRIPTION
Enables toggling comments  with commenting plugins or Neovim's built-in `gcc` mapping

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. (**NA, I think**)
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). (**NA too, I think**)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Vim configuration for Snakemake files that enhances comment formatting.
	- Comments in Snakemake scripts will now automatically begin with a hash symbol followed by a space for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->