### PR TITLE
fix: When generating a DAG or HTML rulegraph, use consistent colours

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2323,11 +2323,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         node2style=lambda node: "rounded",
         node2label=lambda node: node,
     ):
-        # color rules
-        huefactor = 2 / (3 * len(self.rules))
+        # color the rules - sorting by name first gives deterministic output
+        rules = sorted(self.rules, key=lambda r: r.name)
+        huefactor = 2 / (3 * len(rules))
         rulecolor = {
             rule: "{:.2f} 0.6 0.85".format(i * huefactor)
-            for i, rule in enumerate(self.rules)
+            for i, rule in enumerate(rules)
         }
 
         # markup
@@ -2392,10 +2393,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 hex_r=hex_r, hex_g=hex_g, hex_b=hex_b
             )
 
-        huefactor = 2 / (3 * len(self.rules))
+        # Sorting the rules by name before assigning colors gives deterministic output
+        rules = sorted(self.rules, key=lambda r: r.name)
+        huefactor = 2 / (3 * len(rules))
         rulecolor = {
             rule: hsv_to_htmlhexrgb(i * huefactor, 0.6, 0.85)
-            for i, rule in enumerate(self.rules)
+            for i, rule in enumerate(rules)
         }
 
         def resolve_input_functions(input_files):


### PR DESCRIPTION
### Summary

When generating a DAG or HTML rulegraph, use consistent colours for the different rules (resolves issue #1709).

This PR just sorts the set of rules prior to making the colour map, as sets in Python are enumerated in arbitrary order and this is what leads to the random colour assignment.

### QC

I believe any regression should be covered by existing tests (and testing for [in]consistency is very tricky.) I don't see anywhere in the docs that it says the colours will or will not be be randomised each time, so no change needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual representation of the Directed Acyclic Graph (DAG) with improved rule coloring based on sorted names for consistent output.
  
- **Documentation**
	- Updated comments to clarify the new sorting behavior for rule coloring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->