### PR TITLE
docs: Fix typos in basic API example

### DIFF
--- a/apidocs/api_reference/snakemake_api.rst
+++ b/apidocs/api_reference/snakemake_api.rst
@@ -14,17 +14,24 @@ It can be used as follows:
 
 .. code-block:: python
 
-    from snakemake.api import SnakemakeApi
+    from pathlib import Path
 
-    with api.SnakemakeApi(
-        settings.OutputSettings(
+    from snakemake.api import (
+        OutputSettings,
+        ResourceSettings,
+        SnakemakeApi,
+        StorageSettings,
+    )
+
+    with SnakemakeApi(
+        OutputSettings(
             verbose=False,
             show_failed_logs=True,
         ),
     ) as snakemake_api:
         workflow_api = snakemake_api.workflow(
-            storage_settings=settings.StorageSettings(),
-            resource_settings=settings.ResourceSettings(),
+            storage_settings=StorageSettings(),
+            resource_settings=ResourceSettings(),
             snakefile=Path("path/to/Snakefile"),
         )
         dag_api = workflow_api.dag()


### PR DESCRIPTION
This is just a small error in the API docs updated such that it now runs properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Snakemake API documentation import statements
	- Refined references to API settings in documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->