### PR TITLE
fix: properly handle remote storage when waiting for pipes

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -913,7 +913,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             if job.log:
                 files = chain(files, job.log)
             for f in files:
-                if f.is_storage and not f.should_not_be_retrieved_from_storage:
+                if (
+                    f.is_storage
+                    and not f.should_not_be_retrieved_from_storage
+                    and not is_flagged(f, "pipe")
+                    and not is_flagged(f, "service")
+                ):
                     await f.store_in_storage()
                     storage_mtime = (await f.mtime()).storage()
                     # immediately force local mtime to match storage,

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -934,9 +934,11 @@ _double_slash_regex = (
     re.compile(r"([^:]//|^//)") if os.path.sep == "/" else re.compile(r"\\\\")
 )
 
+_CONSIDER_LOCAL_DEFAULT = frozenset()
+
 
 async def wait_for_files(
-    files, latency_wait=3, wait_for_local=False, ignore_pipe_or_service=False
+    files, latency_wait=3, wait_for_local=False, ignore_pipe_or_service=False, consider_local: Set[_IOFile] = _CONSIDER_LOCAL_DEFAULT
 ):
     """Wait for given files to be present in the filesystem."""
     files = list(files)
@@ -949,11 +951,12 @@ async def wait_for_files(
                 return None
             if (
                 isinstance(f, _IOFile)
+                and f not in consider_local
                 and f.is_storage
                 and (not wait_for_local or f.should_not_be_retrieved_from_storage)
             ):
                 if not await f.exists_in_storage():
-                    return f"{f} (missing in storage)"
+                    return f"{f.storage_object.query} (missing in storage)"
             elif not os.path.exists(f):
                 parent_dir = os.path.dirname(f)
                 if list_parent:
@@ -971,16 +974,20 @@ async def wait_for_files(
 
     missing = await get_missing()
     if missing:
+        fmt_missing = "\n".join
+
         sleep = max(latency_wait / 10, 1)
         before_time = time.time()
-        logger.info(f"Waiting at most {latency_wait} seconds for missing files.")
+        logger.info(
+            f"Waiting at most {latency_wait} seconds for missing files:\n{fmt_missing(missing)}"
+        )
         while time.time() - before_time < latency_wait:
             missing = await get_missing()
             logger.debug("still missing files, waiting...")
             if not missing:
                 return
             time.sleep(sleep)
-        missing = "\n".join(await get_missing(list_parent=True))
+        missing = fmt_missing(await get_missing(list_parent=True))
         raise IOError(
             f"Missing files after {latency_wait} seconds. This might be due to "
             "filesystem latency. If that is the case, consider to increase the "

--- a/snakemake/io.py
+++ b/snakemake/io.py
@@ -945,7 +945,11 @@ _CONSIDER_LOCAL_DEFAULT = frozenset()
 
 
 async def wait_for_files(
-    files, latency_wait=3, wait_for_local=False, ignore_pipe_or_service=False, consider_local: Set[_IOFile] = _CONSIDER_LOCAL_DEFAULT
+    files,
+    latency_wait=3,
+    wait_for_local=False,
+    ignore_pipe_or_service=False,
+    consider_local: Set[_IOFile] = _CONSIDER_LOCAL_DEFAULT,
 ):
     """Wait for given files to be present in the filesystem."""
     files = list(files)


### PR DESCRIPTION
Before it could fail with certain storage plugins (e.g. fs), in combination with local execution.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Refined file storage behavior by excluding certain flagged files from retention.
	- Enhanced file waiting functionality with an additional option for local file evaluation and clearer notifications when files are missing.
	- Upgraded job processing by tracking special outputs and providing improved error reporting for smoother operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->