### PR TITLE
fix: use relpath for configfiles added to the source archive (thanks to @sposadac for the initial solution)

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2907,7 +2907,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                     files.add(env_path)
 
         for f in self.workflow.configfiles:
-            files.add(f)
+            files.add(os.path.relpath(f))
 
         # get git-managed files
         # TODO allow a manifest file as alternative

--- a/snakemake/spawn_jobs.py
+++ b/snakemake/spawn_jobs.py
@@ -224,13 +224,15 @@ class SpawnedJobArgsFactory:
             )
 
         return " && ".join(precommand)
-    
+
     def get_configfiles_arg(self):
         # If not shared FS, use relpath for the configfiles (deployed via source archive)
         # Source archive creation ensures that configfiles are in a subdir of the CWD
         # and errors otherwise.
         if SharedFSUsage.SOURCES not in self.workflow.storage_settings.shared_fs_usage:
-            configfiles = [os.path.relpath(f) for f in self.workflow.overwrite_configfiles]
+            configfiles = [
+                os.path.relpath(f) for f in self.workflow.overwrite_configfiles
+            ]
         else:
             configfiles = self.workflow.overwrite_configfiles
         if configfiles:

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -295,8 +295,12 @@ class Workflow(WorkflowExecutorInterface):
             for f in self.dag.get_sources():
                 if f.startswith(".."):
                     logger.warning(
-                        "Ignoring source file {}. Only files relative "
-                        "to the working directory are allowed.".format(f)
+                        f"Ignoring source file {f}! Only files relative "
+                        "to the working directory are allowed. Most likely the "
+                        "spawned jobs will not properly work. Make sure to start "
+                        "the workflow from a directory below which all the sources "
+                        "are located (may be in subfolders) and also ensure that any "
+                        "config files you refer to are inside that directory."
                     )
                     continue
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1106,7 +1106,7 @@ def test_resources_can_be_overwritten_as_global():
 def test_scopes_submitted_to_cluster(mocker):
     from snakemake.spawn_jobs import SpawnedJobArgsFactory
 
-    spy = mocker.spy(SpawnedJobArgsFactory, "get_resource_scopes_args")
+    spy = mocker.spy(SpawnedJobArgsFactory, "get_resource_scopes_arg")
     run(
         dpath("test_group_jobs_resources"),
         cluster="./qsub",


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging messages for ignored source files to provide clearer user guidance regarding directory structure.
	- Added functionality to handle configuration file arguments, including support for relative paths based on shared file system usage.

- **Bug Fixes**
	- Improved consistency in how configuration file paths are recorded, ensuring they are stored as relative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->