### PR TITLE
fix: skip storage object when cloning flags for shadowed IO

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -677,7 +677,9 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         if not self.shadow_dir:
             return f
         f_ = IOFile(os.path.join(self.shadow_dir, f), self.rule)
-        f_.clone_flags(f)
+        # The shadowed path does not need the storage object, storage will be handled
+        # after shadowing.
+        f_.clone_flags(f, skip_storage_object=True)
         return f_
 
     @property


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of flags when cloning from input files to shadowed files, enhancing the management of shadowed file properties.

- **Refactor**
	- Streamlined the `shadowed_path` method for better efficiency by skipping the storage object during the cloning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->