### PR TITLE
fix: Encoded filenames too long for Windows

### DIFF
--- a/snakemake/persistence.py
+++ b/snakemake/persistence.py
@@ -711,6 +711,11 @@ class Persistence(PersistenceExecutorInterface):
             max_len = 255
 
         b64id = self._b64id(id)
+
+        # create 32 character long hash of the b64id
+        # to avoid too long filenames for windows
+        b64id = hashlib.md5(b64id.encode()).hexdigest()
+        
         # split into chunks of proper length
         b64id = [b64id[i : i + max_len - 1] for i in range(0, len(b64id), max_len - 1)]
         # prepend dirs with @ (does not occur in b64) to avoid conflict with b64-named files in the same dir


### PR DESCRIPTION
Closes #2756 .

The fix hashes the base64 encoded file name to 32 a fixed length of characters to avoid the error.

I've tested it locally against my MWE, where this works.

I'm don't know how this would interact with workflows that have marker files that were created without this change.

### QC
<!-- Make sure that you can tick the boxes below. -->

I'm having trouble installing the `test-environment.yml` so I could not run `pytest` on the changes. 

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
