### PR TITLE
fix: group resources

### DIFF
--- a/tests/test_group_jobs_resources/Snakefile
+++ b/tests/test_group_jobs_resources/Snakefile
@@ -15,10 +15,10 @@ rule a:
     group: 0
     threads: 4
     resources:
-        mem_mb=20000,
+        mem_mb="20 GiB",
         fake_res=400,
         global_res=1000,
-        runtime=80,
+        runtime="80 m",
     shell:
         "touch {output}"
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

Resources on groups are gathered but, currently, it only works if they are all numeric. If some resources are human-readable strings (e.g. "10 m" or "5 GiB"), it fails.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
