### PR TITLE
feat: assume checkpoint safe temp files

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1656,6 +1656,17 @@ Further, an output file marked as ``temp`` is deleted after all rules that use i
         shell:
             "somecommand {input} {output}"
 
+
+When using checkpoint rules, Snakemake cannot determine whether temporary files are no longer needed until 
+all checkpoint jobs have been completed. This delay in removal may result in unexpectedly high storage usage.
+This behavior can be disabled by using the option ``--assume-checkpoint-safe-temp-files``. 
+However, if any temporary files might still be needed after future checkpoints, you must ensure they are not 
+deleted prematurely. To do so, include them as input of the checkpoint job (or any jobs dependent on the 
+checkpoint job)."
+
+
+
+
 .. _snakefiles-directory_output:
 
 Directories as outputs

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -847,6 +847,7 @@ def get_argument_parser(profiles=None):
         action="store_true",
         help=("Re-run all jobs the output of which is recognized as incomplete."),
     )
+
     group_exec.add_argument(
         "--shadow-prefix",
         metavar="DIR",
@@ -854,6 +855,19 @@ def get_argument_parser(profiles=None):
             "Specify a directory in which the 'shadow' directory is created. "
             "If not supplied, the value is set to the '.snakemake' directory relative "
             "to the working directory."
+        ),
+    )
+
+    group_exec.add_argument(
+        "--assume-checkpoint-safe-temp-files",
+        action="store_true",
+        help=(
+            "Assume that temporary files are safe to be deleted also when "
+            "checkpoint rules are used. Temporary files are otherwise kept "
+            "until all checkpoints are finished and the DAG is complete. In case temporary files "
+            "might be needed by jobs that will only be scheduled after checkpoint execution, "
+            "either this flag should not be used or ALL of the temporary files that might be "
+            "needed should be explicitly declared as input files of the checkpoint rule or its dependencies."
         ),
     )
 
@@ -2089,6 +2103,7 @@ def args_to_api(args, parser):
                             allowed_rules=args.allowed_rules,
                             rerun_triggers=args.rerun_triggers,
                             max_inventory_wait_time=args.max_inventory_time,
+                            assume_checkpoint_safe_temp_files=args.assume_checkpoint_safe_temp_files,
                         ),
                     )
 

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -112,17 +112,25 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         omitrules=None,
         ignore_incomplete=False,
     ):
+        self.workflow: _workflow.Workflow = workflow
+
         self._queue_input_jobs = None
+        # job -> {jobs that need to run before this job -> files needed}
         self._dependencies = defaultdict(partial(defaultdict, set))
+
+        # job -> {jobs that depend on this job -> files needed}
         self.depending = defaultdict(partial(defaultdict, set))
         self._needrun = set()
         self._checkpoint_jobs = set()
+        self.assume_checkpoint_safe_temp_files = (
+            self.workflow.dag_settings.assume_checkpoint_safe_temp_files
+        )
         self._priority = dict()
         self._reason = defaultdict(Reason)
         self._finished = set()
         self._has_unfinished_queue_input_jobs = None
         self._len = 0
-        self.workflow: _workflow.Workflow = workflow
+
         self.rules = set(rules)
         self.targetfiles = targetfiles
         self.targetrules = targetrules
@@ -185,10 +193,15 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
     @property
     def dependencies(self):
+        """Return the dependency graph as a dictionary mapping jobs
+        to {jobs that need to run before this job -> files needed}"""
         return self._dependencies
 
     @property
     def batch(self):
+        """Returns Batch object (containing rule name, batch index, and nr of batches) in case
+        the DAG is run in batch mode, otherwise None.
+        """
         return self.workflow.dag_settings.batch
 
     async def init(self, progress=False):
@@ -986,7 +999,13 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         progress=False,
         create_inventory=False,
     ):
-        """Update the DAG by adding given jobs and their dependencies."""
+        """Given a set of candidate jobs that might produce a file,
+        select the producer, and update the DAG.
+
+        Raises AmbiguousRuleException in case multiple jobs
+        can be producers.
+        """
+
         if visited is None:
             visited = set()
         if known_producers is None:
@@ -1957,9 +1976,10 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 self.create_conda_envs()
             potential_new_ready_jobs = True
 
-        if not self.checkpoint_jobs:
+        if self.assume_checkpoint_safe_temp_files or not self.checkpoint_jobs:
             # While there are still checkpoint jobs, we cannot safely delete
-            # temp files.
+            # temp files, unless the user has explicitly requested to do so.
+
             # TODO: we maybe could be more accurate and determine whether there is a
             # checkpoint that depends on the temp file.
             for job in jobs:

--- a/snakemake/settings/types.py
+++ b/snakemake/settings/types.py
@@ -202,6 +202,7 @@ class DAGSettings(SettingsBase):
     allowed_rules: AnySet[str] = frozenset()
     rerun_triggers: AnySet[RerunTrigger] = RerunTrigger.all()
     max_inventory_wait_time: int = 20
+    assume_checkpoint_safe_temp_files: bool = False
 
     def _check(self):
         if self.batch is not None and self.forceall:

--- a/tests/common.py
+++ b/tests/common.py
@@ -213,6 +213,7 @@ def run(
     storage_provider_settings=None,
     shared_fs_usage=None,
     benchmark_extended=False,
+    assume_checkpoint_safe_temp_files=False,
     apptainer_args="",
 ):
     """
@@ -369,6 +370,7 @@ def run(
                         force_incomplete=force_incomplete,
                         forceall=forceall,
                         rerun_triggers=rerun_triggers,
+                        assume_checkpoint_safe_temp_files=assume_checkpoint_safe_temp_files,
                     ),
                 )
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2287,6 +2287,15 @@ def test_github_issue2732():
     run(dpath("test_github_issue2732"))
 
 
+@skip_on_windows  # OS agnostic
+def test_assume_checkpoint_safe_temp_files():
+    run(
+        dpath("test_github_issue2732"),
+        assume_checkpoint_safe_temp_files=True,
+        shouldfail=True,
+    )
+
+
 @skip_on_windows
 @apptainer
 def test_shell_exec():


### PR DESCRIPTION
Snakemake can only ensure that temp files will not be needed anymore
after all checkpoint jobs have been executed (#609, #2732, fixed in #2737).
However, waiting for all checkpoint jobs to be completed can lead to
excessive storage use (#2982).

In most cases temp file usage is either unaffected by checkpoint jobs, or
can be explicitly managed by including the temp files as input to
checkpoint jobs or their downstream dependencies. This will ensure they
are kept on disk until they (might) be needed.

To address cases where pipelines using checkpoints become infeasible due
to high storage demands, this commit introduces a new command-line
option `--assume-checkpoint-safe-temp-files`. 

This option lets Snakemake know that it can  safely remove temporary files 
not required by current jobs, even if checkpoint jobs are still pending.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
