### PR TITLE
chore(deps): allow pulp 2.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     nbformat
     packaging
     psutil
-    pulp >=2.3.1,<2.9 # pulp introduced a breaking change from 2.7 to 2.8. Hence we should always pin to the minor version.
+    pulp >=2.3.1,<2.10 # pulp introduced a breaking change from 2.7 to 2.8. Hence we should always pin to the minor version.
     pyyaml
     requests >=2.8.1,<3.0
     reretry


### PR DESCRIPTION
<!--Add a description of your PR here-->

Loosens the dependency bound on `pulp` to allow the 2.9.x series.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. **Existing tests still pass.**
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **I don’t believe a documentation change is required.**

### Notes

I see that you had trouble with a breaking change from pulp 2.7.0 to 2.8.0,

https://github.com/snakemake/snakemake/blob/c1cc6056d368563c36a30146273bffca25f5f59c/setup.cfg#L49

so this may merit a little additional scrutiny. The complete source diff is https://github.com/coin-or/pulp/compare/2.8.0...2.9.0, and the changelog is:

```
2.9.0 2024-07-12
    HiGHS available as solver
    added HiGHS_CMD to github actions
    deactivated warnings on msg=False
    minor fixes
```

…which *looks* innocuous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `pulp` package, allowing compatibility with newer versions up to but not including 2.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->