### PR TITLE
fix: expand environment variables in --remote-job-local-storage-prefix within the remote job, not the main snakemake job

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1432,15 +1432,13 @@ def get_argument_parser(profiles=None):
     )
     group_behavior.add_argument(
         "--remote-job-local-storage-prefix",
-        type=maybe_base64(expandvars(Path)),
+        type=maybe_base64(Path),
         help="Specify prefix for storing local copies of storage files and folders in "
         "case of remote jobs (e.g. cluster or cloud jobs). This may differ from "
         "--local-storage-prefix. If not set, uses value of --local-storage-prefix. "
         "By default, this is a hidden subfolder in the workdir. It can however be "
         "freely chosen, e.g. in order to store those files on a local scratch disk. "
-        "Environment variables will be expanded. In case they shall be expanded only "
-        "within the remote job, mask them with a leading backslash, i.e. "
-        "\\$SLURM_JOB_ID.",
+        "Environment variables will be expanded within the remote job.",
     )
     group_behavior.add_argument(
         "--shared-fs-usage",


### PR DESCRIPTION
fixes #3049, https://github.com/snakemake/snakemake-storage-plugin-fs/issues/22

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- No new features introduced.

- **Bug Fixes**
	- Clarified help text for the `--remote-job-local-storage-prefix` argument.

- **Chores**
	- Minor formatting adjustments and removal of unnecessary comments in the argument parser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->