### PR TITLE
Add a check for nodelocal when selecting which files to store

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -451,6 +451,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                                     and f
                                     not in self.workflow.storage_settings.unneeded_temp_files
                                     and await f.exists_local()
+                                    and not is_flagged(f, "nodelocal")
                                 )
 
                             if self.finished(job):


### PR DESCRIPTION
<!--Add a description of your PR here-->

This change ensures that `temp(, group_jobs=True)` outputs are not uploaded to cloud storage.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ x ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ x ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
