### PR TITLE
fix: correctly set params in bash scripts

### DIFF
--- a/snakemake/script/__init__.py
+++ b/snakemake/script/__init__.py
@@ -1450,7 +1450,6 @@ class BashScript(ScriptBase):
         dicts = ["config"]
         encoder = BashEncoder(namedlists=namedlists, dicts=dicts)
         preamble = encoder.encode_snakemake(snakemake)
-        print(preamble)
         return preamble
 
     def get_preamble(self):

--- a/snakemake/script/__init__.py
+++ b/snakemake/script/__init__.py
@@ -419,7 +419,8 @@ class BashEncoder:
         for var in vars(smk):
             val = getattr(smk, var)
             if var in self.namedlists:
-                aa = f"{self.prefix}_{var.strip('_').lower()}={self.encode_namedlist(val)}"
+                suffix = "params" if var == "_params_store" else var.strip("_").lower()
+                aa = f"{self.prefix}_{suffix}={self.encode_namedlist(val)}"
                 arrays.append(aa)
             elif var in self.dicts:
                 aa = f"{self.prefix}_{var.strip('_').lower()}={self.dict_to_aa(val)}"
@@ -1438,10 +1439,18 @@ class BashScript(ScriptBase):
             scriptdir=path.get_basedir().get_path_or_uri(),
         )
 
-        namedlists = ["input", "output", "log", "resources", "wildcards", "params"]
+        namedlists = [
+            "input",
+            "output",
+            "log",
+            "resources",
+            "wildcards",
+            "_params_store",
+        ]
         dicts = ["config"]
         encoder = BashEncoder(namedlists=namedlists, dicts=dicts)
         preamble = encoder.encode_snakemake(snakemake)
+        print(preamble)
         return preamble
 
     def get_preamble(self):

--- a/tests/test_script/Snakefile
+++ b/tests/test_script/Snakefile
@@ -104,7 +104,7 @@ rule:
 rule bash:
     input:
         "test2.in",
-        named_input="test.in",
+        named="test.in",
     output:
         "bash.out"
     params:

--- a/tests/test_script/scripts/test.sh
+++ b/tests/test_script/scripts/test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+test "${snakemake_params[string]}" = "foo"
+
 echo "The first input file is ${snakemake_input[0]}" > "${snakemake_output[0]}" 2> "${snakemake_log[0]}"
 echo "The named input file is ${snakemake_input[named]}" >> "${snakemake_output[0]}" 2>> "${snakemake_log[0]}"
 echo "The requested number of threads is ${snakemake[threads]}" >> "${snakemake_output[0]}" 2>> "${snakemake_log[0]}"

--- a/tests/test_script/scripts/test.sh
+++ b/tests/test_script/scripts/test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-
+set -euo pipefail
+exec 2> "${snakemake_log[0]}"
 test "${snakemake_params[string]}" = "foo"
 
 echo "The first input file is ${snakemake_input[0]}" > "${snakemake_output[0]}" 2> "${snakemake_log[0]}"


### PR DESCRIPTION
<!--Add a description of your PR here-->

This PR tweaks the Bash script test to trigger the bug raised in #3187 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced error handling in the script with improved shell options.
	- Added a conditional test to validate parameters before executing existing commands.
	- Updated input parameter in the `bash` rule for clarity without affecting functionality.
- **New Features**
	- Improved parameter handling in the Bash script generation process for enhanced functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->