### PR TITLE
fix: use permission safe copying when hidden conda files are already present in a workdir. This avoids problems in case multiple people use the same workdir and workflow.

### DIFF
--- a/snakemake/common/__init__.py
+++ b/snakemake/common/__init__.py
@@ -10,6 +10,7 @@ import operator
 import platform
 import hashlib
 import inspect
+import shutil
 import sys
 import uuid
 import os
@@ -343,3 +344,15 @@ def is_namedtuple_instance(x):
     if not isinstance(f, tuple):
         return False
     return all(type(n) is str for n in f)
+
+
+def copy_permission_safe(src: str, dst: str):
+    """Copy a file to a given destination.
+
+    If destination exists, it is removed first in order to avoid permission issues when
+    the destination permissions are tried to be applied to an already existing
+    destination.
+    """
+    if os.path.exists(dst):
+        os.unlink(dst)
+    shutil.copy(src, dst)

--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -31,6 +31,7 @@ from abc import ABC, abstractmethod
 from snakemake.exceptions import CreateCondaEnvironmentException, WorkflowError
 from snakemake.logging import logger
 from snakemake.common import (
+    copy_permission_safe,
     is_local_file,
     parse_uri,
     ON_WINDOWS,
@@ -540,7 +541,7 @@ class Env:
                         # In addition, this allows to immediately see what an
                         # environment in .snakemake/conda contains.
                         target_env_file = env_path + f".{filetype}"
-                        shutil.copy(env_file, target_env_file)
+                        copy_permission_safe(env_file, target_env_file)
 
                         logger.info("Downloading and installing remote packages.")
 
@@ -619,7 +620,7 @@ class Env:
                 # Execute post-deploy script if present
                 if deploy_file:
                     target_deploy_file = env_path + ".post-deploy.sh"
-                    shutil.copy(deploy_file, target_deploy_file)
+                    copy_permission_safe(deploy_file, target_deploy_file)
                     self.execute_deployment_script(env_file, target_deploy_file)
 
                 # Touch "done" flag file


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to enhance file copying while managing permissions effectively.

- **Bug Fixes**
	- Improved handling of file permissions during the copying of environment files and deployment scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->