### PR TITLE
fix: Revert cleaning of env vars in apptainer

### DIFF
--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -422,7 +422,7 @@ otherwise, it assumes the given specification to point to an existing environmen
 Running jobs in containers
 --------------------------
 
-As an alternative to using Conda (see above), it is possible to define, for each rule, a (docker) container to use, e.g.,
+As an alternative to using Conda (see above), it is possible to define, for each rule, a (Docker) container to use, e.g.,
 
 .. code-block:: python
 
@@ -447,6 +447,10 @@ When executing Snakemake with
 it will execute the job within a container that is spawned from the given image.
 Allowed image urls entail everything supported by apptainer (e.g., ``shub://`` and ``docker://``).
 However, ``docker://`` is preferred, as other container runtimes will be supported in the future (e.g. podman).
+
+Note that the isolation of jobs running in containers depends on the container engine.
+For example, Docker does not pass any host environment variables to the container, whereas Apptainer/Singularity passes everything.
+To override the default behaviour, consider using ``--apptainer-args`` or ``--singularity-args``, e.g. to pass ``--cleanenv``.
 
 Defining global container images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -633,10 +637,10 @@ and reproduce the data analysis at any time in the future.
 Global workflow dependencies
 ----------------------------
 
-Often, your workflow will depend on some additional packages that need to be present 
+Often, your workflow will depend on some additional packages that need to be present
 along with Snakemake in order to handle actions before any rule is executed.
-Classical examples for this are `pandas <https://pandas.pydata.org/>`_, 
-`pep <https://pep.databio.org>`_ (also see :ref:`snakefiles-peps`) and 
+Classical examples for this are `pandas <https://pandas.pydata.org/>`_,
+`pep <https://pep.databio.org>`_ (also see :ref:`snakefiles-peps`) and
 :ref:`storage plugins <storage-support>`.
 
 Snakemake allows to define such global dependencies using a global ``conda`` directive
@@ -655,8 +659,8 @@ With ``envs/global.yaml`` containing e.g.::
     dependencies:
       - pandas=1.0.3
       - snakemake-storage-plugin-s3
-    
-Under the hood, this is implemented using `conda-inject <https://github.com/koesterlab/conda-inject>`_, 
+
+Under the hood, this is implemented using `conda-inject <https://github.com/koesterlab/conda-inject>`_,
 which modifies the python searchpath and the PATH variable on the fly during execution,
 pointing to additional environments that do not alter the environment in which Snakemake
 has been installed.

--- a/snakemake/deployment/singularity.py
+++ b/snakemake/deployment/singularity.py
@@ -127,7 +127,7 @@ def shellcmd(
     if container_workdir:
         args += f" --pwd {repr(container_workdir)}"
 
-    cmd = "{} singularity {} exec --cleanenv --home {} {} {} {} -c '{}'".format(
+    cmd = "{} singularity {} exec --home {} {} {} {} -c '{}'".format(
         envvars,
         "--quiet --silent" if quiet else "",
         repr(os.getcwd()),

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -1348,10 +1348,12 @@ def expand(*args, **wildcard_values):
     }
 
     def do_expand(
-        wildcard_values: Dict[str, dict[str, Union[str, collections.abc.Iterable[str]]]]
+        wildcard_values: Dict[
+            str, dict[str, Union[str, collections.abc.Iterable[str]]]
+        ],
     ):
         def flatten(
-            wildcard_values: Dict[str, Union[str, collections.abc.Iterable[str]]]
+            wildcard_values: Dict[str, Union[str, collections.abc.Iterable[str]]],
         ):
             for wildcard, value in wildcard_values.items():
                 if (


### PR DESCRIPTION
<!--Add a description of your PR here-->

This PR reverts the change introduced by 76d53290a003891c5ee41f81e8eb4821c406255d which, when using Apptainer/Singularity, forces cleaning of system environment variables going into the container. This is neither a fixed nor default behavior of Apptainer itself since it can be desirable to not fully isolate from the system. Hence Snakemake shouldn't dictate it. With the change in 76d53290a003891c5ee41f81e8eb4821c406255d, users do not have any chance to deactivate the behavior. On the other hand, the `--cleanenv` can easily be added through `--aptainer-args`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated container execution behavior by removing the `--cleanenv` option, allowing host environment variables to be passed through to container tasks for a more consistent execution context.
  
- **Documentation**
	- Enhanced documentation on Snakemake workflow structure, adding requirements for a "Code of Conduct," "Contribution instructions," and a "Test directory."
	- Clarified the importance of maintaining a `.tests` directory and specified subdirectories for integration and unit tests.
	- Updated repository structure requirements to include an SVG-formatted rule graph and technical documentation file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->