### PR TITLE
feat: do not fail if --cache is active but no SNAKEMAKE_OUTPUT_CACHE env var is defined. Instead, print a warning that explains the options.

### DIFF
--- a/snakemake/caching/__init__.py
+++ b/snakemake/caching/__init__.py
@@ -8,7 +8,11 @@ import os
 
 from snakemake.jobs import Job
 from snakemake.io import apply_wildcards
-from snakemake.exceptions import MissingOutputFileCachePathException, WorkflowError, CacheMissException
+from snakemake.exceptions import (
+    MissingOutputFileCachePathException,
+    WorkflowError,
+    CacheMissException,
+)
 from snakemake.caching.hash import ProvenanceHashMap
 from snakemake.logging import logger
 

--- a/snakemake/caching/__init__.py
+++ b/snakemake/caching/__init__.py
@@ -8,8 +8,9 @@ import os
 
 from snakemake.jobs import Job
 from snakemake.io import apply_wildcards
-from snakemake.exceptions import WorkflowError, CacheMissException
+from snakemake.exceptions import MissingOutputFileCachePathException, WorkflowError, CacheMissException
 from snakemake.caching.hash import ProvenanceHashMap
+from snakemake.logging import logger
 
 LOCATION_ENVVAR = "SNAKEMAKE_OUTPUT_CACHE"
 
@@ -21,11 +22,7 @@ class AbstractOutputFileCache:
         try:
             self.cache_location = os.environ[LOCATION_ENVVAR]
         except KeyError:
-            raise WorkflowError(
-                "Output file cache activated (--cache), but no cache "
-                "location specified. Please set the environment variable "
-                "${}.".format(LOCATION_ENVVAR)
-            )
+            raise MissingOutputFileCachePathException()
         self.provenance_hash_map = ProvenanceHashMap()
 
     @abstractmethod

--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -11,6 +11,7 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from typing import List, Mapping, Optional, Set, Union
 
+from snakemake import caching
 from snakemake_interface_executor_plugins.settings import ExecMode
 from snakemake_interface_executor_plugins.registry import ExecutorPluginRegistry
 from snakemake_interface_executor_plugins.utils import is_quoted, maybe_base64
@@ -475,7 +476,7 @@ def get_argument_parser(profiles=None):
         nargs="*",
         metavar="RULE",
         help="Store output files of given rules in a central cache given by the environment "
-        "variable $SNAKEMAKE_OUTPUT_CACHE. Likewise, retrieve output files of the given rules "
+        f"variable ${caching.LOCATION_ENVVAR}. Likewise, retrieve output files of the given rules "
         "from this cache if they have been created before (by anybody writing to the same cache), "
         "instead of actually executing the rules. Output files are identified by hashing all "
         "steps, parameters and software stack (conda envs or containers) needed to create them.",

--- a/snakemake/exceptions.py
+++ b/snakemake/exceptions.py
@@ -603,6 +603,10 @@ class LookupError(WorkflowError):
         super().__init__(*args)
 
 
+class MissingOutputFileCachePathException(Exception):
+    pass
+
+
 def is_file_not_found_error(exc, considered_files):
     # TODO find a better way to detect whether the input files are not present
     if isinstance(exc, FileNotFoundError) and exc.filename in considered_files:

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -54,6 +54,7 @@ from snakemake.logging import logger, format_resources
 from snakemake.rules import Rule, Ruleorder, RuleProxy
 from snakemake.exceptions import (
     CreateCondaEnvironmentException,
+    MissingOutputFileCachePathException,
     RuleException,
     CreateRuleException,
     UnknownRuleException,
@@ -123,7 +124,7 @@ from snakemake.sourcecache import (
     infer_source_file,
 )
 from snakemake.deployment.conda import Conda
-from snakemake import api, sourcecache
+from snakemake import api, caching, sourcecache
 import snakemake.ioutils
 import snakemake.ioflags
 from snakemake.jobs import jobs_to_rulenames
@@ -685,15 +686,26 @@ class Workflow(WorkflowExecutorInterface):
             self.cache_rules.update(
                 {rulename: "all" for rulename in self.workflow_settings.cache}
             )
-            if (
-                self.storage_settings is not None
-                and self.storage_settings.default_storage_provider is not None
-            ):
-                self._output_file_cache = StorageOutputFileCache(
-                    self.storage_registry.default_storage_provider
+            try:
+                if (
+                    self.storage_settings is not None
+                    and self.storage_settings.default_storage_provider is not None
+                ):
+                    self._output_file_cache = StorageOutputFileCache(
+                        self.storage_registry.default_storage_provider
+                    )
+                else:
+                    self._output_file_cache = LocalOutputFileCache()
+            except MissingOutputFileCachePathException:
+                logger.warning(
+                    "Output file cache activated (--cache), but no cache "
+                    "location specified. Hence, Snakemake will not use between workflow "
+                    "caching (see "
+                    "https://snakemake.readthedocs.io/en/stable/executing/caching.html). "
+                    "Please set the environment variable "
+                    f"${caching.LOCATION_ENVVAR} to a reasonable path or storage URI "
+                    "(if you use a storage plugin) to activate the caching."
                 )
-            else:
-                self._output_file_cache = LocalOutputFileCache()
 
         def rules(items):
             return map(self._rules.__getitem__, filter(self.is_rule, items))


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new exception `MissingOutputFileCachePathException` for more precise error handling in output file caching

- **Documentation**
  - Updated help text for `--cache` argument to reference the correct environment variable

- **Bug Fixes**
  - Improved error handling for scenarios involving missing output file cache paths
  - Enhanced workflow robustness when initializing storage cache settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->