### PR TITLE
chore: use locally deployed minio instead of play.min.io for storage testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         uses: comfuture/minio-action@v1
         with:
           access_key: minio
-          secret_key: minio
+          secret_key: minio123
           port: 9000
 
       - name: Test minio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,12 +90,11 @@ jobs:
           sudo sysctl -p /etc/sysctl.d/90-disable-userns-restrictions.conf
 
       - name: Setup minio
-        uses: infleet/minio-action@v0.0.1
+        uses: comfuture/minio-action@v1
         with:
-          port: "9000"
-          version: "latest"
-          username: "minio"
-          password: "minio"
+          access_key: minio
+          secret_key: minio
+          port: 9000
 
       - name: Test local
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,13 @@ jobs:
           access_key: minio
           secret_key: minio
           port: 9000
-          bucket_name: test
+
+      - name: Test minio
+        run: |
+          export AWS_ACCESS_KEY_ID=minio
+          export AWS_SECRET_ACCESS_KEY=minio
+          export AWS_EC2_METADATA_DISABLED=true
+          aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test
 
       - name: Test local
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
           access_key: minio
           secret_key: minio
           port: 9000
+          bucket_name: test
 
       - name: Test local
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Test minio
         run: |
           export AWS_ACCESS_KEY_ID=minio
-          export AWS_SECRET_ACCESS_KEY=minio
+          export AWS_SECRET_ACCESS_KEY=minio123
           export AWS_EC2_METADATA_DISABLED=true
           aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,14 @@ jobs:
               >/etc/sysctl.d/90-disable-userns-restrictions.conf'
           sudo sysctl -p /etc/sysctl.d/90-disable-userns-restrictions.conf
 
+      - name: Setup minio
+        uses: infleet/minio-action@v0.0.1
+        with:
+          port: "9000"
+          version: "latest"
+          username: "minio"
+          password: "minio"
+
       - name: Test local
         env:
           CI: true

--- a/apidocs/requirements.txt
+++ b/apidocs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx >=3
 sphinxcontrib-napoleon
 sphinx-argparse
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints =3.0.1
 docutils
 myst-parser
 configargparse

--- a/apidocs/requirements.txt
+++ b/apidocs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx ==8.1  # TODO workaround for bug, update as soon as fixed
+sphinx ==8.1  # TODO workaround for bug in 8.2.0, update as soon as fixed
 sphinxcontrib-napoleon
 sphinx-argparse
 sphinx-autodoc-typehints

--- a/apidocs/requirements.txt
+++ b/apidocs/requirements.txt
@@ -1,7 +1,7 @@
 sphinx >=3
 sphinxcontrib-napoleon
 sphinx-argparse
-sphinx-autodoc-typehints =3.0.1
+sphinx-autodoc-typehints ==3.0.1
 docutils
 myst-parser
 configargparse

--- a/apidocs/requirements.txt
+++ b/apidocs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx >=3
+sphinx ==8.1  # TODO workaround for bug, update as soon as fixed
 sphinxcontrib-napoleon
 sphinx-argparse
-sphinx-autodoc-typehints ==3.0.1
+sphinx-autodoc-typehints
 docutils
 myst-parser
 configargparse

--- a/docs/snakefiles/best_practices.rst
+++ b/docs/snakefiles/best_practices.rst
@@ -23,7 +23,7 @@ Care about code readability
 1. There is an automatic formatter for Snakemake workflows, called `Snakefmt <https://github.com/snakemake/snakefmt>`_, which should be applied to any Snakemake workflow before publishing it.
 2. Try to keep filenames short (thus easier on the eye), but informative. Avoid mixing of too many special characters (e.g. decide whether to use ``_`` or ``-`` as a separator and do that consistently throughout the workflow).
 3. Try to keep Python code like helper functions separate from rules (e.g. in a ``workflow/rules/common.smk`` file). This way, you help non-experts to read the workflow without needing to parse internals that are irrelevant for them. The helper function names should be chosen in a way that makes them sufficiently informative without looking at their content. Also avoid ``lambda`` expressions inside of rules.
-4. Use Snakemake's :ref:`semantic helper functions <snakefiles-semantic-helpers>` in order to increase readibility and to avoid the reimplementation of common functionality for aggregation, parameter lookup or path modifications.
+4. Use Snakemake's :ref:`semantic helper functions <snakefiles-semantic-helpers>` in order to increase readability and to avoid the reimplementation of common functionality for aggregation, parameter lookup or path modifications.
 
 Ensure portability
 ------------------
@@ -33,7 +33,7 @@ Annotate all your rules with versioned :ref:`Conda <integrated_package_managemen
 Generate interactive reports (for free)
 ---------------------------------------
 
-Annotate your final results for inclusing into Snakemake's automatic :ref:`interactive reports <snakefiles-reports>` (thereby make sure to use all the features, including categories and labels).
+Annotate your final results for including into Snakemake's automatic :ref:`interactive reports <snakefiles-reports>` (thereby make sure to use all the features, including categories and labels).
 This makes them explorable in a high-level way, while connecting them to the workflow code, parameters, and software stack.
 
 Enable configurability

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def s3_storage():
     import uuid
     import boto3
 
-    endpoint_url = "http://localhost:9000"
+    endpoint_url = "http://127.0.0.1:9000"
     access_key = "minio"
     secret_key = "minio"
     bucket = f"snakemake-{uuid.uuid4().hex}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,9 @@ def s3_storage():
     import uuid
     import boto3
 
-    endpoint_url = "https://play.minio.io:9000"
-    access_key = "Q3AM3UQ867SPQQA43P2F"
-    secret_key = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+    endpoint_url = "https://127.0.0.1:9000"
+    access_key = "minio"
+    secret_key = "minio"
     bucket = f"snakemake-{uuid.uuid4().hex}"
 
     tagged_settings = TaggedSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def s3_storage():
 
     endpoint_url = "http://127.0.0.1:9000"
     access_key = "minio"
-    secret_key = "minio"
+    secret_key = "minio123"
     bucket = f"snakemake-{uuid.uuid4().hex}"
 
     tagged_settings = TaggedSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def s3_storage():
     import uuid
     import boto3
 
-    endpoint_url = "http://127.0.0.1:9000"
+    endpoint_url = "http://localhost:9000"
     access_key = "minio"
     secret_key = "minio"
     bucket = f"snakemake-{uuid.uuid4().hex}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def s3_storage():
     import uuid
     import boto3
 
-    endpoint_url = "https://127.0.0.1:9000"
+    endpoint_url = "http://127.0.0.1:9000"
     access_key = "minio"
     secret_key = "minio"
     bucket = f"snakemake-{uuid.uuid4().hex}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -761,7 +761,7 @@ def test_threads0():
     run(dpath("test_threads0"))
 
 
-@skip_on_windows # no minio deployment on windows implemented in our CI
+@skip_on_windows  # no minio deployment on windows implemented in our CI
 def test_default_storage(s3_storage):
     prefix, settings = s3_storage
 
@@ -789,7 +789,7 @@ def test_default_storage_local_job(s3_storage):
     )
 
 
-@skip_on_windows # no minio deployment on windows implemented in our CI
+@skip_on_windows  # no minio deployment on windows implemented in our CI
 def test_storage(s3_storage):
     prefix, settings = s3_storage
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -761,6 +761,7 @@ def test_threads0():
     run(dpath("test_threads0"))
 
 
+@skip_on_windows # no minio deployment on windows implemented in our CI
 def test_default_storage(s3_storage):
     prefix, settings = s3_storage
 
@@ -788,6 +789,7 @@ def test_default_storage_local_job(s3_storage):
     )
 
 
+@skip_on_windows # no minio deployment on windows implemented in our CI
 def test_storage(s3_storage):
     prefix, settings = s3_storage
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced our CI workflow by configuring a local object storage service for improved testing reliability.

- **Tests**
	- Updated storage settings to use local credentials for a more isolated test environment.
	- Added new tests to validate storage functionality across supported platforms, with specific handling for Windows.
	- Expanded test coverage for storage-related features.

- **Documentation**
	- Updated package version requirement for `sphinx` to address a temporary bug.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->