### PR TITLE
fix: Show apptainer image URL in snakemake report

### DIFF
--- a/src/snakemake/report/html_reporter/template/components/rule_info.js
+++ b/src/snakemake/report/html_reporter/template/components/rule_info.js
@@ -41,7 +41,7 @@ class RuleInfo extends React.Component {
             this.renderItems("Input", rule.input, {}, false),
             this.renderItems("Output", rule.output),
             this.renderSoftware(),
-            this.renderItems("Container", [rule.container]),
+            this.renderItems("Container", [rule.container_img_url]),
             this.renderCode(),
         )
     }


### PR DESCRIPTION
Closes #3406 

Show Apptainer image URL in software section of rules in report

### QC

*  [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
*  [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the presentation of the Container section in reports to display a specific image, providing a clearer and more visually appealing view. The update refines what users see by ensuring the display now presents the intended image reference for improved clarity in the report. Overall, this change delivers a better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->