### PR TITLE
fix: Remove incomplete marker also when drop-metadata is active

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -299,6 +299,7 @@ class Persistence(PersistenceExecutorInterface):
 
     async def finished(self, job):
         if not self.dag.workflow.execution_settings.keep_metadata:
+            self._remove_incomplete_marker(job)
             # do not store metadata if not requested
             return
 
@@ -352,6 +353,8 @@ class Persistence(PersistenceExecutorInterface):
                 },
                 f,
             )
+        #remove incomplete marker only after creation of metadata record.
+        #otherwise the job starttime will be missing. 
         self._remove_incomplete_marker(job)
 
     def cleanup(self, job):


### PR DESCRIPTION
Fix: This PR adds back the removal of the incomplete marker file also when keep_metadata is False (i.e. --drop-metadata is active).  

The removal calls were merged and put at the start of the function in #3162, but this caused loss of starttime info in the metadata record. In #3197 this was fixed, but by moving the removal call to the end of the function, the incomplete tracker file was not removed anymore when --drop-metadata was active.  This PR adds the call to the removal function back also for that case, and adds a note to inform why the code is structured this way. 