### PR TITLE
feat: add first 5 rules to group name (used e.g. when naming cluster/cloud jobs or logfiles)

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1528,7 +1528,10 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
 
     @property
     def name(self):
-        return str(self.groupid)
+        rules = sorted({job.rule.name for job in self.jobs})
+        if len(rules) > 5:
+            rules = rules[:5] + ["..."]
+        return f"{self.groupid}_{'_'.join(rules)}"
 
     def check_protected_output(self):
         for job in self.jobs:


### PR DESCRIPTION
<!--Add a description of your PR here-->
fixes https://github.com/snakemake/snakemake-executor-plugin-slurm/issues/154

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the naming of group jobs to include associated rule names, improving readability and context.
	- Implemented truncation for long lists of rule names, ensuring clarity.

- **Bug Fixes**
	- Minor adjustments made to the formatting of the group job's name for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->