### PR TITLE
feat: mastodon robot enabled

### DIFF
--- a/.github/workflows/post_to_mastodon.sh
+++ b/.github/workflows/post_to_mastodon.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Extract version from PR tag passed as environment variable
+if [ -z "${PR_TITLE}" ]; then
+    echo "Error: 'PR_TITLE' environment variable is not set."
+    exit 1
+fi
+
+# Check if this is a release PR
+if [[ ! "${PR_TITLE}" =~ ^chore\(main\):\ release ]]; then
+    echo "Not a release PR, skipping Mastodon post"
+    exit 0
+fi
+
+# Extract version (everything after "release ")
+if [[ "${PR_TITLE}" =~ [Rr]elease[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+    version="${BASH_REMATCH[1]}"
+else
+    echo "Error: Could not extract version number from PR title"
+    exit 1
+fi
+
+# Validate version format
+if ! [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Invalid version format in PR title: $version"
+    exit 1
+fi
+
+# Construct changelog URL with proper quoting
+changelog="https://github.com/snakemake/snakemake-executor-plugin-slurm/releases/tag/v${version}"
+
+# Maximum character limit for Mastodon posts (on Fediscience: 1500 characters)
+MAX_TOOT_LENGTH=1500
+
+read -d '\n' message << EndOfText
+BEEP, BEEP - I  am your friendly #Snakemake release announcement bot.
+
+There is a new release of Snakemake itself. Its version is now '${version}'!
+
+See ${changelog//\'/\\\'} for details.
+
+Give us some time and you will automatically find the plugin on #Bioconda and #Pypi.
+
+If you want to discuss the release you will find the maintainer here on Mastodon! - @johanneskoester@fosstodon.org
+
+If you find any issues, please report them on https://github.com/snakemake/snakemake/issues .
+
+#Snakemake #ReproducibleComputing #ReproducibleResearch #OpenScience
+EndOfText
+
+# Validate message length
+if [ ${#message} -gt $MAX_TOOT_LENGTH ]; then
+    echo "Error: Message exceeds Fediscience's character limit"
+    exit 1
+fi
+
+# Validate Mastodon token
+if [ -z "${MASTODONBOT}" ]; then
+    echo "Error: MASTODONBOT secret is not set"
+    exit 1
+fi
+
+# Send post to Mastodon with proper quoting and error handling
+response=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Authorization: Bearer ${MASTODONBOT}" \
+    -F "status=${message}" \
+    "https://fediscience.org/api/v1/statuses")
+
+status_code=$(echo "$response" | tail -n1)
+response_body=$(echo "$response" | sed '$d')
+
+if [ "$status_code" -ne 200 ]; then
+    echo "Error: Failed to post to Mastodon (HTTP ${status_code})"
+    echo "Response: ${response_body}"
+    exit 1
+fi
+
+echo "Successfully posted to Mastodon"

--- a/.github/workflows/post_to_mastodon.yml
+++ b/.github/workflows/post_to_mastodon.yml
@@ -1,0 +1,30 @@
+name: Post to Mastodon on PR Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  pull-requests: read
+
+jobs:
+  post_to_mastodon:
+    if: |
+      ${{ github.event.pull_request.merged }} &&
+      (contains(github.event.pull_request.title, 'release') || contains(github.event.pull_request.title, ' v') || contains(github.event.pull_request.title, 'version'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Post to Mastodon
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          command: |
+            export MASTODONBOT="${{ secrets.MASTODONBOT }}"
+            export PR_TITLE="${{ github.event.pull_request.title }}"
+            chmod +x $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh
+            $GITHUB_WORKSPACE/.github/workflows/post_to_mastodon.sh


### PR DESCRIPTION
This PR enables auto-posting of release messages to the Mastodon announcement bot at https://fediscience.org/@snakemake

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

This PR does not alter any code. It is hence not necessary to include a test case or documentation
