### PR TITLE
fix: configfile `group` and `group-components` were not being registered

### DIFF
--- a/snakemake/profiles.py
+++ b/snakemake/profiles.py
@@ -10,7 +10,6 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
         import yte
 
         profile_dir = Path(stream.name).parent
-
         try:
             parsed_obj = yte.process_yaml(stream, require_use_yte=True)
         except Exception as e:
@@ -52,6 +51,8 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                         "default-resources",
                         "config",
                         "wms-monitor-arg",
+                        "groups",
+                        "group-components",
                     ):
                         result[key] = format_one_level_dict(value)
                     elif key == "set-resources":

--- a/snakemake/profiles.py
+++ b/snakemake/profiles.py
@@ -8,9 +8,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
     def parse(self, stream):
         # taken from configargparse and modified to add special handling for key-value pairs
         import yte
-        import pdb
 
-        pdb.set_trace()
         profile_dir = Path(stream.name).parent
         try:
             parsed_obj = yte.process_yaml(stream, require_use_yte=True)

--- a/snakemake/profiles.py
+++ b/snakemake/profiles.py
@@ -8,7 +8,9 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
     def parse(self, stream):
         # taken from configargparse and modified to add special handling for key-value pairs
         import yte
+        import pdb
 
+        pdb.set_trace()
         profile_dir = Path(stream.name).parent
         try:
             parsed_obj = yte.process_yaml(stream, require_use_yte=True)

--- a/tests/test_profile/config.yaml
+++ b/tests/test_profile/config.yaml
@@ -11,3 +11,11 @@ set-resources:
     mem_mb: max(1024*24*input.size_mb, 1)
     spam_factor: X
     double_jeopardy: attempt
+
+groups:
+  a: grp1
+  b: grp1
+  c: grp1
+
+group-components:
+  grp1: 5

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -763,6 +763,14 @@ def test_run_namedlist():
 
 def test_profile():
     run(dpath("test_profile"))
+    
+    from snakemake.profiles import ProfileConfigFileParser
+    grouped_profile = Path(dpath("test_profile")) / "config.yaml"
+    with grouped_profile.open("r") as f:
+        parser = ProfileConfigFileParser()
+        result = parser.parse(f)
+        assert result["groups"] == list(["a=grp1", "b=grp1", "c=grp1"])
+        assert result["group-components"] == list(["grp1=5"])
 
 
 @skip_on_windows

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -763,8 +763,9 @@ def test_run_namedlist():
 
 def test_profile():
     run(dpath("test_profile"))
-    
+
     from snakemake.profiles import ProfileConfigFileParser
+
     grouped_profile = Path(dpath("test_profile")) / "config.yaml"
     with grouped_profile.open("r") as f:
         parser = ProfileConfigFileParser()


### PR DESCRIPTION
This bug Fixes https://github.com/snakemake/snakemake/issues/3039 

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced profile configuration parser to support new keys: `groups` and `group-components`.
	- Updated configuration file to define groups and their components.

- **Bug Fixes**
	- Improved parsing logic to maintain consistency with existing keys.

- **Tests**
	- Introduced a new test function to validate the parsing of profile configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->