### PR TITLE
feat: make conda/apptainer/network tests skippable via env vars

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -46,6 +46,8 @@ def md5sum(filename, ignore_newlines=False):
 
 # test skipping
 def is_connected():
+    if "SNAKEMAKE_TESTS_NO_CONNECTED" in os.environ:
+        return False
     try:
         urllib.request.urlopen("http://www.google.com", timeout=1)
         return True
@@ -70,12 +72,16 @@ def has_zenodo_token():
 
 
 def has_apptainer():
+    if "SNAKEMAKE_TESTS_NO_APPTAINER" in os.environ:
+        return False
     return (shutil.which("apptainer") is not None) or (
         shutil.which("singularity") is not None
     )
 
 
 def has_conda():
+    if "SNAKEMAKE_TESTS_NO_CONDA" in os.environ:
+        return False
     return shutil.which("conda") is not None
 
 


### PR DESCRIPTION
Currently, tests for network, apptainer/singularity and conda are skipped if the network/executables are not available.

This works for most cases, but not when e.g. the executable is available but not functional.

This PR adds the possibility to skip those tests based on the environment variables:

* `SNAKEMAKE_NO_TESTS_CONNECTED` for network access
* `SNAKEMAKE_NO_TESTS_APPTAINER` for singularity/apptainer
* `SNAKEMAKE_NO_TESTS_CONDA` for conda

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. <br/>_Comment: this adds test selection, the tests themselves do not change_
* [x] The documentation (`docs/`) is ~~updated to reflect the changes or this is~~ not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).<br/>_Comment: internal behavior only_
