### PR TITLE
fix: group job error call

### DIFF
--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -1477,6 +1477,8 @@ class GroupJob(AbstractJob, GroupJobExecutorInterface):
                 **kwargs,
             ),
         )
+        for job in sorted(self.jobs, key=lambda j: j.rule.name):
+            job.log_error(indent=True)
 
     def register(self, external_jobid: Optional[str] = None):
         for job in self.jobs:

--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -22,6 +22,7 @@ from snakemake.common import async_run
 
 from snakemake.exceptions import RuleException, WorkflowError, print_exception
 from snakemake.logging import logger
+from snakemake.jobs import GroupJob
 
 from snakemake.settings.types import MaxJobsPerTimespan
 
@@ -216,10 +217,13 @@ class JobScheduler(JobSchedulerExecutorInterface):
                         if not user_kill:
                             logger.error(_ERROR_MSG_FINAL)
                             for job in self.failed:
-                                logger.error(
-                                    f"Error in jobid: {self.workflow.dag.jobid(job)}",
-                                    extra=job.get_log_error_info(),
-                                )
+                                if isinstance(job, GroupJob):
+                                    job.log_error()
+                                else:
+                                    logger.error(
+                                        f"Error in jobid: {self.workflow.dag.jobid(job)}",
+                                        extra=job.get_log_error_info(),
+                                    )
                         return False
                     continue
 


### PR DESCRIPTION
This wasn't caught earlier, likely due to how we check for tests that expect failure. The `test_group_jobs_fail` test was failing, but it was b/c of this issue. Perhaps should check for the expected exception.
### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error logging to display grouped job errors in a sorted, consistent order for clearer troubleshooting.
  - Introduced tailored error logging during job scheduling, ensuring that errors for grouped jobs are handled separately for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->