### PR TITLE
fix: do not use outdated metadata for rerun triggers (only warn about it)

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -1254,7 +1254,6 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             if is_forced(job):
                 reason.forced = True
             elif job in self.targetjobs:
-                # TODO find a way to handle added/removed input files here?
                 if not job.has_products(include_logfiles=False):
                     if job.input:
                         if job.rule.norun:
@@ -1326,9 +1325,9 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                             )
                             if not self.workflow.persistence.has_metadata(job):
                                 reason.no_metadata = True
+                            elif self.workflow.persistence.has_outdated_metadata(job):
+                                reason.outdated_metadata = True
                             else:
-                                if self.workflow.persistence.has_outdated_metadata(job):
-                                    reason.outdated_metadata = True
                                 if RerunTrigger.PARAMS in self.workflow.rerun_triggers:
                                     reason.params_changed = (
                                         self.workflow.persistence.params_changed(job)


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved metadata handling logic to more accurately detect and flag jobs that need to be rerun due to outdated metadata.
    - Enhanced workflow execution process to ensure consistent and precise job status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->