### PR TITLE
fix: proper error message if conda info fails

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -693,9 +693,15 @@ class Conda:
                 container_img = container_img.path
             self.container_img = container_img
 
-            self.info = json.loads(
-                shell.check_output(self._get_cmd("conda info --json"), text=True)
-            )
+            try:
+                self.info = json.loads(
+                    shell.check_output(self._get_cmd("conda info --json"), text=True)
+                )
+            except subprocess.CalledProcessError as e:
+                raise WorkflowError(
+                    "Error running conda info. "
+                    f"Is conda installed and accessible? Error: {e}"
+                )
 
             if prefix_path is None or container_img is not None:
                 self.prefix_path = self.info["conda_prefix"]


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for the `Conda` class to catch and report errors during the retrieval of conda information.
	- Corrected indentation for better readability in the `__init__` method of the `Conda` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->