### PR TITLE
feat: Fix keep_local in storage directive and more freedom over remote retrieval behaviour

### DIFF
--- a/docs/snakefiles/storage.rst
+++ b/docs/snakefiles/storage.rst
@@ -138,6 +138,68 @@ each time providing a different tag::
         shell:
             "..."
 
+Retrieving and keeping remote files locally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When the input file is a remote file, the default behaviour is to download the remote
+file to the local area and then remove it after the workflow no longer needs it.
+
+This behaviour can be configured from the command line arguments, using::
+
+    snakemake --keep-storage-local-copies --not-retrieve-storage
+
+where ``--keep-storage-local-copies`` directs snakemake to keep the local copies of
+remote files that it makes and ``--not-retrieve-storage`` directs snakemake to not download
+copies of remote files.
+
+Additionally, this behaviour can be set at the level of the storage directive e.g.::
+
+    storage:
+        provider="http",
+        retrieve=False,
+
+    storage http_local:
+        provider="http",
+        keep_local=True,
+
+    rule example_remote:
+        input:
+            storage.http("http://example.com/example.txt")
+        output:
+            "example_remote.txt"
+        shell:
+            "..."
+
+    rule example_local:
+        input:
+            storage.http_local("http://example.com/example.txt")
+        output:
+            "example_local.txt"
+        shell:
+            "..."
+
+Finally, ``retrieve`` and ``keep_local`` can also be set inside the call to the storage
+plugin within a rule::
+
+    storage:
+        provider="http",
+        retrieve=False,
+
+    rule example_remote:
+        input:
+            storage.http("http://example.com/example.txt", retrieve=False)
+        output:
+            "example_remote.txt"
+        shell:
+            "..."
+
+    rule example_local:
+        input:
+            storage.http("http://example.com/example.txt", keep_local=True)
+        output:
+            "example_local.txt"
+        shell:
+            "..."
 
 Automatic inference
 ^^^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   "smart-open>=4.0,<8.0",
   "snakemake-interface-executor-plugins>=9.3.2,<10.0",
   "snakemake-interface-common>=1.17.0,<2.0",
-  "snakemake-interface-storage-plugins>=3.2.3,<4.0",
+  "snakemake-interface-storage-plugins>=3.5.0,<4.0",
   "snakemake-interface-report-plugins>=1.1.0,<2.0.0",
   "snakemake-interface-logger-plugins>=1.1.0,<2.0.0",
   "tabulate",

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1375,6 +1375,11 @@ def get_argument_parser(profiles=None):
         help="Keep local copies of remote input and output files.",
     )
     group_behavior.add_argument(
+        "--not-retrieve-storage",
+        action="store_true",
+        help="Do not retrieve remote files (default is to retrieve remote files).",
+    )
+    group_behavior.add_argument(
         "--target-files-omit-workdir-adjustment",
         action="store_true",
         help="Do not adjust the paths of given target files relative to the working directory.",
@@ -1976,6 +1981,7 @@ def args_to_api(args, parser):
                 remote_job_local_storage_prefix=args.remote_job_local_storage_prefix,
                 shared_fs_usage=args.shared_fs_usage,
                 keep_storage_local=args.keep_storage_local_copies,
+                retrieve_storage=not args.not_retrieve_storage,
                 notemp=args.notemp,
                 all_temp=args.all_temp,
                 unneeded_temp_files=args.unneeded_temp_files,

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -450,7 +450,11 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             ) or (self.workflow.remote_exec and not shared_local_copies):
                 async with asyncio.TaskGroup() as tg:
                     for f in chain(job.input, job.output):
-                        if f.is_storage and f not in cleaned and not f.should_keep_local:
+                        if (
+                            f.is_storage
+                            and f not in cleaned
+                            and not f.should_keep_local
+                        ):
                             f.storage_object.cleanup()
                             tg.create_task(
                                 f.remove(remove_non_empty_dir=True, only_local=True)

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -450,7 +450,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             ) or (self.workflow.remote_exec and not shared_local_copies):
                 async with asyncio.TaskGroup() as tg:
                     for f in chain(job.input, job.output):
-                        if f.is_storage and f not in cleaned:
+                        if f.is_storage and f not in cleaned and not f.should_keep_local:
                             f.storage_object.cleanup()
                             tg.create_task(
                                 f.remove(remove_non_empty_dir=True, only_local=True)

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -229,6 +229,7 @@ class StorageSettings(SettingsBase, StorageSettingsExecutorInterface):
     default_storage_prefix: Optional[str] = None
     shared_fs_usage: AnySet[SharedFSUsage] = SharedFSUsage.all()
     keep_storage_local: bool = False
+    retrieve_storage: bool = True
     local_storage_prefix: Path = Path(".snakemake/storage")
     remote_job_local_storage_prefix: Optional[Path] = None
     notemp: bool = False

--- a/src/snakemake/storage.py
+++ b/src/snakemake/storage.py
@@ -95,11 +95,21 @@ class StorageRegistry:
                 f"{plugin.name} is not."
             )
 
-        keep_local = settings["keep_local"] if "keep_local" in settings else self.workflow.storage_settings.keep_storage_local
+        keep_local = (
+            settings["keep_local"]
+            if "keep_local" in settings
+            else self.workflow.storage_settings.keep_storage_local
+        )
+        retrieve = (
+            settings["retrieve"]
+            if "retrieve" in settings
+            else self.workflow.storage_settings.retrieve_storage
+        )
         provider_instance = plugin.storage_provider(
             local_prefix=local_prefix,
             settings=final_settings,
             keep_local=keep_local,
+            retrieve=retrieve,
             is_default=is_default,
         )
         self._storages[name] = provider_instance
@@ -107,11 +117,14 @@ class StorageRegistry:
         # untagged provider is registered later without the settings
         # prevent the settings loss by registering it here
         if tag is not None and plugin.name not in self._storages:
-            local_prefix = self.workflow.storage_settings.local_storage_prefix / plugin.name
+            local_prefix = (
+                self.workflow.storage_settings.local_storage_prefix / plugin.name
+            )
             provider_instance = plugin.storage_provider(
                 local_prefix=local_prefix,
                 settings=final_settings,
                 keep_local=keep_local,
+                retrieve=retrieve,
                 is_default=is_default,
             )
             self._storages[plugin.name] = provider_instance
@@ -149,7 +162,7 @@ class StorageRegistry:
     def __call__(
         self,
         query: str,
-        retrieve: bool = True,
+        retrieve: Optional[bool] = None,
         keep_local: Optional[bool] = None,
     ):
         return self._storage_object(
@@ -160,7 +173,7 @@ class StorageRegistry:
         self,
         query: Union[str, List[str]],
         provider: Optional[str] = None,
-        retrieve: bool = True,
+        retrieve: Optional[bool] = None,
         keep_local: Optional[bool] = None,
     ):
         if isinstance(query, list):
@@ -203,7 +216,7 @@ class StorageProviderProxy:
     def __call__(
         self,
         query: str,
-        retrieve: bool = True,
+        retrieve: Optional[bool] = None,
         keep_local: Optional[bool] = None,
     ):
         return self.registry._storage_object(

--- a/src/snakemake/storage.py
+++ b/src/snakemake/storage.py
@@ -95,15 +95,11 @@ class StorageRegistry:
                 f"{plugin.name} is not."
             )
 
-        keep_local = (
-            settings["keep_local"]
-            if "keep_local" in settings
-            else self.workflow.storage_settings.keep_storage_local
+        keep_local = settings.get(
+            "keep_local", self.workflow.storage_settings.keep_storage_local
         )
-        retrieve = (
-            settings["retrieve"]
-            if "retrieve" in settings
-            else self.workflow.storage_settings.retrieve_storage
+        retrieve = settings.get(
+            "retrieve", self.workflow.storage_settings.retrieve_storage
         )
         provider_instance = plugin.storage_provider(
             local_prefix=local_prefix,

--- a/tests/test_local_and_retrieve/keep_local.smk
+++ b/tests/test_local_and_retrieve/keep_local.smk
@@ -1,0 +1,26 @@
+storage:
+    provider="http"
+
+storage http_local:
+    provider="http",
+    keep_local=True
+
+rule keep_local_default:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png")
+    output: "keep_local_default.flag"
+    shell: "touch {output}"
+
+rule keep_local_true:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png", keep_local=True)
+    output: "keep_local_true.flag"
+    shell: "touch {output}"
+
+rule keep_local_false:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png", keep_local=False)
+    output: "keep_local_false.flag"
+    shell: "touch {output}"
+
+rule keep_local_true_directive:
+    input: storage.http_local("https://github.com/snakemake/snakemake/blob/main/images/logo.png")
+    output: "keep_local_true_directive.flag"
+    shell: "touch {output}"

--- a/tests/test_local_and_retrieve/retrieve.smk
+++ b/tests/test_local_and_retrieve/retrieve.smk
@@ -1,0 +1,29 @@
+storage:
+    provider="http",
+    keep_local=True
+
+storage http_ret:
+    provider="http",
+    keep_local=True,
+    retrieve=False,
+
+
+rule retrieve_default:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png")
+    output: "retrieve_default.flag"
+    shell: "touch {output}"
+
+rule retrieve_true:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png", retrieve=True)
+    output: "retrieve_true.flag"
+    shell: "touch {output}"
+
+rule retrieve_false:
+    input: storage.http("https://github.com/snakemake/snakemake/blob/main/images/logo.png", retrieve=False)
+    output: "retrieve_false.flag"
+    shell: "touch {output}"
+
+rule retrieve_false_directive:
+    input: storage.http_ret("https://github.com/snakemake/snakemake/blob/main/images/logo.png")
+    output: "retrieve_false_directive.flag"
+    shell: "touch {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2176,3 +2176,95 @@ def test_nodelocal():
     assert not (work_path / "local/temp.txt").exists() or not any(
         (work_path / "scratch/").iterdir()
     )
+
+
+def test_keep_local():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        snakefile = os.path.join(dpath("test_local_and_retrieve"), "keep_local.smk")
+        local_img = os.path.join(
+            tmpdir,
+            ".snakemake/storage/http/github.com/snakemake/snakemake/blob/main/images/logo.png",
+        )
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "keep_local_default.flag"], cwd=tmpdir
+        )
+        assert not os.path.exists(local_img)
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "keep_local_false.flag"], cwd=tmpdir
+        )
+        assert not os.path.exists(local_img)
+
+        p = sp.check_output(
+            [
+                "snakemake",
+                "-s",
+                snakefile,
+                "-c1",
+                "keep_local_default.flag",
+                "--force",
+                "--keep-storage-local-copies",
+            ],
+            cwd=tmpdir,
+        )
+        assert os.path.exists(local_img)
+        shutil.rmtree(os.path.join(tmpdir, ".snakemake", "storage", "http"))
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "keep_local_true.flag"], cwd=tmpdir
+        )
+        assert os.path.exists(local_img)
+        shutil.rmtree(os.path.join(tmpdir, ".snakemake", "storage", "http"))
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "keep_local_true_directive.flag"],
+            cwd=tmpdir,
+        )
+        assert os.path.exists(local_img.replace("http", "http_local"))
+
+
+def test_retrieve():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        snakefile = os.path.join(dpath("test_local_and_retrieve"), "retrieve.smk")
+        local_img = os.path.join(
+            tmpdir,
+            ".snakemake/storage/http/github.com/snakemake/snakemake/blob/main/images/logo.png",
+        )
+
+        p = sp.check_output(
+            [
+                "snakemake",
+                "-s",
+                snakefile,
+                "-c1",
+                "retrieve_default.flag",
+                "--not-retrieve-storage",
+            ],
+            cwd=tmpdir,
+        )
+        assert not os.path.exists(local_img)
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "retrieve_false.flag"], cwd=tmpdir
+        )
+        assert not os.path.exists(local_img)
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "retrieve_false_directive.flag"],
+            cwd=tmpdir,
+        )
+        assert not os.path.exists(local_img.replace("http", "http_ret"))
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "retrieve_default.flag", "--force"],
+            cwd=tmpdir,
+        )
+        assert os.path.exists(local_img)
+
+        shutil.rmtree(os.path.join(tmpdir, ".snakemake", "storage", "http"))
+
+        p = sp.check_output(
+            ["snakemake", "-s", snakefile, "-c1", "retrieve_true.flag"], cwd=tmpdir
+        )
+        assert os.path.exists(local_img)


### PR DESCRIPTION
This PR enhances the behaviour of `keep_local` and `retrieve` when using remote storage plugins:
* `keep_local` was not always respected when used in a storage directive (see https://github.com/snakemake/snakemake/issues/2844 e.g.)
* This allows `keep_local` to be specified in the storage directive (which overrides the CLI argument) and in the call to `storage` (which overrides the specification, if any, in the storage directive)
* The default behaviour for retrieving remote files is to always do so unless `retrieve=False` is used in the call to `storage`
  * This PR moves the behaviour more inline with `keep_local` i.e. a default behaviour can be specified with a new CLI argument `--not-retrieve-local` (not a very graceful name, open to suggestions!)
  * The default behaviour is to keep `retrieve=True` as is currently the case in snakemake but it can be overridden in a storage directive
* This requires some small changes in `snakemake-interface-storage-plugins` which I will open another PR for

This PR also changes the behaviour when defining a tagged storage provider without specifying the default:
* If a tagged storage provider is defined but not the default one, then the settings of the tagged provider are not properly respected as the underlying provider is registered later only when the `storage_object` is accessed i.e. it has no access to the tagged settings
* This is changed by checking, when a tagged storage provider is registered, if the underlying provider has not yet been registered then it is registered using the same settings as the tagged provider

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation to guide users on managing remote files and controlling local file retention through new options.

- **New Features**
  - Introduced a command-line option to disable remote file downloads.
  - Enhanced the workflow's cleanup process to preserve local files when desired.
  - Added configurable settings for controlling file retrieval and local storage behavior.

- **Tests**
  - Included new example workflows and automated tests to showcase and verify the updated storage and retrieval functionalities.
  - Added tests for local storage retention and retrieval behaviors under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->