### PR TITLE
fix: remote pre-command not installing all required storage plugins

### DIFF
--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -201,12 +201,13 @@ class SpawnedJobArgsFactory:
             executor_common_settings.auto_deploy_default_storage_provider
             and self.workflow.storage_settings.default_storage_provider is not None
         ):
-            package_name = StoragePluginRegistry().get_plugin_package_name(
-                self.workflow.storage_settings.default_storage_provider
+            packages_to_install = set(
+                StoragePluginRegistry().get_plugin_package_name(pkg)
+                for pkg in self.workflow.storage_provider_settings.keys()
             )
-            precommand.append(
-                f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {package_name}"
-            )
+            pkgs = " ".join(packages_to_install)
+
+            precommand.append(f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {pkgs}")
 
         if (
             SharedFSUsage.SOURCES not in self.workflow.storage_settings.shared_fs_usage


### PR DESCRIPTION
<!--Add a description of your PR here-->
Related Issues: 
#2501 
https://github.com/snakemake/snakemake-executor-plugin-kubernetes/issues/19 

When the job spawner prepares the `precommand` for remote execution, it only registers the `default storage provider` which fails to acknowledge the presence of a storage provider within the snakefile. 

This PR should now register all storage providers that `workflow` has recognized. 

NOTE: unsure how to I could add a test case for this? 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced package installation logic for storage providers, allowing multiple packages to be installed simultaneously when the auto-deploy feature is enabled. 

- **Bug Fixes**
	- Improved handling of duplicate package names in the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->