### PR TITLE
feat: switch from toposort to graphlib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ install_requires =
     snakemake-interface-report-plugins >=1.0.0,<2.0.0
     tabulate
     throttler
-    toposort >=1.10,<2.0
     wrapt
     yte >=1.5.1,<2.0
     dpath >=2.1.6,<3.0.0

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2790,7 +2790,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 deps = self._dependencies[job]
             dependencies[job] = {dep for dep in deps if dep in jobs}
 
-        toposorted = self.toposort(dependencies)
+        toposorted = toposort(dependencies)
 
         # Within each toposort layer, entries should be sorted so that pipe jobs are
         # listed order of dependence, i.e. dependent jobs before depending jobs
@@ -2806,7 +2806,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             for group in pipe_groups.values():
                 sorted_layer.extend(
                     chain.from_iterable(
-                        self.toposort(
+                        toposort(
                             {
                                 job: {
                                     dep

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2751,7 +2751,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             while sorter.is_active():
                 ready = set()
                 for task in sorter.get_ready():
-                    ready.update(str(task))
+                    ready.add(task)
                     sorter.done(task)
                 sorted.append(ready)
             return sorted

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2805,7 +2805,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             for group in pipe_groups.values():
                 sorted_layer.extend(
                     chain.from_iterable(
-                        toposort(
+                        graphlib_toposort(
                             {
                                 job: {
                                     dep

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2744,11 +2744,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
     def toposorted(self, jobs=None, inherit_pipe_dependencies=False):
         def graphlib_toposort(graph):
             from graphlib import TopologicalSorter
+
             sorter = TopologicalSorter(graph)
             sorter.prepare()
             sorted = list()
             while sorter.is_active():
-                ready=set()
+                ready = set()
                 for task in sorter.get_ready():
                     ready.update(str(task))
                     sorter.done(task)

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -41,7 +41,6 @@ dependencies:
   - pulp >=2.3.1
   - environment-modules
   - nbformat
-  - toposort >=1.10
   - crc32c
   - requests-mock
   - peppy

--- a/tests/test_toposort/Snakefile
+++ b/tests/test_toposort/Snakefile
@@ -1,0 +1,4 @@
+from snakemake.dag import toposort
+
+graph = {"job4": ["job2", "job3"], "job3": ["job1"], "job2": ["job1"]}
+assert toposort(graph) == [{'job1'}, {'job2', 'job3'}, {'job4'}]

--- a/tests/test_toposort/Snakefile
+++ b/tests/test_toposort/Snakefile
@@ -1,4 +1,10 @@
 from snakemake.dag import toposort
 
-graph = {"job4": ["job2", "job3"], "job3": ["job1"], "job2": ["job1"]}
-assert toposort(graph) == [{'job1'}, {'job2', 'job3'}, {'job4'}]
+graph1 = {"job4": ["job2", "job3"], "job3": ["job1"], "job2": ["job1"]}
+assert toposort(graph1) == [{'job1'}, {'job2', 'job3'}, {'job4'}], "Basic graph toposort failed"
+
+graph2 = {}
+assert toposort(graph2) == [], "Empty graph toposort failed"
+
+graph3 = {"job1": [], "job2": []}
+assert toposort(graph3) == [{'job1', 'job2'}], "Disconnected graph toposort failed"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2266,5 +2266,6 @@ def test_checkpoint_open():
         default_storage_prefix="storage",
     )
 
-def test_exists():
+
+def test_toposort():
     run(dpath("test_toposort"), check_results=False, executor="dryrun")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2265,3 +2265,6 @@ def test_checkpoint_open():
         default_storage_provider="fs",
         default_storage_prefix="storage",
     )
+
+def test_exists():
+    run(dpath("test_toposort"), check_results=False, executor="dryrun")


### PR DESCRIPTION
<!--Add a description of your PR here-->
Use `graphlib` instead of `toposort` for topological sorting (following #2134).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced topological sorting for job execution in workflows, improving efficiency and reliability.
	- Introduced new tests to validate the functionality of the topological sorting feature.

- **Bug Fixes**
	- Removed the `toposort` dependency to streamline package requirements.

- **Chores**
	- Updated dependencies in the test environment for better compatibility and performance.
	- Adjusted formatting and organization of the dependencies in configuration files for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->