### PR TITLE
fix: clean env vars in apptainer

### DIFF
--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -127,7 +127,7 @@ def shellcmd(
     if container_workdir:
         args += f" --pwd {repr(container_workdir)}"
 
-    cmd = "{} singularity {} exec --home {} {} {} {} -c '{}'".format(
+    cmd = "{} singularity {} exec --cleanenv --home {} {} {} {} -c '{}'".format(
         envvars,
         "--quiet --silent" if quiet else "",
         repr(os.getcwd()),


### PR DESCRIPTION
<!--Add a description of your PR here-->

The apptainer command used in snakemake now does not have `--cleanenv` (or `-e`) option. The envinronment variables in the host (e.g. PYTHONPATH or CONDA_EXE) will be passed to the container. This may affect reproducibility and even cause some errors. This PR proposes adding the `--cleanenv` option to the apptainer commmand to avoid passing host environment variables. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Singularity command execution by adding the `--cleanenv` option, ensuring a clean environment for better handling of environment variables during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->