### PR TITLE
add cli option to provide source file manifest to specify workflow source files

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1587,6 +1587,15 @@ def get_argument_parser(profiles=None):
         help="Provide a custom name for the jobscript that is submitted to the "
         'cluster (see --cluster). NAME is "snakejob.{name}.{jobid}.sh" '
         "per default. The wildcard {jobid} has to be present in the name.",
+    ) 
+    group_cluster.add_argument(
+        "--source-file-manifest",
+        metavar="FILE",
+        type=Path,
+        help="Provide a file listing paths to workflow source files to deploy before "
+        "a remote job is started. If not provided git ls-files will be used to define "
+        "source files to upload. Only applies if --no-shared-fs is set or executors are "
+        "used that imply no shared FS (e.g. the kubernetes executor).",
     )
 
     group_flux = parser.add_argument_group("FLUX")
@@ -2187,6 +2196,7 @@ def args_to_api(args, parser):
                                 envvars=args.envvars,
                                 immediate_submit=args.immediate_submit,
                                 job_deploy_sources=args.job_deploy_sources,
+                                source_file_manifest=args.source_file_manifest,
                             ),
                             scheduling_settings=SchedulingSettings(
                                 prioritytargets=args.prioritize,

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -2911,26 +2911,36 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         for f in self.workflow.configfiles:
             files.add(os.path.relpath(f))
 
-        # get git-managed files
-        # TODO allow a manifest file as alternative
-        try:
-            out = subprocess.check_output(
-                ["git", "ls-files", "--recurse-submodules", "."], stderr=subprocess.PIPE
-            )
-            for f in out.decode().split("\n"):
-                if f:
-                    files.add(os.path.relpath(f))
-        except subprocess.CalledProcessError as e:
-            if "fatal: not a git repository" in e.stderr.decode().lower():
-                logger.warning(
-                    "Unable to retrieve additional files from git. "
-                    "This is not a git repository."
+        # check if a manifest file is provided
+        # or get git-managed files
+        if self.workflow.remote_execution_settings.source_file_manifest:
+            fl = self.workflow.remote_execution_settings.source_file_manifest 
+            try:
+                with open(fl, "r") as manifest:
+                    for f in manifest.read().splitlines():
+                        if f.strip():
+                            files.add(os.path.relpath(f.strip()))
+            except FileNotFoundError:
+                raise WorkflowError(f"Manifest file not found: {fl}")
+        else:
+            try:
+                out = subprocess.check_output(
+                    ["git", "ls-files", "--recurse-submodules", "."], stderr=subprocess.PIPE
                 )
-            else:
-                raise WorkflowError(
-                    "Error executing git (Snakemake requires git to be installed for "
-                    "remote execution without shared filesystem):\n" + e.stderr.decode()
-                )
+                for f in out.decode().split("\n"):
+                    if f:
+                        files.add(os.path.relpath(f))
+            except subprocess.CalledProcessError as e:
+                if "fatal: not a git repository" in e.stderr.decode().lower():
+                    logger.warning(
+                        "Unable to retrieve additional files from git. "
+                        "This is not a git repository."
+                    )
+                else:
+                    raise WorkflowError(
+                        "Error executing git (Snakemake requires git to be installed for "
+                        "remote execution without shared filesystem):\n" + e.stderr.decode()
+                    )
 
         return files
 

--- a/snakemake/settings/types.py
+++ b/snakemake/settings/types.py
@@ -409,6 +409,7 @@ class RemoteExecutionSettings(SettingsBase, RemoteExecutionSettingsExecutorInter
     immediate_submit: bool = False
     precommand: Optional[str] = None
     job_deploy_sources: bool = True
+    source_file_manifest: Optional[Path] = None
 
 
 @dataclass


### PR DESCRIPTION
<!--Add a description of your PR here-->

See issue #3287 . This proposed new cli argument `--source-file-manifest` allows the user to specify source files that will be packaged in the workflow source tarball for remote execution. This option is an alternative to the current approach, which requires all files to be tracked by git (due to the use of`git ls-files` to identify source files).

### QC
<!-- Make sure that you can tick the boxes below. -->

I did not add an additional test case for this. I can add one once the proposed feature is considered.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.

The new CLI option should be automatically added to the docs and i believe is sufficiently documented in the cli argument description.

* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
