### PR TITLE
fix: add missing @conda annotations

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -519,6 +519,7 @@ def test_conda_list_envs():
 # it is being used by another process:
 # 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\snakemake-2q4osog0\\test-env.yaml'
 @skip_on_windows
+@conda
 def test_conda_create_envs_only():
     tmpdir = run(
         dpath("test_conda"),
@@ -609,22 +610,27 @@ def test_wrapper_local_git_prefix():
         )
 
 
+@conda
 def test_get_log_none():
     run(dpath("test_get_log_none"))
 
 
+@conda
 def test_get_log_both():
     run(dpath("test_get_log_both"))
 
 
+@conda
 def test_get_log_stderr():
     run(dpath("test_get_log_stderr"))
 
 
+@conda
 def test_get_log_stdout():
     run(dpath("test_get_log_stdout"))
 
 
+@conda
 def test_get_log_complex():
     run(dpath("test_get_log_complex"))
 
@@ -1325,6 +1331,7 @@ def test_issue1037():
     )
 
 
+@conda
 def test_issue1046():
     run(dpath("test_issue1046"))
 
@@ -1629,6 +1636,7 @@ def test_containerized():
 
 
 @skip_on_windows
+@conda
 def test_containerize():
     run(dpath("test_conda"), containerize=True, check_results=False)
 


### PR DESCRIPTION
The snakemake tests use the decorator `@conda` to check whether the `conda` executable is in the user `$PATH` and otherwise  skips them.

However, some annotations are missing and hence failing instead of being skipped without `conda`:

```
tests/tests.py::test_conda_create_envs_only
tests/tests.py::test_get_log_none
tests/tests.py::test_get_log_both
tests/tests.py::test_get_log_stderr
tests/tests.py::test_get_log_stdout
tests/tests.py::test_get_log_complex
tests/tests.py::test_issue1046
tests/tests.py::test_containerize
```

This patch adds the missing decorator to those tests.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Expanded automated test coverage to verify environment setup processes.
	- Added validations for logging behavior across multiple scenarios, ensuring robust handling of different output conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->