### PR TITLE
feat: add derived flag for marking params as being derived from e.g. input or output files. For such params, Snakemake does not trigger reruns upon change (since the original (e.g. input) value change is already enough)

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1092,7 +1092,7 @@ Similar to ``input``, ``params`` can take functions as well (see :ref:`snakefile
         input:
             ...
         params:
-            prefix=lambda wildcards, output: output[0][:-4]
+            prefix=lambda wildcards, output: derived(output[0][:-4])
         output:
             "somedir/{sample}.csv"
         shell:
@@ -1108,6 +1108,9 @@ to get the same effect as above. Note that in contrast to the ``input`` directiv
 From the Python perspective, they can be seen as optional keyword arguments without a default value.
 Their order does not matter, apart from the fact that ``wildcards`` has to be the first argument.
 In the example above, this allows you to derive the prefix name from the output file.
+
+**Importantly** we here mark the derived path with ``derived()``.
+This denotes that the value is derived from another property of the rule (here the output file) and does not trigger reruns when changing (since the original value change is trigger enough).
 
 .. _snakefiles-external_scripts:
 

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1121,6 +1121,32 @@ def temp(value):
     return flag(value, "temp")
 
 
+class Derived:
+    pass
+
+
+class DerivedStr(str):
+    pass
+
+
+class DerivedPath(Path):
+    pass
+
+
+def derived(value: Union[str, Path]):
+    """Mark a value as derived from other rule properties like input or output files.
+    This can be used to ensure that certain params do not trigger reruns when they change.
+    """
+    if isinstance(value, str):
+        return DerivedStr(value)
+    elif isinstance(value, Path):
+        return DerivedPath(value)
+    else:
+        raise WorkflowError(
+            f"Values marked with derived flag must be a string or a Path, given {value} {type(value)}."
+        )
+
+
 @dataclass
 class QueueInfo:
     queue: queue.Queue

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -66,6 +66,7 @@ from snakemake.scheduler import JobScheduler
 from snakemake.parser import parse
 import snakemake.io
 from snakemake.io import (
+    derived,
     protected,
     temp,
     temporary,
@@ -212,6 +213,7 @@ class Workflow(WorkflowExecutorInterface):
         _globals["gitlab"] = sourcecache.GitlabFile
         _globals["gitfile"] = sourcecache.LocalGitFile
         _globals["storage"] = self._storage_registry
+        _globals["derived"] = derived
         snakemake.ioutils.register_in_globals(_globals)
         snakemake.ioflags.register_in_globals(_globals)
         _globals["from_queue"] = from_queue


### PR DESCRIPTION

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for Snakemake workflows, including new features like parameter handling, template rendering, and MPI support.
	- Introduced continuous input handling and output file updating capabilities.
	- Added service rules for resource management in workflows.
	- Improved job properties and code tracking mechanisms.

- **Bug Fixes**
	- Enhanced serialization methods for job parameters to improve robustness.

- **Documentation**
	- Updated documentation with clearer explanations and examples for new functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->