### PR TITLE
fix: Remove incomplete marker for job finished only after metadata is written

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -298,8 +298,6 @@ class Persistence(PersistenceExecutorInterface):
             self._delete_record(self._incomplete_path, f)
 
     async def finished(self, job):
-        self._remove_incomplete_marker(job)
-
         if not self.dag.workflow.execution_settings.keep_metadata:
             # do not store metadata if not requested
             return
@@ -354,6 +352,7 @@ class Persistence(PersistenceExecutorInterface):
                 },
                 f,
             )
+        self._remove_incomplete_marker(job)
 
     def cleanup(self, job):
         for f in job.output:


### PR DESCRIPTION
This PR makes Snakemake remove the incomplete marker for a job thats finished only after the metadata is written. Otherwise the jobs starttime for the report was missing in the metadata and caused problems in the plot for the runtimes of individual jobs.