### PR TITLE
feat: adding --replace-workflow-config to fully replace workflow configs (from config: directive) with --configfile, instead of merging them

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1989,7 +1989,7 @@ def args_to_api(args, parser):
                         config=parse_config(args.config),
                         configfiles=args.configfile,
                         config_args=args.config,
-                        replace_workflow=args.replace_workflow_config,
+                        replace_workflow_config=args.replace_workflow_config,
                     ),
                     storage_settings=storage_settings,
                     storage_provider_settings=storage_provider_settings,

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -660,6 +660,16 @@ def get_argument_parser(profiles=None):
         ),
     )
     group_exec.add_argument(
+        "--replace-workflow-config",
+        action="store_true",
+        help=(
+            "Config files provided via command line do not update and extend the config "
+            "dictionary of the workflow but instead fully replace it. Keys that are not "
+            "defined in the provided config files will be undefined even if specified "
+            "within the workflow config."
+        ),
+    )
+    group_exec.add_argument(
         "--envvars",
         nargs="+",
         metavar="VARNAME",
@@ -1979,6 +1989,7 @@ def args_to_api(args, parser):
                         config=parse_config(args.config),
                         configfiles=args.configfile,
                         config_args=args.config,
+                        replace_workflow=args.replace_workflow_config
                     ),
                     storage_settings=storage_settings,
                     storage_provider_settings=storage_provider_settings,

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1989,7 +1989,7 @@ def args_to_api(args, parser):
                         config=parse_config(args.config),
                         configfiles=args.configfile,
                         config_args=args.config,
-                        replace_workflow=args.replace_workflow_config
+                        replace_workflow=args.replace_workflow_config,
                     ),
                     storage_settings=storage_settings,
                     storage_provider_settings=storage_provider_settings,

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -358,6 +358,7 @@ class ConfigSettings(SettingsBase):
     config: Mapping[str, str] = immutables.Map()
     configfiles: Sequence[Path] = tuple()
     config_args: Optional[str] = None
+    replace_workflow: bool = False
 
     def __post_init__(self):
         self.overwrite_config = self._get_overwrite_config()

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -358,7 +358,7 @@ class ConfigSettings(SettingsBase):
     config: Mapping[str, str] = immutables.Map()
     configfiles: Sequence[Path] = tuple()
     config_args: Optional[str] = None
-    replace_workflow: bool = False
+    replace_workflow_config: bool = False
 
     def __post_init__(self):
         self.overwrite_config = self._get_overwrite_config()
@@ -374,11 +374,6 @@ class ConfigSettings(SettingsBase):
                 update_config(overwrite_config, load_configfile(f))
         if self.config:
             update_config(overwrite_config, self.config)
-        if self.replace_workflow and not overwrite_config:
-            logger.warning(
-                "--replace-workflow-config was used but no config entries are provided via "
-                "command line. This flag will be ignored."
-            )
         return overwrite_config
 
     def _get_configfiles(self):

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -366,12 +366,19 @@ class ConfigSettings(SettingsBase):
         self.config_args = self._get_config_args()
 
     def _get_overwrite_config(self):
+        from snakemake.logging import logger
+
         overwrite_config = dict()
         if self.configfiles:
             for f in self.configfiles:
                 update_config(overwrite_config, load_configfile(f))
         if self.config:
             update_config(overwrite_config, self.config)
+        if self.replace_workflow and not overwrite_config:
+            logger.warning(
+                "--replace-workflow-config was used but no config entries are provided via"
+                "command line. This flag will be ignored."
+            )
         return overwrite_config
 
     def _get_configfiles(self):

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -366,8 +366,6 @@ class ConfigSettings(SettingsBase):
         self.config_args = self._get_config_args()
 
     def _get_overwrite_config(self):
-        from snakemake.logging import logger
-
         overwrite_config = dict()
         if self.configfiles:
             for f in self.configfiles:

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -376,7 +376,7 @@ class ConfigSettings(SettingsBase):
             update_config(overwrite_config, self.config)
         if self.replace_workflow and not overwrite_config:
             logger.warning(
-                "--replace-workflow-config was used but no config entries are provided via"
+                "--replace-workflow-config was used but no config entries are provided via "
                 "command line. This flag will be ignored."
             )
         return overwrite_config

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1642,12 +1642,11 @@ class Workflow(WorkflowExecutorInterface):
                     merge_action = "extended"
                     if self.config_settings.replace_workflow:
                         # discard entire global config before merging
-                        self.globals['config'] = {}
+                        self.globals["config"] = {}
                         merge_action = "replaced"
                     logger.info(
                         "Config file {} is {} by additional config specified via the command line.".format(
-                            fp,
-                            merge_action
+                            fp, merge_action
                         )
                     )
                     update_config(self.config, self.config_settings.overwrite_config)

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1640,7 +1640,7 @@ class Workflow(WorkflowExecutorInterface):
                 update_config(self.config, c)
                 if self.config_settings.overwrite_config:
                     merge_action = "extended"
-                    if self.config_settings.replace_workflow:
+                    if self.config_settings.replace_workflow_config:
                         # discard entire global config before merging
                         self.globals["config"] = {}
                         merge_action = "replaced"

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1639,9 +1639,15 @@ class Workflow(WorkflowExecutorInterface):
                 c = load_configfile(fp)
                 update_config(self.config, c)
                 if self.config_settings.overwrite_config:
+                    merge_action = "extended"
+                    if self.config_settings.replace_workflow:
+                        # discard entire global config before merging
+                        self.globals['config'] = {}
+                        merge_action = "replaced"
                     logger.info(
-                        "Config file {} is extended by additional config specified via the command line.".format(
-                            fp
+                        "Config file {} is {} by additional config specified via the command line.".format(
+                            fp,
+                            merge_action
                         )
                     )
                     update_config(self.config, self.config_settings.overwrite_config)

--- a/tests/test_config_replacing/Snakefile
+++ b/tests/test_config_replacing/Snakefile
@@ -1,4 +1,3 @@
-import json
 configfile: "workflow-config.yaml"
 
 name = config['name'] if 'name' in config else 'noname'

--- a/tests/test_config_replacing/Snakefile
+++ b/tests/test_config_replacing/Snakefile
@@ -1,0 +1,17 @@
+import json
+configfile: "workflow-config.yaml"
+
+name = config['name'] if 'name' in config else 'noname'
+id = config['id'] if 'id' in config else 'noid'
+value = config['value'] if 'value' in config else 'novalue'
+
+rule all:
+    input:
+        'result.txt'
+
+rule create:
+    output:
+        'result.txt'
+    shell:
+        'echo "{name}-{id}-{value}" > {output}'
+

--- a/tests/test_config_replacing/Snakefile
+++ b/tests/test_config_replacing/Snakefile
@@ -12,5 +12,5 @@ rule create:
     output:
         'result.txt'
     shell:
-        'echo "{name}-{id}-{value}" > {output}'
+        'echo {name}-{id}-{value} > {output}'
 

--- a/tests/test_config_replacing/cli-config.yaml
+++ b/tests/test_config_replacing/cli-config.yaml
@@ -1,0 +1,2 @@
+id: 'id'
+value: 'value1'

--- a/tests/test_config_replacing/expected-results/result.txt
+++ b/tests/test_config_replacing/expected-results/result.txt
@@ -1,0 +1,1 @@
+noname-id-value2

--- a/tests/test_config_replacing/workflow-config.yaml
+++ b/tests/test_config_replacing/workflow-config.yaml
@@ -1,0 +1,1 @@
+name: 'name'

--- a/tests/test_config_replacing_nocli/Snakefile
+++ b/tests/test_config_replacing_nocli/Snakefile
@@ -1,4 +1,3 @@
-import json
 configfile: "workflow-config.yaml"
 
 name = config['name'] if 'name' in config else 'noname'

--- a/tests/test_config_replacing_nocli/Snakefile
+++ b/tests/test_config_replacing_nocli/Snakefile
@@ -1,0 +1,17 @@
+import json
+configfile: "workflow-config.yaml"
+
+name = config['name'] if 'name' in config else 'noname'
+id = config['id'] if 'id' in config else 'noid'
+value = config['value'] if 'value' in config else 'novalue'
+
+rule all:
+    input:
+        'result.txt'
+
+rule create:
+    output:
+        'result.txt'
+    shell:
+        'echo "{name}-{id}-{value}" > {output}'
+

--- a/tests/test_config_replacing_nocli/Snakefile
+++ b/tests/test_config_replacing_nocli/Snakefile
@@ -12,5 +12,5 @@ rule create:
     output:
         'result.txt'
     shell:
-        'echo "{name}-{id}-{value}" > {output}'
+        'echo {name}-{id}-{value} > {output}'
 

--- a/tests/test_config_replacing_nocli/expected-results/result.txt
+++ b/tests/test_config_replacing_nocli/expected-results/result.txt
@@ -1,0 +1,1 @@
+name-noid-novalue

--- a/tests/test_config_replacing_nocli/workflow-config.yaml
+++ b/tests/test_config_replacing_nocli/workflow-config.yaml
@@ -1,0 +1,1 @@
+name: 'name'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -372,6 +372,13 @@ def test_config_replacing():
     )
 
 
+def test_config_replacing_nocli():
+    run(
+        dpath("test_config_replacing_nocli"),
+        shellcmd='snakemake -j 1 --replace-workflow-config',
+    )
+
+
 def test_wildcard_keyword():
     run(dpath("test_wildcard_keyword"))
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -375,7 +375,7 @@ def test_config_replacing():
 def test_config_replacing_nocli():
     run(
         dpath("test_config_replacing_nocli"),
-        shellcmd='snakemake -j 1 --replace-workflow-config',
+        shellcmd="snakemake -j 1 --replace-workflow-config",
     )
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -365,6 +365,13 @@ def test_config_merging():
     )
 
 
+def test_config_replacing():
+    run(
+        dpath("test_config_replacing"),
+        shellcmd='snakemake -j 1 --configfile cli-config.yaml --config "value=value2" --replace-workflow-config',
+    )
+
+
 def test_wildcard_keyword():
     run(dpath("test_wildcard_keyword"))
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

Adds a new flag `--replace-workflow-config` to change the behavior of config file merging: Instead of extended und updating the values in the config dictionary of the workflow, the config dictionary provided via CLI replaces the workflow dictionary entirely. Keys that are not redefined via the CLI dictionary are not present in the final config.

This addresses the request from #730 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command‐line option allowing users to fully replace the workflow configuration with a provided configuration file, ensuring only the specified settings are applied.
  - Enhanced logging now clearly indicates whether configurations are being extended or replaced, providing clearer insights during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->