### PR TITLE
docs: remove duplicated 'functions'.

### DIFF
--- a/docs/project_info/codebase.rst
+++ b/docs/project_info/codebase.rst
@@ -103,7 +103,7 @@ Besides these central classes, the following modules add additional functionalit
 
 ioutils
 """""""
-The ``ioutils`` module (`snakemake/ioutils <https://github.com/snakemake/snakemake/blob/main/snakemake/ioutils>`__) implements semantic helper functions functions for handling input and output files as well as non-file parameters in the workflow.
+The ``ioutils`` module (`snakemake/ioutils <https://github.com/snakemake/snakemake/blob/main/snakemake/ioutils>`__) implements semantic helper functions for handling input and output files as well as non-file parameters in the workflow.
 
 linting
 """""""


### PR DESCRIPTION
Fixes duplicated word 'functions' in documentation.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity by removing redundant wording in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->