### PR TITLE
fix: ensure that intermediate files in job groups do not cause spurious mtime errors when checking for consistency with output files

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -677,11 +677,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
     async def check_and_touch_output(
         self,
-        job,
-        wait=3,
-        ignore_missing_output=False,
-        no_touch=False,
-        wait_for_local=True,
+        job: Job,
+        wait: int = 3,
+        ignore_missing_output: bool = False,
+        no_touch: bool = False,
+        wait_for_local: bool = True,
+        check_output_mtime: bool = True,
     ):
         """Raise exception if output files of job are missing."""
         # do not touch output in storage. This is done before by the touch executor.
@@ -733,7 +734,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 if await output_path.exists_local():
                     output_path.touch()
 
-        if wait_for_local:
+        if wait_for_local and check_output_mtime:
             await self.check_output_mtime(job, expanded_output)
 
     async def check_output_mtime(

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1521,7 +1521,7 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
             if i > 0:
                 # Wait a bit to ensure that subsequent levels really have distinct
                 # modification times.
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
             async with asyncio.TaskGroup() as tg:
                 for job in level:
                     # postprocessing involves touching output files (to ensure that

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -14,6 +14,7 @@ import functools
 
 from itertools import chain, filterfalse
 from operator import attrgetter
+import time
 from typing import Iterable, List, Optional
 from collections.abc import AsyncGenerator
 from abc import ABC, abstractmethod
@@ -1117,11 +1118,12 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
 
     async def postprocess(
         self,
-        store_in_storage=True,
-        handle_log=True,
-        handle_touch=True,
-        error=False,
-        ignore_missing_output=False,
+        store_in_storage: bool = True,
+        handle_log: bool = True,
+        handle_touch: bool = True,
+        error: bool = False,
+        ignore_missing_output: bool = False,
+        check_output_mtime: bool = True,
     ):
         if self.dag.is_draft_notebook_job(self):
             # no output produced but have to delete incomplete marker
@@ -1154,6 +1156,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
                         ignore_missing_output=ignore_missing_output,
                         # storage not yet handled, just require the local files
                         wait_for_local=True,
+                        check_output_mtime=check_output_mtime,
                     )
                 self.dag.unshadow_output(self, only_log=error)
 
@@ -1514,13 +1517,22 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
     async def postprocess(self, error=False, **kwargs):
         # Iterate over jobs in toposorted order (see self.__iter__) to
         # ensure that outputs are touched in correct order.
-        for level in self.toposorted:
+        for i, level in enumerate(self.toposorted):
+            if i > 0:
+                # Wait a bit to ensure that subsequent levels really have distinct
+                # modification times.
+                time.sleep(0.1)
             async with asyncio.TaskGroup() as tg:
                 for job in level:
                     # postprocessing involves touching output files (to ensure that
                     # modification times are always correct. This has to happen in
                     # topological order, such that they are not mixed up.
-                    tg.create_task(job.postprocess(error=error, **kwargs))
+                    # We have to disable output mtime checks here
+                    # (at least for now), because they interfere with the update of
+                    # intermediate file mtimes that might happen in previous levels.
+                    tg.create_task(
+                        job.postprocess(error=error, check_output_mtime=False, **kwargs)
+                    )
         # remove all pipe and service outputs since all jobs of this group are done and the
         # outputs are no longer needed
         for job in self.jobs:


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced output verification process with new checks for output file modification times.
	- Improved control over output handling during job postprocessing with additional parameters.

- **Bug Fixes**
	- Added detailed error handling to raise errors for outdated output files.

- **Refactor**
	- Updated method signatures in the `DAG` and `Job` classes to include new parameters for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->