### PR TITLE
fix:  snakemake deployment update for mamba > 2.0.0

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -502,7 +502,7 @@ class Env:
                             "--quiet",
                             "--no-shortcuts" if ON_WINDOWS else "",
                             "--yes",
-                            "--no-default-packages",
+                            "--no-default-packages" if (self.frontend == "mamba") else "",
                             f"--prefix '{env_path}'",
                         ]
                         + packages
@@ -545,7 +545,7 @@ class Env:
                             + [
                                 "create",
                                 "--quiet",
-                                "--no-default-packages",
+                                "--no-default-packages" if (self.frontend == "mamba") else "",
                                 f'--file "{target_env_file}"',
                                 f'--prefix "{env_path}"',
                             ]

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -502,7 +502,12 @@ class Env:
                             "--quiet",
                             "--no-shortcuts" if ON_WINDOWS else "",
                             "--yes",
-                            "--no-default-packages" if (self.frontend != "mamba") else "",
+                            (
+                                "--no-default-packages"
+                                if self.frontend != "mamba"
+                                or not self.mamba_version.startswith("2")
+                                else ""
+                            ),
                             f"--prefix '{env_path}'",
                         ]
                         + packages
@@ -545,7 +550,12 @@ class Env:
                             + [
                                 "create",
                                 "--quiet",
-                                "--no-default-packages" if (self.frontend != "mamba") else "",
+                                (
+                                    "--no-default-packages"
+                                    if self.frontend != "mamba"
+                                    or not self.mamba_version.startswith("2")
+                                    else ""
+                                ),
                                 f'--file "{target_env_file}"',
                                 f'--prefix "{env_path}"',
                             ]
@@ -830,6 +840,17 @@ class Conda:
         env_address = env_address.replace("\\", "/")
 
         return f'"{activate}" "{env_address}"&&{cmd}'
+
+    @property
+    def mamba_version(self) -> str:
+        if not is_mamba_available():
+            return ""
+        try:
+            version = subprocess.check_output(["mamba", "--version"]).decode().strip()
+            return version.split()[-1]
+        except subprocess.CalledProcessError:
+            logger.debug("Could not determine mamba version.")
+            return ""
 
 
 def is_mamba_available():

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -859,10 +859,7 @@ class Conda:
                 )
             else:
                 version = version_matches[0]
-            if Version(version) < Version("2.0.0"):
-                return True
-            else:
-                return False
+            return Version(version) < Version("2.0.0")
 
 
 def is_mamba_available():

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -502,7 +502,7 @@ class Env:
                             "--quiet",
                             "--no-shortcuts" if ON_WINDOWS else "",
                             "--yes",
-                            "--no-default-packages" if (self.frontend == "mamba") else "",
+                            "--no-default-packages" if (self.frontend != "mamba") else "",
                             f"--prefix '{env_path}'",
                         ]
                         + packages
@@ -545,7 +545,7 @@ class Env:
                             + [
                                 "create",
                                 "--quiet",
-                                "--no-default-packages" if (self.frontend == "mamba") else "",
+                                "--no-default-packages" if (self.frontend != "mamba") else "",
                                 f'--file "{target_env_file}"',
                                 f'--prefix "{env_path}"',
                             ]


### PR DESCRIPTION
### Description 

This PR removes the `--no-default-packages` flag if the dependency engine detected is determined to be `mamba` since this flag is deprecated in `mamba >= 2.0.0`. 

### QC

This change should be covered by the pre-existing test cases that exhibit `conda` dependencies. It also should not require any documentation changes 

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of the `--no-default-packages` option when creating conda environments based on the selected frontend and mamba version.
	- Added a new property to retrieve the version of mamba for enhanced environment management.

- **Bug Fixes**
	- Enhanced clarity in logging messages related to environment creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->