### PR TITLE
fix: Do not perform storage object cleanup with --keep-storage-local-copies set

### DIFF
--- a/snakemake/cli.py
+++ b/snakemake/cli.py
@@ -1356,7 +1356,7 @@ def get_argument_parser(profiles=None):
     group_behavior.add_argument(
         "--keep-storage-local-copies",
         action="store_true",
-        help="Keep local copies of remote input files.",
+        help="Keep local copies of remote input and output files.",
     )
     group_behavior.add_argument(
         "--target-files-omit-workdir-adjustment",

--- a/snakemake/workflow.py
+++ b/snakemake/workflow.py
@@ -1291,7 +1291,8 @@ class Workflow(WorkflowExecutorInterface):
 
             if not dryrun_or_touch:
                 async_run(self.dag.store_storage_outputs())
-                async_run(self.dag.cleanup_storage_objects())
+                if not self.storage_settings.keep_storage_local:
+                    async_run(self.dag.cleanup_storage_objects())
 
             if success:
                 if self.dryrun:


### PR DESCRIPTION
This PR fixes the `--keep-storage-local-copies` functionality. Prior to these changes, the option would retain the dirnames of the output files, but the files themselves would be deleted.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
