### PR TITLE
docs: Adds instructions for using syntax highlighting with lazy.nvim

### DIFF
--- a/misc/vim/README.md
+++ b/misc/vim/README.md
@@ -14,20 +14,20 @@ To install via [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
 To install via [lazy.nvim](https://github.com/folke/lazy.nvim):
 
-``` lua
-return {
-  {
-    "snakemake/snakemake",
-    ft = "snakemake",
-    config = function(plugin)
-      vim.opt.rtp:append(plugin.dir .. "/misc/vim")
-    end,
-    init = function(plugin)
-      require("lazy.core.loader").ftdetect(plugin.dir .. "/misc/vim")
-    end,
-  },
-}
-```
+    ``` lua
+    return {
+      {
+        "snakemake/snakemake",
+        ft = "snakemake",
+        config = function(plugin)
+          vim.opt.rtp:append(plugin.dir .. "/misc/vim")
+        end,
+        init = function(plugin)
+          require("lazy.core.loader").ftdetect(plugin.dir .. "/misc/vim")
+        end,
+      },
+    }
+    ```
 
 To manually install, copy `syntax/snakemake.vim` file to `$HOME/.vim/syntax`
 directory and `ftdetect/snakemake.vim` file to `$HOME/.vim/ftdetect`.

--- a/misc/vim/README.md
+++ b/misc/vim/README.md
@@ -12,6 +12,23 @@ To install via [packer.nvim](https://github.com/wbthomason/packer.nvim):
 
     use {'snakemake/snakemake', rtp='misc/vim', ft='snakemake'}
 
+To install via [lazy.nvim](https://github.com/folke/lazy.nvim):
+
+``` lua
+return {
+  {
+    "snakemake/snakemake",
+    ft = "snakemake",
+    config = function(plugin)
+      vim.opt.rtp:append(plugin.dir .. "/misc/vim")
+    end,
+    init = function(plugin)
+      require("lazy.core.loader").ftdetect(plugin.dir .. "/misc/vim")
+    end,
+  },
+}
+```
+
 To manually install, copy `syntax/snakemake.vim` file to `$HOME/.vim/syntax`
 directory and `ftdetect/snakemake.vim` file to `$HOME/.vim/ftdetect`.
 


### PR DESCRIPTION
This PR adds instructions for loading the Snakemake syntax highlighting using Neovim with lazy.nvim.
It only affects the documentation.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated Vim plugin installation instructions for Snakemake syntax highlighting.
	- Added new installation method using lazy.nvim plugin manager. 
	- Enhanced configuration guide for Snakemake syntax highlighting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->