### PR TITLE
fix: ensure correct topological order when touching group job outputs

### DIFF
--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1514,8 +1514,8 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
     async def postprocess(self, error=False, **kwargs):
         # Iterate over jobs in toposorted order (see self.__iter__) to
         # ensure that outputs are touched in correct order.
-        async with asyncio.TaskGroup() as tg:
-            for level in self.toposorted:
+        for level in self.toposorted:
+            async with asyncio.TaskGroup() as tg:
                 for job in level:
                     # postprocessing involves touching output files (to ensure that
                     # modification times are always correct. This has to happen in


### PR DESCRIPTION
fixes #3165

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved management of asynchronous tasks in job processing, enhancing performance and reliability.
	- Updated output verification process for jobs to ensure protected outputs are correctly checked.

- **Refactor**
	- Reorganized task creation logic to streamline job processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->