### PR TITLE
fix: fix bug in code change detection leading to spurious code change reporting when relying on older snakemake metadata

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -475,7 +475,7 @@ class Persistence(PersistenceExecutorInterface):
     def _code_changed(self, job, file=None):
         assert file is not None
         fmt_version = self.record_format_version(file)
-        if fmt_version is not None and fmt_version < 3:
+        if fmt_version is None or fmt_version < 3:
             # no reliable code stored
             return False
         recorded = self.code(file)

--- a/tests/test_params_outdated_code/Snakefile
+++ b/tests/test_params_outdated_code/Snakefile
@@ -5,9 +5,6 @@ This is a test for the params syntax.
 shell.executable("bash")
 
 rule:
-	input: "somedir/test.out"
-
-rule:
 	params: lambda wildcards: "-f", dir="{dir}"
 	output: "{dir}/test.out"
 	shell: "rm -r {params.dir}; mkdir -p {params.dir}; touch {params[0]} {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -264,10 +264,10 @@ def test_params():
     run(dpath("test_params"))
 
 
-def test_params_outdated_code(mocker):
+def test_params_outdated_metadata(mocker):
     spy = mocker.spy(Persistence, "has_outdated_metadata")
 
-    run(dpath("test_params_outdated_code"))
+    run(dpath("test_params_outdated_code"), targets=["somedir/test.out"])
     assert spy.spy_return == True
 
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of code version checks by updating the condition for determining if code can be reliably identified.
  
- **New Features**
	- Updated parameters syntax in the Snakefile for better functionality.
	- Expanded test coverage with new test functions focusing on various aspects of the Snakemake workflow.

- **Style**
	- Minor formatting adjustments for improved code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->