### PR TITLE
chore: do not compare checksum after tailwind download, as the returned CSS is not stable for even the same release

### DIFF
--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -32,9 +32,11 @@ class Asset:
             except urllib.error.URLError as e:
                 err = AssetDownloadError(f"Failed to download asset {self.url}: {e}")
                 continue
-            if self.sha256 != hashlib.sha256(content).hexdigest():
+            content_sha = hashlib.sha256(content).hexdigest()
+            if self.sha256 != content_sha:
                 err = AssetDownloadError(
-                    f"Checksum mismatch when downloading asset {self.url}"
+                    f"Checksum mismatch when downloading asset {self.url} "
+                    f"(sha: {content_sha}). First 100 bytes:\n{content[:100].decode()}"
                 )
                 continue
             return content

--- a/snakemake/assets/__init__.py
+++ b/snakemake/assets/__init__.py
@@ -62,7 +62,7 @@ class Assets:
         ),
         "tailwindcss/tailwind.css": Asset(
             url="https://cdn.tailwindcss.com/3.0.23?plugins=forms@0.4.0,typography@0.5.2",
-            # The tailwindcss cdn checksum is not stable. Since this is only included 
+            # The tailwindcss cdn checksum is not stable. Since this is only included
             # as CSS styles, the risk is low.
         ),
         "react/LICENSE": Asset(


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for asset downloads, providing clearer error messages in case of checksum mismatches.
	- Improved checksum validation logic for downloaded content.

- **Chores**
	- Refined control flow for asset download attempts, maintaining up to six retries before an error is raised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->