### PR TITLE
fix: fix bug with --edit-notebook sessions causing output files marked as incomplete, fix bug leading to missing log file after edit notebook sessions

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -525,6 +525,13 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             and job.targetfile in self.targetfiles
         )
 
+    def is_draft_notebook_job(self, job):
+        return (
+            self.workflow.execution_settings.edit_notebook
+            and self.workflow.execution_settings.edit_notebook.draft_only
+            and job.targetfile in self.targetfiles
+        )
+
     def get_job_group(self, job):
         return self._group.get(job)
 

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1121,6 +1121,11 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         error=False,
         ignore_missing_output=False,
     ):
+        if self.dag.is_draft_notebook_job(self):
+            # no output produced but have to delete incomplete marker
+            self.dag.workflow.persistence.remove_incomplete_marker(self)
+            return
+
         shared_input_output = (
             SharedFSUsage.INPUT_OUTPUT
             in self.dag.workflow.storage_settings.shared_fs_usage

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1123,7 +1123,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
     ):
         if self.dag.is_draft_notebook_job(self):
             # no output produced but have to delete incomplete marker
-            self.dag.workflow.persistence.remove_incomplete_marker(self)
+            self.dag.workflow.persistence.cleanup(self)
             return
 
         shared_input_output = (
@@ -1134,49 +1134,56 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
             SharedFSUsage.STORAGE_LOCAL_COPIES
             in self.dag.workflow.storage_settings.shared_fs_usage
         )
-        if (
-            self.dag.workflow.exec_mode == ExecMode.SUBPROCESS
-            or shared_input_output
-            or (self.dag.workflow.remote_exec and not shared_input_output)
-            or self.is_local
-        ):
-            if not error and handle_touch:
-                self.dag.handle_touch(self)
-            if handle_log:
-                await self.dag.handle_log(self)
-            if not error:
-                await self.dag.check_and_touch_output(
-                    self,
-                    wait=self.dag.workflow.execution_settings.latency_wait,
-                    ignore_missing_output=ignore_missing_output,
-                    # storage not yet handled, just require the local files
-                    wait_for_local=True,
-                )
-            self.dag.unshadow_output(self, only_log=error)
-
+        try:
             if (
-                not error
-                and self.rule.is_template_engine
-                and not is_flagged(self.output[0], "temp")
+                self.dag.workflow.exec_mode == ExecMode.SUBPROCESS
+                or shared_input_output
+                or (self.dag.workflow.remote_exec and not shared_input_output)
+                or self.is_local
             ):
-                # TODO also check if consumers are executed on the same node
-                check_template_output(self)
+                if not error and handle_touch:
+                    self.dag.handle_touch(self)
+                if handle_log:
+                    await self.dag.handle_log(self)
+                if not error:
+                    await self.dag.check_and_touch_output(
+                        self,
+                        wait=self.dag.workflow.execution_settings.latency_wait,
+                        ignore_missing_output=ignore_missing_output,
+                        # storage not yet handled, just require the local files
+                        wait_for_local=True,
+                    )
+                self.dag.unshadow_output(self, only_log=error)
 
-            await self.dag.handle_storage(
-                self, store_in_storage=store_in_storage, store_only_log=error
-            )
-            if not error:
-                self.dag.handle_protected(self)
-        elif not shared_input_output and not wait_for_local and not error:
-            expanded_output = list(self.output)
-            if self.benchmark:
-                expanded_output.append(self.benchmark)
-            await wait_for_files(
-                expanded_output,
-                wait_for_local=False,
-                latency_wait=self.dag.workflow.execution_settings.latency_wait,
-                ignore_pipe_or_service=True,
-            )
+                if (
+                    not error
+                    and self.rule.is_template_engine
+                    and not is_flagged(self.output[0], "temp")
+                ):
+                    # TODO also check if consumers are executed on the same node
+                    check_template_output(self)
+
+                await self.dag.handle_storage(
+                    self, store_in_storage=store_in_storage, store_only_log=error
+                )
+                if not error:
+                    self.dag.handle_protected(self)
+            elif not shared_input_output and not wait_for_local and not error:
+                expanded_output = list(self.output)
+                if self.benchmark:
+                    expanded_output.append(self.benchmark)
+                await wait_for_files(
+                    expanded_output,
+                    wait_for_local=False,
+                    latency_wait=self.dag.workflow.execution_settings.latency_wait,
+                    ignore_pipe_or_service=True,
+                )
+
+        except Exception as e:
+            # cleanup metadata in case of any exception above
+            self.dag.workflow.persistence.cleanup(self)
+            raise e
+
         if not error:
             try:
                 await self.dag.workflow.persistence.finished(self)

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1121,11 +1121,6 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         error=False,
         ignore_missing_output=False,
     ):
-        if self.dag.is_edit_notebook_job(self):
-            # No postprocessing necessary, we have just created the skeleton notebook and
-            # execution will anyway stop afterwards.
-            return
-
         shared_input_output = (
             SharedFSUsage.INPUT_OUTPUT
             in self.dag.workflow.storage_settings.shared_fs_usage

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -292,10 +292,14 @@ class Persistence(PersistenceExecutorInterface):
         for f in job.output:
             self._record(self._incomplete_path, {"external_jobid": external_jobid}, f)
 
+    def remove_incomplete_marker(self, job):
+        for f in job.output:
+            self._delete_record(self._incomplete_path, f)
+
     async def finished(self, job):
+        self.remove_incomplete_marker(job)
         if not self.dag.workflow.execution_settings.keep_metadata:
-            for f in job.output:
-                self._delete_record(self._incomplete_path, f)
+            # do not store metadata if not requested
             return
 
         code = self._code(job.rule)
@@ -346,7 +350,6 @@ class Persistence(PersistenceExecutorInterface):
                 },
                 f,
             )
-            self._delete_record(self._incomplete_path, f)
 
     def cleanup(self, job):
         for f in job.output:

--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -292,12 +292,13 @@ class Persistence(PersistenceExecutorInterface):
         for f in job.output:
             self._record(self._incomplete_path, {"external_jobid": external_jobid}, f)
 
-    def remove_incomplete_marker(self, job):
+    def _remove_incomplete_marker(self, job):
         for f in job.output:
             self._delete_record(self._incomplete_path, f)
 
     async def finished(self, job):
-        self.remove_incomplete_marker(job)
+        self._remove_incomplete_marker(job)
+
         if not self.dag.workflow.execution_settings.keep_metadata:
             # do not store metadata if not requested
             return


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for executing and editing notebooks, including improved output handling and saving of modified notebooks.
	- Introduced a method to identify draft notebook jobs, enhancing job classification.

- **Bug Fixes**
	- Simplified postprocessing for draft notebook jobs, ensuring consistent handling across all job types.

- **Refactor**
	- Streamlined logic for determining output file paths in notebook execution.
	- Improved organization of job completion and metadata handling in persistence management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->