### PR TITLE
fix: DeprecationWarning when using snakemake.utils.validate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "psutil",
   "pulp>=2.3.1,<2.10",
   "pyyaml",
+  "referencing",
   "requests>=2.8.1,<3.0",
   "reretry",
   "smart-open>=4.0,<8.0",

--- a/src/snakemake/utils.py
+++ b/src/snakemake/utils.py
@@ -101,7 +101,6 @@ def validate(data, schema, set_default=True):
         )
         logger.warning("Note that schema file may not be validated correctly.")
     Defaultvalidator = extend_with_default(Validator)
-    print(Validator.META_SCHEMA["$schema"])
 
     def _validate_record(record):
         if set_default:

--- a/src/snakemake/utils.py
+++ b/src/snakemake/utils.py
@@ -102,6 +102,7 @@ def validate(data, schema, set_default=True):
         logger.warning("Note that schema file may not be validated correctly.")
     Defaultvalidator = extend_with_default(Validator)
     print(Validator.META_SCHEMA["$schema"])
+
     def _validate_record(record):
         if set_default:
             Defaultvalidator(schema, registry=registry).validate(record)


### PR DESCRIPTION
This PR closes #2468, by replacing RefResolver functionality with the referencing library.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
