### PR TITLE
fix: ignore derived parameters when storing job metadata and inferring rerun necessity of jobs (this gets rid of spurious triggers caused by e.g. changed resources, threads, remote storage configuration)

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -222,6 +222,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         "_params_and_resources_resetted",
         "_queue_input",
         "_aux_resources",
+        "_non_derived_params",
     ]
 
     def __init__(
@@ -275,6 +276,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         self._inputsize = None
         self._is_updated = False
         self._params_and_resources_resetted = False
+        self._non_derived_params = None
 
         self._attempt = self.dag.workflow.attempt
         self._aux_resources = dict()
@@ -419,10 +421,19 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
     @property
     def params(self):
         if self._params is None:
-            self._params = self.rule.expand_params(
-                self.wildcards_dict, self.input, self.output, self
-            )
+            self._expand_params()
         return self._params
+
+    @property
+    def non_derived_params(self):
+        if self._non_derived_params is None:
+            self._expand_params()
+        return self._non_derived_params
+
+    def _expand_params(self):
+        self._params, self._non_derived_params = self.rule.expand_params(
+            self.wildcards_dict, self.input, self.output, self
+        )
 
     @property
     def log(self):

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -455,14 +455,13 @@ class Persistence(PersistenceExecutorInterface):
 
         changes = NO_PARAMS_CHANGE
 
-        fmt_version = self.record_format_version(file)
-        if fmt_version is None or fmt_version < 4:
-            # no reliable params stored
-            return changes
-
         new = set(self._params(job))
 
         for outfile in files:
+            fmt_version = self.record_format_version(outfile)
+            if fmt_version is None or fmt_version < 4:
+                # no reliable params stored
+                continue
             recorded = self.params(outfile)
             if recorded is not None:
                 old = set(recorded)

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -12,7 +12,7 @@ import stat
 import tempfile
 import time
 from base64 import urlsafe_b64encode, b64encode
-from functools import lru_cache, partial
+from functools import lru_cache
 from itertools import count
 from pathlib import Path
 from contextlib import contextmanager

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -12,7 +12,7 @@ import stat
 import tempfile
 import time
 from base64 import urlsafe_b64encode, b64encode
-from functools import lru_cache
+from functools import lru_cache, partial
 from itertools import count
 from pathlib import Path
 from contextlib import contextmanager
@@ -454,6 +454,12 @@ class Persistence(PersistenceExecutorInterface):
         files = [file] if file is not None else job.output
 
         changes = NO_PARAMS_CHANGE
+
+        fmt_version = self.record_format_version(file)
+        if fmt_version is None or fmt_version < 4:
+            # no reliable params stored
+            return changes
+
         new = set(self._params(job))
 
         for outfile in files:
@@ -543,11 +549,11 @@ class Persistence(PersistenceExecutorInterface):
     def _log(self, job):
         return sorted(job.log)
 
-    def _serialize_param_builtin(self, param):
+    def _serialize_param_builtin(self, value: Any):
         if (
-            param is None
+            value is None
             or isinstance(
-                param,
+                value,
                 (
                     int,
                     float,
@@ -564,25 +570,25 @@ class Persistence(PersistenceExecutorInterface):
                     bytearray,
                 ),
             )
-            and param is not TBDString
+            and value is not TBDString
         ):
-            return repr(param)
+            return repr(value)
         else:
             return UNREPRESENTABLE
 
-    def _serialize_param_pandas(self, param):
+    def _serialize_param_pandas(self, value: Any):
         import pandas as pd
 
-        if isinstance(param, (pd.DataFrame, pd.Series, pd.Index)):
-            return repr(pd.util.hash_pandas_object(param).tolist())
-        return self._serialize_param_builtin(param)
+        if isinstance(value, (pd.DataFrame, pd.Series, pd.Index)):
+            return repr(pd.util.hash_pandas_object(value).tolist())
+        return self._serialize_param_builtin(value)
 
     @lru_cache()
-    def _params(self, job):
+    def _params(self, job: Job):
         return sorted(
             filter(
                 lambda p: p is not UNREPRESENTABLE,
-                map(self._serialize_param, job.params),
+                (self._serialize_param(value) for value in job.non_derived_params),
             )
         )
 

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -845,6 +845,7 @@ class Rule(RuleInterface):
 
         return input, mapping, dependencies, incomplete
 
+    @classmethod
     def _is_deriving_function(func):
         if is_callable(func):
             func_params = get_function_params(func)

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -846,7 +846,7 @@ class Rule(RuleInterface):
         return input, mapping, dependencies, incomplete
 
     @classmethod
-    def _is_deriving_function(func):
+    def _is_deriving_function(cls, func):
         if is_callable(func):
             func_params = get_function_params(func)
             return (

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -696,6 +696,7 @@ class Rule(RuleInterface):
         incomplete_checkpoint_func=lambda e: None,
         allow_unpack=True,
         groupid=None,
+        non_derived_items: typing.List[typing.Any] = None,
     ):
         incomplete = False
         if aux_params is None:
@@ -705,6 +706,7 @@ class Rule(RuleInterface):
             start = len(newitems)
             is_unpack = is_flagged(item, "unpack")
             _is_callable = is_callable(item)
+            is_derived = False
 
             if _is_callable:
                 if omit_callable:
@@ -717,6 +719,8 @@ class Rule(RuleInterface):
                     groupid=groupid,
                     **aux_params,
                 )
+                if non_derived_items is not None:
+                    is_derived = self._is_deriving_function(item)
 
             if is_unpack and not incomplete:
                 if not allow_unpack:
@@ -739,14 +743,22 @@ class Rule(RuleInterface):
                     )
                 # Allow streamlined code with/without unpack
                 if isinstance(item, list):
-                    pairs = zip([None] * len(item), item, [_is_callable] * len(item))
+                    apply_results = zip(
+                        [None] * len(item),
+                        item,
+                        [_is_callable] * len(item),
+                        [is_derived] * len(item),
+                    )
                 else:
                     assert isinstance(item, dict)
-                    pairs = [(name, item, _is_callable) for name, item in item.items()]
+                    apply_results = [
+                        (name, item, _is_callable, is_derived)
+                        for name, item in item.items()
+                    ]
             else:
-                pairs = [(name, item, _is_callable)]
+                apply_results = [(name, item, _is_callable, is_derived)]
 
-            for name, item, from_callable in pairs:
+            for name, item, from_callable, is_derived in apply_results:
                 is_iterable = True
                 if not_iterable(item) or no_flattening:
                     item = [item]
@@ -770,6 +782,8 @@ class Rule(RuleInterface):
 
                     concrete = concretize(item_, wildcards, _is_callable)
                     newitems.append(concrete)
+                    if not is_derived and non_derived_items is not None:
+                        non_derived_items.append(concrete)
                     if mapping is not None:
                         mapping[concrete] = olditem
 
@@ -831,6 +845,18 @@ class Rule(RuleInterface):
 
         return input, mapping, dependencies, incomplete
 
+    def _is_deriving_function(func):
+        if is_callable(func):
+            func_params = get_function_params(func)
+            if (
+                "input" in func_params
+                or "output" in func_params
+                or "threads" in func_params
+                or "resources" in func_params
+            ):
+                return True
+        return False
+
     def expand_params(self, wildcards, input, output, job, omit_callable=False):
         def concretize_param(p, wildcards, is_from_callable):
             if not is_from_callable:
@@ -862,6 +888,7 @@ class Rule(RuleInterface):
         threads = lambda: job.resources._cores
 
         params = Params()
+        non_derived_params = []
         try:
             # When applying wildcards to params, the return type need not be
             # a string, so the check is disabled.
@@ -882,6 +909,7 @@ class Rule(RuleInterface):
                     "threads": threads,
                 },
                 incomplete_checkpoint_func=handle_incomplete_checkpoint,
+                non_derived_items=non_derived_params,
             )
         except WildcardError as e:
             raise WildcardError(
@@ -894,7 +922,7 @@ class Rule(RuleInterface):
                 str(e),
                 rule=self,
             )
-        return params
+        return params, non_derived_params
 
     def expand_output(self, wildcards):
         output = OutputFiles(o.apply_wildcards(wildcards) for o in self.output)

--- a/snakemake/rules.py
+++ b/snakemake/rules.py
@@ -848,13 +848,12 @@ class Rule(RuleInterface):
     def _is_deriving_function(func):
         if is_callable(func):
             func_params = get_function_params(func)
-            if (
+            return (
                 "input" in func_params
                 or "output" in func_params
                 or "threads" in func_params
                 or "resources" in func_params
-            ):
-                return True
+            )
         return False
 
     def expand_params(self, wildcards, input, output, job, omit_callable=False):


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parameter management in the Job class for better handling of non-derived parameters.
	- Improved input function handling in the Rule class, allowing for differentiation between derived and non-derived parameters.

- **Bug Fixes**
	- Updated methods in the Persistence class to ensure type safety and clarity.

- **Documentation**
	- Added type hints to method signatures for improved code understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->