### PR TITLE
fix: in remote jobs, upload storage in topological order such that modification dates are preserved (e.g. in case of group jobs)

### DIFF
--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -410,7 +410,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             logger.info("Storing output in storage.")
             try:
                 for level in self.toposorted(
-                    list(self.needrun_jobs(exclude_finished=False))
+                    set(self.needrun_jobs(exclude_finished=False))
                 ):
                     async with asyncio.TaskGroup() as tg:
                         for job in level:

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -409,7 +409,9 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         if self.workflow.remote_exec:
             logger.info("Storing output in storage.")
             try:
-                for level in self.toposorted(list(self.needrun_jobs(exclude_finished=False))):
+                for level in self.toposorted(
+                    list(self.needrun_jobs(exclude_finished=False))
+                ):
                     async with asyncio.TaskGroup() as tg:
                         for job in level:
                             benchmark = [job.benchmark] if job.benchmark else []

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -409,7 +409,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         if self.workflow.remote_exec:
             logger.info("Storing output in storage.")
             try:
-                for level in self.toposorted(self.needrun_jobs(exclude_finished=False)):
+                for level in self.toposorted(list(self.needrun_jobs(exclude_finished=False))):
                     async with asyncio.TaskGroup() as tg:
                         for job in level:
                             benchmark = [job.benchmark] if job.benchmark else []


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the job output storage workflow by changing the data structure for job processing.

- **New Features**
	- Included template files in the package distribution for enhanced functionality.

- **Chores**
	- Restructured dependencies in the test environment to treat certain tools as top-level dependencies, streamlining package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->