### PR TITLE
New CLI argument `--premable-only`, acting as a flexible side-kick to `--draft-notebook`

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -982,6 +982,12 @@ def get_argument_parser(profiles=None):
         "will automatically be reused in non-interactive mode by Snakemake for subsequent jobs.",
     )
     group_notebooks.add_argument(
+        "--preamble-only",
+        metavar="TARGET",
+        help="Print the preamble used in notebooks and scripts to configure the `snakemake` rule object."
+        "No code is being run and existing notebooks or scripts are not modified.",
+    )
+    group_notebooks.add_argument(
         "--edit-notebook",
         metavar="TARGET",
         help="Interactively edit the notebook associated with the rule used to generate the given target file. "
@@ -1893,6 +1899,9 @@ def parse_edit_notebook(args):
     if args.draft_notebook:
         args.targets = {args.draft_notebook}
         edit_notebook = NotebookEditMode(draft_only=True)
+    elif args.preamble_only:
+        args.targets = {args.preamble_only}
+        edit_notebook = NotebookEditMode(preamble_only=True)
     elif args.edit_notebook:
         args.targets = {args.edit_notebook}
         args.force = True

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -525,10 +525,13 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             and job.targetfile in self.targetfiles
         )
 
-    def is_draft_notebook_job(self, job):
+    def is_draft_or_preamble_notebook_job(self, job):
         return (
             self.workflow.execution_settings.edit_notebook
-            and self.workflow.execution_settings.edit_notebook.draft_only
+            and (
+                self.workflow.execution_settings.edit_notebook.draft_only
+                or self.workflow.execution_settings.edit_notebook.preamble_only
+            )
             and job.targetfile in self.targetfiles
         )
 

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -1123,7 +1123,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
         error=False,
         ignore_missing_output=False,
     ):
-        if self.dag.is_draft_notebook_job(self):
+        if self.dag.is_draft_or_preamble_notebook_job(self):
             # no output produced but have to delete incomplete marker
             self.dag.workflow.persistence.cleanup(self)
             return

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -31,7 +31,6 @@ class JupyterNotebook(ScriptBase):
     def draft(self):
         import nbformat
 
-        preamble = self.get_preamble()
         nb = nbformat.v4.new_notebook()
         self.insert_preamble_cell(preamble, nb)
 
@@ -334,6 +333,9 @@ def notebook(
 
     if edit is None:
         executor.evaluate(edit=edit)
+    elif edit.preamble_only:
+        msg = f"Preamble is:\n{executor.get_preamble()}"
+        logger.info(msg)
     elif edit.draft_only:
         executor.draft()
         msg = f"Generated skeleton notebook:\n{path} "
@@ -348,6 +350,7 @@ def notebook(
                 "\nEditing with Jupyter CLI:"
                 "\nconda activate {}\njupyter notebook {}\n".format(conda_env, path)
             )
+        msg += (f"\nPreamble is:\n{executor.get_preamble()} ")
         logger.info(msg)
     elif draft:
         executor.draft_and_edit(listen=edit)

--- a/snakemake/notebook.py
+++ b/snakemake/notebook.py
@@ -31,6 +31,7 @@ class JupyterNotebook(ScriptBase):
     def draft(self):
         import nbformat
 
+        preamble = self.get_preamble()
         nb = nbformat.v4.new_notebook()
         self.insert_preamble_cell(preamble, nb)
 
@@ -66,7 +67,7 @@ class JupyterNotebook(ScriptBase):
 
         with tempfile.TemporaryDirectory() as tmp:
             if edit is not None:
-                assert not edit.draft_only
+                assert not edit.draft_only and not edit.preamble_only
                 logger.info("Opening notebook for editing.")
                 cmd = (
                     "jupyter notebook --browser ':' --no-browser --log-level ERROR --ip {edit.ip} --port {edit.port} "
@@ -350,7 +351,7 @@ def notebook(
                 "\nEditing with Jupyter CLI:"
                 "\nconda activate {}\njupyter notebook {}\n".format(conda_env, path)
             )
-        msg += (f"\nPreamble is:\n{executor.get_preamble()} ")
+        msg += f"\nPreamble is:\n{executor.get_preamble()} "
         logger.info(msg)
     elif draft:
         executor.draft_and_edit(listen=edit)

--- a/snakemake/settings/types.py
+++ b/snakemake/settings/types.py
@@ -48,10 +48,16 @@ class SettingsBase(ABC):
 
 
 class NotebookEditMode:
-    def __init__(self, server_addr: Optional[str] = None, draft_only: bool = False):
+    def __init__(
+        self,
+        server_addr: Optional[str] = None,
+        draft_only: bool = False,
+        preamble_only: bool = False,
+    ):
         if server_addr is not None:
             self.ip, self.port = server_addr.split(":")
         self.draft_only = draft_only
+        self.preamble_only = preamble_only
 
 
 class MaxJobsPerTimespan:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1566,6 +1566,19 @@ def test_jupyter_notebook_draft():
     )
 
 
+@conda
+def test_jupyter_notebook_preamble():
+    from snakemake.settings.types import NotebookEditMode
+
+    run(
+        dpath("test_jupyter_notebook_preamble"),
+        deployment_method={DeploymentMethod.CONDA},
+        edit_notebook=NotebookEditMode(preamble_only=True),
+        targets=["results/result_intermediate.txt"],
+        check_md5=False,
+    )
+
+
 def test_github_issue456():
     run(dpath("test_github_issue456"))
 


### PR DESCRIPTION
Jupyter notebooks are great! But, they don't fit everyone's workflow. To cover *any* developmental workflow for interactively developing snakemake workflows, this PR adds a CLI argument to print the `preamble` for a given target file.  

Resolves #2742 

### RFC

- This is a draft PR, i.e. please provide feedback to the envisioned implementations. 
- This has not been tested thoroughly so far.

### TODO QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
