### PR TITLE
fix: rely on conda >24.7.1 for conda env deployment and deprecate mamba support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,11 @@ jobs:
           sed -E -i 's/- python.+/- python =${{ matrix.py_ver }}/' test-environment-${{ matrix.py_ver }}.yml
 
       - name: Setup snakemke environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           environment-file: test-environment-${{ matrix.py_ver }}.yml
           environment-name: snakemake
-          cache-environment: true
 
       - name: Install snakemake from source
         shell: bash -el {0}
@@ -144,13 +144,12 @@ jobs:
               if all(pkg not in line for pkg in excluded_on_win):
                   print(line, end="")
 
-      - name: Setup snakemake environment
-        uses: mamba-org/setup-micromamba@v1
+      - name: Setup snakemke environment
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
           environment-file: test-environment.yml
           environment-name: snakemake
-          init-shell: powershell
-          cache-environment: true
 
       - name: Install snakemake from source
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           cp test-environment.yml test-environment-${{ matrix.py_ver }}.yml
           sed -E -i 's/- python.+/- python =${{ matrix.py_ver }}/' test-environment-${{ matrix.py_ver }}.yml
 
-      - name: Setup snakemke environment
+      - name: Setup snakemake environment
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     requests >=2.8.1,<3.0
     reretry
     smart-open >=4.0,<8.0
-    snakemake-interface-executor-plugins >=9.2.0,<10.0
+    snakemake-interface-executor-plugins >=9.3.2,<10.0
     snakemake-interface-common >=1.17.0,<2.0
     snakemake-interface-storage-plugins >=3.2.3,<4.0
     snakemake-interface-report-plugins >=1.0.0,<2.0.0

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1621,7 +1621,7 @@ def get_argument_parser(profiles=None):
     )
     group_conda.add_argument(
         "--conda-frontend",
-        default="mamba",
+        default="conda",
         choices=["conda", "mamba"],
         help="Choose the conda frontend for installing environments. "
         "Mamba is much faster and highly recommended.",

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -403,7 +403,7 @@ class Env:
                     tmp.write(self.content_deploy)
                     deploy_file = tmp.name
                     tmp_deploy_file = tmp.name
-            if self.pin_file:
+            if self.pin_file and not dryrun:
                 with tempfile.NamedTemporaryFile(delete=False, suffix="pin.txt") as tmp:
                     tmp.write(self.content_pin)
                     pin_file = tmp.name
@@ -411,7 +411,8 @@ class Env:
         else:
             env_file = env_file.get_path_or_uri()
             deploy_file = self.post_deploy_file
-            pin_file = self.pin_file
+            if not dryrun:
+                pin_file = self.pin_file
 
         env_path = self.address
 

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -43,6 +43,9 @@ from snakemake.io import (
 from snakemake_interface_common.utils import lazy_property
 
 
+MIN_CONDA_VER = "24.7.1"
+
+
 class CondaCleanupMode(Enum):
     tarballs = "tarballs"
     cache = "cache"
@@ -758,9 +761,9 @@ class Conda:
             )
         else:
             version = version_matches[0]
-        if Version(version) < Version("24.9.1"):
+        if Version(version) < Version(MIN_CONDA_VER):
             raise CreateCondaEnvironmentException(
-                f"Conda must be version 24.9.1 or later, found version {version}. "
+                f"Conda must be version {MIN_CONDA_VER} or later, found version {version}. "
                 "Please update conda to the latest version. "
                 "Note that you can also install conda into the snakemake environment "
                 "without modifying your main conda installation."

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -69,8 +69,6 @@ class Env:
         self.name = env_name
         if env_name is not None:
             assert env_file is None, "bug: both env_file and env_name specified"
-
-        self.frontend = workflow.deployment_settings.conda_frontend
         self.workflow = workflow
 
         self._container_img = container_img
@@ -91,9 +89,7 @@ class Env:
 
     @lazy_property
     def conda(self):
-        return Conda(
-            container_img=self._container_img, frontend=self.frontend, check=True
-        )
+        return Conda(container_img=self._container_img, check=True)
 
     def _path_or_uri_prefix(self):
         prefix = self.file.get_path_or_uri()
@@ -533,7 +529,7 @@ class Env:
                             else []
                         )
 
-                        subcommand = [self.frontend]
+                        subcommand = ["conda"]
                         yes_flag = ["--yes"]
                         if filetype == "yaml":
                             subcommand.append("env")
@@ -654,7 +650,7 @@ class Conda:
     instances = dict()
     lock = threading.Lock()
 
-    def __new__(cls, container_img=None, prefix_path=None, frontend=None, check=False):
+    def __new__(cls, container_img=None, prefix_path=None, check=False):
         with cls.lock:
             if container_img not in cls.instances:
                 inst = super().__new__(cls)
@@ -663,9 +659,7 @@ class Conda:
             else:
                 return cls.instances[container_img]
 
-    def __init__(
-        self, container_img=None, prefix_path=None, frontend=None, check=False
-    ):
+    def __init__(self, container_img=None, prefix_path=None, check=False):
         if not self.is_initialized:  # avoid superfluous init calls
             from snakemake.deployment import singularity
             from snakemake.shell import shell
@@ -673,7 +667,6 @@ class Conda:
             if isinstance(container_img, singularity.Image):
                 container_img = container_img.path
             self.container_img = container_img
-            self.frontend = frontend
 
             self.info = json.loads(
                 shell.check_output(self._get_cmd("conda info --json"), text=True)
@@ -688,8 +681,6 @@ class Conda:
 
             # check conda installation
             if check:
-                if frontend is None:
-                    raise ValueError("Frontend must be specified if check is True.")
                 self._check()
 
     @property
@@ -704,59 +695,46 @@ class Conda:
     def _check(self):
         from snakemake.shell import shell
 
-        frontends = ["conda"]
-        if self.frontend == "mamba":
-            frontends = ["mamba", "conda"]
+        frontend = "conda"
+        # Use type here since conda now is a function.
+        # type allows to check for both functions and regular commands.
+        if not ON_WINDOWS or shell.get_executable():
+            locate_cmd = f"type {frontend}"
+        else:
+            locate_cmd = f"where {frontend}"
 
-        for frontend in frontends:
-            # Use type here since conda now is a function.
-            # type allows to check for both functions and regular commands.
-            if not ON_WINDOWS or shell.get_executable():
-                locate_cmd = f"type {frontend}"
-            else:
-                locate_cmd = f"where {frontend}"
-
-            try:
-                shell.check_output(
-                    self._get_cmd(locate_cmd), stderr=subprocess.STDOUT, text=True
+        try:
+            shell.check_output(
+                self._get_cmd(locate_cmd), stderr=subprocess.STDOUT, text=True
+            )
+        except subprocess.CalledProcessError as e:
+            if self.container_img:
+                msg = (
+                    f"The '{frontend}' command is not "
+                    "available inside "
+                    "your singularity container "
+                    "image. Snakemake mounts "
+                    "your conda installation "
+                    "into singularity. "
+                    "Sometimes, this can fail "
+                    "because of shell restrictions. "
+                    "It has been tested to work "
+                    "with docker://ubuntu, but "
+                    "it e.g. fails with "
+                    "docker://bash "
                 )
-            except subprocess.CalledProcessError as e:
-                if self.container_img:
-                    msg = (
-                        f"The '{frontend}' command is not "
-                        "available inside "
-                        "your singularity container "
-                        "image. Snakemake mounts "
-                        "your conda installation "
-                        "into singularity. "
-                        "Sometimes, this can fail "
-                        "because of shell restrictions. "
-                        "It has been tested to work "
-                        "with docker://ubuntu, but "
-                        "it e.g. fails with "
-                        "docker://bash "
-                    )
-                else:
-                    msg = (
-                        f"The '{frontend}' command is not "
-                        "available in the "
-                        f"shell {shell.get_executable()} that will be "
-                        "used by Snakemake. You have "
-                        "to ensure that it is in your "
-                        "PATH, e.g., first activating "
-                        "the conda base environment "
-                        "with `conda activate base`."
-                    )
-                if frontend == "mamba":
-                    msg += (
-                        "The mamba package manager (https://github.com/mamba-org/mamba) is a "
-                        "fast and robust conda replacement. "
-                        "It is the recommended way of using Snakemake's conda integration. "
-                        "It can be installed with `conda install -n base -c conda-forge mamba`. "
-                        "If you still prefer to use conda, you can enforce that by setting "
-                        "`--conda-frontend conda`."
-                    )
-                raise CreateCondaEnvironmentException(msg)
+            else:
+                msg = (
+                    f"The '{frontend}' command is not "
+                    "available in the "
+                    f"shell {shell.get_executable()} that will be "
+                    "used by Snakemake. You have "
+                    "to ensure that it is in your "
+                    "PATH, e.g., first activating "
+                    "the conda base environment "
+                    "with `conda activate base`."
+                )
+            raise CreateCondaEnvironmentException(msg)
 
         try:
             self._check_version()
@@ -773,16 +751,19 @@ class Conda:
         version = shell.check_output(
             self._get_cmd("conda --version"), stderr=subprocess.PIPE, text=True
         )
-        version_matches = re.findall(r"\d+.\d+.\d+", version)
+        version_matches = re.findall(r"\d+\.\d+\.\d+", version)
         if len(version_matches) != 1:
             raise WorkflowError(
                 f"Unable to determine conda version. 'conda --version' returned {version}"
             )
         else:
             version = version_matches[0]
-        if Version(version) < Version("4.2"):
+        if Version(version) < Version("24.9.1"):
             raise CreateCondaEnvironmentException(
-                f"Conda must be version 4.2 or later, found version {version}."
+                f"Conda must be version 24.9.1 or later, found version {version}. "
+                "Please update conda to the latest version. "
+                "Note that you can also install conda into the snakemake environment "
+                "without modifying your main conda installation."
             )
 
     def _check_condarc(self):
@@ -802,9 +783,10 @@ class Conda:
         if res["get"].get("channel_priority") != "strict":
             logger.warning(
                 "Your conda installation is not configured to use strict channel priorities. "
-                "This is however crucial for having robust and correct environments (for details, "
+                "This is however important for having robust and correct environments (for details, "
                 "see https://conda-forge.org/docs/user/tipsandtricks.html). "
-                "Please consider to configure strict priorities by executing 'conda config --set channel_priority strict'."
+                "Please consider to configure strict priorities by executing "
+                "'conda config --set channel_priority strict'."
             )
 
     def bin_path(self):
@@ -830,10 +812,6 @@ class Conda:
         env_address = env_address.replace("\\", "/")
 
         return f'"{activate}" "{env_address}"&&{cmd}'
-
-
-def is_mamba_available():
-    return shutil.which("mamba") is not None
 
 
 class CondaEnvSpec(ABC):

--- a/snakemake/deployment/containerize.py
+++ b/snakemake/deployment/containerize.py
@@ -40,7 +40,7 @@ def containerize(workflow, dag):
         # build a hash of the environment contents
         envhash.update(env.content)
 
-    print("FROM condaforge/mambaforge:latest")
+    print("FROM condaforge/miniforge3:latest")
     print('LABEL io.github.snakemake.containerized="true"')
     print(f'LABEL io.github.snakemake.conda_env_hash="{envhash.hexdigest()}"')
 
@@ -67,13 +67,13 @@ def containerize(workflow, dag):
             get_env_cmds.append(f"ADD {env.file.get_path_or_uri()} {env_target_path}")
 
         generate_env_cmds.append(
-            f"mamba env create --prefix {prefix} --file {env_target_path} &&"
+            f"conda env create --prefix {prefix} --file {env_target_path} &&"
         )
         generated.add(env.content_hash)
 
-    print("\n# Step 1: Retrieve conda environments")
+    print("\n# Step 2: Retrieve conda environments")
     for cmd in get_env_cmds:
         print(cmd)
 
-    print("\n# Step 2: Generate conda environments")
-    print("\nRUN", " \\\n    ".join(generate_env_cmds), "\\\n    mamba clean --all -y")
+    print("\n# Step 3: Generate conda environments")
+    print("\nRUN", " \\\n    ".join(generate_env_cmds), "\\\n    conda clean --all -y")

--- a/snakemake/settings/types.py
+++ b/snakemake/settings/types.py
@@ -249,7 +249,7 @@ class DeploymentSettings(SettingsBase, DeploymentSettingsExecutorInterface):
     conda_prefix: Optional[Path] = None
     conda_cleanup_pkgs: Optional[CondaCleanupPkgs] = None
     conda_base_path: Optional[Path] = None
-    conda_frontend: str = "mamba"
+    conda_frontend: str = "conda"
     conda_not_block_search_path_envvars: bool = False
     apptainer_args: str = ""
     apptainer_prefix: Optional[Path] = None
@@ -259,10 +259,21 @@ class DeploymentSettings(SettingsBase, DeploymentSettingsExecutorInterface):
         self.deployment_method.add(method)
 
     def __post_init__(self):
+        from snakemake.logging import logger
+
         if self.apptainer_prefix is None:
             self.apptainer_prefix = os.environ.get("APPTAINER_CACHEDIR", None)
         self.apptainer_prefix = expand_vars_and_user(self.apptainer_prefix)
         self.conda_prefix = expand_vars_and_user(self.conda_prefix)
+        if self.conda_frontend != "conda":
+            logger.warning(
+                "Support for alternative conda frontends has been deprecated in "
+                "favor of simpler support and code base. "
+                "This should not cause issues since current conda releases rely on "
+                "fast solving via libmamba. "
+                f"Ignoring the alternative conda frontend setting ({self.conda_frontend})."
+            )
+            self.conda_frontend = "conda"
 
 
 @dataclass

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -43,7 +43,7 @@ dependencies:
   - toposort >=1.10
   - crc32c
   - requests-mock
-  - peppy
+  - peppy =0.40.5 # TODO remove constraint once this is fixed: https://github.com/pepkit/peppy/issues/496
   - eido
   - glpk
   - smart_open

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -4,7 +4,6 @@ channels:
   - nodefaults
 dependencies:
   - python >=3.11
-  - mamba
   - yte
   - packaging
   - datrie

--- a/tests/common.py
+++ b/tests/common.py
@@ -160,7 +160,7 @@ def run(
     nodes=None,
     set_pythonpath=True,
     cleanup=True,
-    conda_frontend="mamba",
+    conda_frontend="conda",
     config=dict(),
     targets=set(),
     container_image=os.environ.get("CONTAINER_IMAGE", "snakemake/snakemake:latest"),

--- a/tests/test_conda_function/Snakefile
+++ b/tests/test_conda_function/Snakefile
@@ -1,7 +1,7 @@
 def conda_func(wildcards, params):
     env_name = f"{params.name_prefix}-test-env-{wildcards.version}"
     shell(
-        f"mamba create -y -n {env_name} -c conda-forge --override-channels ripgrep=={wildcards.version}"
+        f"conda create -y -n {env_name} -c conda-forge --override-channels ripgrep=={wildcards.version}"
     )
     return env_name
 

--- a/tests/test_conda_named/Snakefile
+++ b/tests/test_conda_named/Snakefile
@@ -4,7 +4,7 @@ import sys
 
 try:
     shell(
-        "mamba create -y -n xxx-test-env -c conda-forge --override-channels ripgrep==13.0.0"
+        "conda create -y -n xxx-test-env -c conda-forge --override-channels ripgrep==13.0.0"
     )
     print("created conda env", file=sys.stderr)
 except sp.CalledProcessError as e:

--- a/tests/test_containerized/Dockerfile
+++ b/tests/test_containerized/Dockerfile
@@ -1,21 +1,22 @@
-FROM condaforge/mambaforge:latest
+FROM condaforge/miniforge3:latest
 LABEL io.github.snakemake.containerized="true"
-LABEL io.github.snakemake.conda_env_hash="d630028d41ac6564d03ea65c4edb2d271d33f36409fedab419872fe30d7df6b4"
+LABEL io.github.snakemake.conda_env_hash="cb075ce12360612250e0065299b188ea3547727b9abc02b9927671af50d26bca"
 
-# Step 1: Retrieve conda environments
+# Step 2: Retrieve conda environments
 
 # Conda environment:
 #   source: env.yaml
-#   prefix: /conda-envs/_1219696ceec39be99ff366456467efb2
+#   prefix: /conda-envs/2a132eb0d84044eaf02032bd9f9851fd
 #   channels:
-#     - bioconda
 #     - conda-forge
+#     - bioconda
+#     - nodefaults
 #   dependencies:
-#     - bcftools =1.10
-RUN mkdir -p /conda-envs/_1219696ceec39be99ff366456467efb2
-COPY env.yaml /conda-envs/_1219696ceec39be99ff366456467efb2/environment.yaml
+#     - bcftools =1.21
+RUN mkdir -p /conda-envs/2a132eb0d84044eaf02032bd9f9851fd
+COPY env.yaml /conda-envs/2a132eb0d84044eaf02032bd9f9851fd/environment.yaml
 
-# Step 2: Generate conda environments
+# Step 3: Generate conda environments
 
-RUN mamba env create --prefix /conda-envs/_1219696ceec39be99ff366456467efb2 --file /conda-envs/_1219696ceec39be99ff366456467efb2/environment.yaml && \
-    mamba clean --all -y
+RUN conda env create --prefix /conda-envs/2a132eb0d84044eaf02032bd9f9851fd --file /conda-envs/2a132eb0d84044eaf02032bd9f9851fd/environment.yaml && \
+    conda clean --all -y

--- a/tests/test_containerized/Snakefile
+++ b/tests/test_containerized/Snakefile
@@ -1,4 +1,4 @@
-containerized: "docker://quay.io/snakemake/containerize-testimage:1.0"
+containerized: "docker://snakemake/containerize-testimage:1.2"
 
 rule a:
     output:

--- a/tests/test_containerized/env.yaml
+++ b/tests/test_containerized/env.yaml
@@ -1,5 +1,6 @@
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
+  - nodefaults
 dependencies:
-  - bcftools =1.10
+  - bcftools =1.21

--- a/tests/test_containerized/expected-results/test.out
+++ b/tests/test_containerized/expected-results/test.out
@@ -1,7 +1,7 @@
 
 Program: bcftools (Tools for variant calling and manipulating VCFs and BCFs)
 License: GNU GPLv3+, due to use of the GNU Scientific Library
-Version: 1.10.2 (using htslib 1.10.2)
+Version: 1.21 (using htslib 1.21)
 
 Usage:   bcftools [--version|--version-only] [--help] <command> <argument>
 
@@ -14,6 +14,7 @@ Commands:
     annotate     annotate and edit VCF/BCF files
     concat       concatenate VCF/BCF files from the same set of samples
     convert      convert VCF/BCF files to different formats and back
+    head         view VCF/BCF file headers
     isec         intersections of VCF/BCF files
     merge        merge VCF/BCF files files from non-overlapping sample sets
     norm         left-align and normalize indels
@@ -34,6 +35,9 @@ Commands:
     polysomy     detect number of chromosomal copies
     roh          identify runs of autozygosity (HMM)
     stats        produce VCF/BCF stats
+
+ -- Plugins (collection of programs for calling, file manipulation & analysis)
+    39 plugins available, run "bcftools plugin -lv" to see a complete list
 
  Most commands accept VCF, bgzipped VCF, and BCF with the file type detected
  automatically even when streaming from a pipe. Indexed VCF and BCF will work

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,6 +12,7 @@ import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from snakemake.deployment.conda import get_env_setup_done_flag_file
 from snakemake.resources import DefaultResources, GroupResources
 from snakemake.settings.enums import RerunTrigger
 
@@ -495,7 +496,7 @@ def test_conda_create_envs_only():
         (p for p in Path(tmpdir, ".snakemake", "conda").iterdir() if p.is_dir()), None
     )
     assert env_dir is not None
-    assert Path(env_dir, "env_setup_done").exists()
+    assert get_env_setup_done_flag_file(Path(env_dir)).exists()
     shutil.rmtree(tmpdir)
 
 


### PR DESCRIPTION
Rationale:
Since a while, conda uses internally the libmamba solver (i.e. the same thing as mamba). Mamba development itself is basically over, as the devs concentrate on rattler-based solving. The latter is the future for Snakemake as well, by natively interfacing with rattler via py-rattler. However, until then, the recent quite disruptive changes in mamba 2.0 (including CLI and unexpected behavior changes) suggest that it is more robust for us at the moment to move back to conda, and simply require a recent conda release, such that it is as fast as mamba.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the default package manager from `mamba` to `conda` across various components, simplifying environment setup.
	- Introduced a new function to enhance environment setup flag management.

- **Bug Fixes**
	- Enhanced error handling and messaging for conda environment initialization.

- **Chores**
	- Removed unnecessary dependencies, including `mamba`, and updated the testing environment configuration for better compatibility.
	- Updated Docker images and commands for environment setup to reflect the transition to `conda`.
	- Added the `nodefaults` channel to configuration files for improved package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->