### PR TITLE
fix: Update ReadTheDocs configuration for documentation build to use Pixi

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,7 @@ build:
     - mamba install -c conda-forge -c nodefaults pixi
     - pixi install --environment docs
     - pixi run --environment docs build-docs
+    - mkdir -p $READTHEDOCS_OUTPUT/html
     - rm -rf $READTHEDOCS_OUTPUT/html && mv docs/_build/html $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,8 @@ build:
     python: mambaforge-latest
   commands:
     - mamba install -c conda-forge -c nodefaults pixi
-    - pixi shell --environment docs
-    - pixi run build-docs
+    - pixi install --environment docs
+    - pixi run --environment docs build-docs
     - rm -rf $READTHEDOCS_OUTPUT/html && mv docs/_build/html $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-
+    # this ensures a viable `mamba` is on `$PATH``
+    python: mambaforge-latest
+  commands:
+    - mamba install -c conda-forge -c nodefaults pixi
+    - pixi shell --environment docs
+    - pixi run build-docs
+    - rm -rf $READTHEDOCS_OUTPUT/html && mv docs/_build/html $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/conf.py
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,3 @@ build:
     - rm -rf $READTHEDOCS_OUTPUT/html && mv docs/_build/html $READTHEDOCS_OUTPUT/html
 sphinx:
   configuration: docs/conf.py
-
-python:
-  install:
-    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ from sphinxawesome_theme.postprocess import Icons
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../src/"))
+# sys.path.insert(0, os.path.abspath("../src/"))
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 from datetime import datetime
 from sphinxawesome_theme.postprocess import Icons
@@ -23,6 +22,7 @@ from sphinxawesome_theme.postprocess import Icons
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath("../src/"))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.


### PR DESCRIPTION
- just using pixi now to build the docs within ReadTheDocs Environment 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the documentation build process with an updated configuration that leverages a modern runtime environment and improved dependency management.
- **Documentation**
  - Streamlined the setup to ensure a more reliable and consistent generation of documentation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->