### PR TITLE
feat: keep shadow folder of failed job when `--keep-incomplete` flag is set

### DIFF
--- a/snakemake/api.py
+++ b/snakemake/api.py
@@ -244,6 +244,7 @@ class SnakemakeApi(ApiBase):
         stdout: bool = False,
         mode: ExecMode = ExecMode.DEFAULT,
         dryrun: bool = False,
+        keep_incomplete: bool = False,
     ):
         if not self.output_settings.keep_logger:
             setup_logger(
@@ -257,6 +258,7 @@ class SnakemakeApi(ApiBase):
                 mode=mode,
                 show_failed_logs=self.output_settings.show_failed_logs,
                 dryrun=dryrun,
+                keep_incomplete=keep_incomplete,
             )
 
     def _check_is_in_context(self):
@@ -531,6 +533,7 @@ class DAGApi(ApiBase):
             stdout=executor_plugin.common_settings.dryrun_exec,
             mode=self.workflow_api.workflow_settings.exec_mode,
             dryrun=executor_plugin.common_settings.dryrun_exec,
+            keep_incomplete=execution_settings.keep_incomplete,
         )
 
         if executor_plugin.common_settings.local_exec:

--- a/snakemake/dag.py
+++ b/snakemake/dag.py
@@ -779,9 +779,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                         rule=job.rule,
                     )
 
-    def unshadow_output(self, job, only_log=False):
+    def unshadow_output(self, job, only_log=False, keep=False):
         """Move files from shadow directory to real output paths."""
-        if not job.shadow_dir or not job.output:
+        if not job.shadow_dir:
+            return
+        if not job.output:
+            shutil.rmtree(job.shadow_dir)
             return
 
         files = job.log if only_log else chain(job.output, job.log)
@@ -799,7 +802,8 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             if os.path.realpath(shadow_output) == os.path.realpath(real_output):
                 continue
             shutil.move(shadow_output, real_output)
-        shutil.rmtree(job.shadow_dir)
+        if not keep:
+            shutil.rmtree(job.shadow_dir)
 
     def check_periodic_wildcards(self, job):
         """Raise an exception if a wildcard of the given job appears to be periodic,

--- a/snakemake/executors/local.py
+++ b/snakemake/executors/local.py
@@ -59,7 +59,7 @@ except ImportError:
 class Executor(RealExecutor):
     def __post_init__(self):
         self.use_threads = self.workflow.execution_settings.use_threads
-        self.keepincomplete = self.workflow.execution_settings.keep_incomplete
+        self.keep_incomplete = self.workflow.execution_settings.keep_incomplete
         cores = self.workflow.resource_settings.cores
 
         # Zero thread jobs do not need a thread, but they occupy additional workers.

--- a/snakemake/logging.py
+++ b/snakemake/logging.py
@@ -322,6 +322,7 @@ class Logger:
         self.show_failed_logs = False
         self.logfile_handler = None
         self.dryrun = False
+        self.log_shadow = False
 
     def setup_logfile(self):
         from snakemake_interface_executor_plugins.settings import ExecMode
@@ -584,6 +585,9 @@ class Logger:
                     yield "    shell:\n        {}\n        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)".format(
                         msg["shellcmd"]
                     )
+                if self.log_shadow and msg["shadow_dir"]:
+                    yield "    shadow: {}".format(msg["shadow_dir"])
+                    yield "        (shadow folder of broken job was kept permanently as `--keep-incomplete` was set)"
 
                 for item in msg["aux"].items():
                     yield "    {}: {}".format(*item)
@@ -738,6 +742,7 @@ def setup_logger(
     mode=None,
     show_failed_logs=False,
     dryrun=False,
+    keep_incomplete=False,
 ):
     from snakemake.settings.types import Quietness
 
@@ -774,3 +779,4 @@ def setup_logger(
     logger.mode = mode
     logger.dryrun = dryrun
     logger.show_failed_logs = show_failed_logs
+    logger.log_shadow = keep_incomplete

--- a/tests/test_incomplete_shadow/Snakefile
+++ b/tests/test_incomplete_shadow/Snakefile
@@ -1,0 +1,36 @@
+rule run:
+    params:
+        ki="--keep-incomplete",
+    shadow:
+        "shallow"
+    run:
+        shell(
+            "(python -m snakemake -s Snakefile fail {params.ki} > fail.log 2>&1) || echo 1"
+        )
+        with open("fail.log") as fi:
+            for line in fi:
+                if line.startswith("Error in rule fail:"):
+                    break
+            for line in fi:
+                if line.startswith("    shadow: "):
+                    break
+            else:
+                raise ValueError("shadow not found")
+            shadow_path = line[12:].strip()
+            with open(f"{shadow_path}/fail.txt") as fi:
+                assert fi.read().strip() == "success"
+
+
+use rule run as run2 with:
+    params:
+        ki="",
+
+
+rule fail:
+    output:
+        "fail.txt",
+    shadow:
+        "shallow"
+    run:
+        shell("echo success > fail.txt")
+        raise

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1159,6 +1159,16 @@ def test_issue1037():
     )
 
 
+def test_incomplete_shadow():
+    run(dpath("test_incomplete_shadow"), check_results=False)
+    run(
+        dpath("test_incomplete_shadow"),
+        check_results=False,
+        shouldfail=True,
+        targets=["run2"],
+    )
+
+
 def test_checkpoints():
     run(dpath("test_checkpoints"))
 


### PR DESCRIPTION
will fit #3412

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). (planing to)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced workflow execution with options to preserve detailed logs for incomplete jobs, enabling improved diagnostic feedback and more flexible handling of job outputs.
- **Tests**
  - Introduced new workflows and test cases that simulate failure scenarios to validate the proper functioning of the incomplete job log handling and output cleanup features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->