### PR TITLE
fix: include unit test templates in

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "report/html_reporter/template/**/*",
             "report/html_reporter/template/*",
             "common/tests/testcases/**/*",
+            "snakemake/snakemake/unit_tests/templates/*"
         ]
     },
 )


### PR DESCRIPTION
Fixes #3137

<!--Add a description of your PR here-->
This PR forces inclusion of `snakemake/snakemake/unit_tests/templates/` when building Snakemake. 

/templates/`

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
