### PR TITLE
fix: ReadTheDocs layout issue due to src directory change

### DIFF
--- a/apidocs/conf.py
+++ b/apidocs/conf.py
@@ -22,7 +22,7 @@ from sphinxawesome_theme.postprocess import Icons
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(0, os.path.abspath("../src/"))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,7 @@ from sphinxawesome_theme.postprocess import Icons
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../"))
-
+sys.path.insert(0, os.path.abspath("../src/"))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
Update the documentation configuration to reflect the new source directory structure, ensuring compatibility with ReadTheDocs.

Logs from readthedocs build:

https://app.readthedocs.org/api/v2/build/27498010.txt

https://app.readthedocs.org/projects/snakemake/builds/27498010/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Adjusted the documentation build configuration to reference the correct source location, ensuring that generated documentation accurately reflects the available modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->