### PR TITLE
fix: only skip eval when `resource` depends on `input`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "report/html_reporter/template/**/*",
             "report/html_reporter/template/*",
             "common/tests/testcases/**/*",
+            "snakemake/snakemake/unit_tests/templates/*"
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
             "report/html_reporter/template/**/*",
             "report/html_reporter/template/*",
             "common/tests/testcases/**/*",
-            "snakemake/snakemake/unit_tests/templates/*"
+            "snakemake/snakemake/unit_tests/templates/*",
         ]
     },
 )

--- a/snakemake/jobs.py
+++ b/snakemake/jobs.py
@@ -491,12 +491,11 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
                 skip_evaluation = {"tmpdir"}
             if not self._params_and_resources_resetted:
                 # initial evaluation, input files of job are probably not yet present.
-                # Therefore skip all functions
-                skip_evaluation.update(
-                    name
-                    for name, val in self.rule.resources.items()
-                    if is_callable(val)
-                )
+                # Therefore skip all functions that depend on input files.
+                for name, val in self.rule.resources.items():
+                    if is_callable(val) and 'input' in val.__code__.co_varnames:
+                        skip_evaluation.add(name)
+
             self._resources = self.rule.expand_resources(
                 self.wildcards_dict,
                 self.input,


### PR DESCRIPTION
<!--Add a description of your PR here-->
Fixes #3271.

Currently, evaluation of functions in resources are skipped until after input is evaluated. However, this is not necessary when a function does not rely on input. This PR amends the skipping, to only operate on resources that depend on input. 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
