### PR TITLE
docs: fix profiles linking, add Sphinx rst syntax infos

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -106,7 +106,7 @@ Snakemake will process beyond the rule ``myrule``, because all of its input file
 Obviously, a good choice of the rule to perform the batching is a rule that has a lot of input files and upstream jobs, for example a central aggregation step within your workflow.
 We advice all workflow developers to inform potential users of the best suited batching rule.
 
-.. _profiles:
+.. _executing-profiles:
 
 --------
 Profiles

--- a/docs/getting_started/migration.rst
+++ b/docs/getting_started/migration.rst
@@ -577,7 +577,7 @@ Profiles
 ^^^^^^^^
 
 Profiles can now be versioned.
-If your profile makes use of settings that are available in version 8 or later, use the filename ``config.v8+.yaml`` for the profile configuration (see :ref:`profiles <profiles>`).
+If your profile makes use of settings that are available in version 8 or later, use the filename ``config.v8+.yaml`` for the profile configuration (see :ref:`executing-profiles`).
 
 API
 ^^^

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -251,7 +251,7 @@ Documentation Guidelines
 ========================
 
 The documentation uses `Sphinx <https://www.sphinx-doc.org/>`_ and is written in ``reStructuredText``.
-For details on the syntax, see the `Sphinx primer on reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer>`_ and the `Sphinx documentation on crossreferences <https://www.sphinx-doc.org/en/master/usage/referencing.html>`_.
+For details on the syntax, see the `Sphinx primer on reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer>`_ and the `Sphinx documentation on cross-references <https://www.sphinx-doc.org/en/master/usage/referencing.html>`_.
 
 For the documentation, please adhere to the following guidelines:
 

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -57,7 +57,7 @@ Write Documentation
 Snakemake could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
 
 Snakemake uses `Sphinx <https://sphinx-doc.org>`_ for the user manual (that you are currently reading).
-See :ref:`project_info-doc_guidelines` on how the documentation reStructuredText is used.
+See :ref:`project_info-doc_guidelines` on how the reStructuredText is used for the documentation.
 
 
 
@@ -250,7 +250,7 @@ The existing unit tests should all cope with this, and in general you should avo
 Documentation Guidelines
 ========================
 
-The documentation uses `Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ and is written in ``reStructuredText``.
+The documentation uses `Sphinx <https://www.sphinx-doc.org/>`_ and is written in ``reStructuredText``.
 For details on the syntax, see the `Sphinx primer on reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer>`_ and the `Sphinx documentation on crossreferences <https://www.sphinx-doc.org/en/master/usage/referencing.html>`_.
 
 For the documentation, please adhere to the following guidelines:
@@ -259,7 +259,7 @@ For the documentation, please adhere to the following guidelines:
 - Provide `hyperlink targets <https://www.sphinx-doc.org/en/master/usage/referencing.html#cross-referencing-arbitrary-locations>`_, at least for the first two section levels.
   For this, use the format ``<document_part>-<section_name>``, for example ``project_info-doc_guidelines`` for the current section.
   Set the hyperlink target right above the section heading with ``.. _project_info-doc_guidelines:``.
-  Reference the hyperlink (i.e. link to it) with ``::ref`project_info-doc_guidelines```.
+  Reference the hyperlink (i.e. link to it) with ``:ref:`project_info-doc_guidelines```.
 - Use the `section structure recommended by Sphinx <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_, which references the `recommendations in the Python Developer's Guide <https://devguide.python.org/documentation/markup/#sections>`_.
   Namely, the levels are:
 

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -56,7 +56,9 @@ Write Documentation
 
 Snakemake could always use more documentation, whether as part of the official docs, in docstrings, or even on the web in blog posts, articles, and such.
 
-Snakemake uses `Sphinx <https://sphinx-doc.org>`_ for the user manual (that you are currently reading).
+.. _Sphinx: https://sphinx-doc.org
+
+Snakemake uses `Sphinx`_ for the user manual (that you are currently reading).
 See :ref:`project_info-doc_guidelines` on how the reStructuredText is used for the documentation.
 
 
@@ -250,7 +252,7 @@ The existing unit tests should all cope with this, and in general you should avo
 Documentation Guidelines
 ========================
 
-The documentation uses `Sphinx <https://www.sphinx-doc.org/>`_ and is written in ``reStructuredText``.
+The documentation uses `Sphinx`_ and is written in ``reStructuredText``.
 For details on the syntax, see the `Sphinx primer on reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer>`_ and the `Sphinx documentation on cross-references <https://www.sphinx-doc.org/en/master/usage/referencing.html>`_.
 
 For the documentation, please adhere to the following guidelines:

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -250,11 +250,16 @@ The existing unit tests should all cope with this, and in general you should avo
 Documentation Guidelines
 ========================
 
+The documentation uses `Sphinx <https://www.sphinx-doc.org/en/master/index.html>`_ and is written in ``reStructuredText``.
+For details on the syntax, see the `Sphinx primer on reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-primer>`_ and the `Sphinx documentation on crossreferences <https://www.sphinx-doc.org/en/master/usage/referencing.html>`_.
+
 For the documentation, please adhere to the following guidelines:
 
 - Put each sentence on its own line, this makes tracking changes through Git SCM easier.
-- Provide hyperlink targets, at least for the first two section levels.
-  For this, use the format ``<document_part>-<section_name>``, e.g., ``project_info-doc_guidelines``.
+- Provide `hyperlink targets <https://www.sphinx-doc.org/en/master/usage/referencing.html#cross-referencing-arbitrary-locations>`_, at least for the first two section levels.
+  For this, use the format ``<document_part>-<section_name>``, for example ``project_info-doc_guidelines`` for the current section.
+  Set the hyperlink target right above the section heading with ``.. _project_info-doc_guidelines:``.
+  Reference the hyperlink (i.e. link to it) with ``::ref`project_info-doc_guidelines```.
 - Use the `section structure recommended by Sphinx <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_, which references the `recommendations in the Python Developer's Guide <https://devguide.python.org/documentation/markup/#sections>`_.
   Namely, the levels are:
 

--- a/docs/snakefiles/configuration.rst
+++ b/docs/snakefiles/configuration.rst
@@ -226,4 +226,4 @@ Usually, it is preferred to only set the working directory via the command line,
 Cluster Configuration (not supported anymore)
 ---------------------------------------------
 
-The previously supported cluster configuration has been replaced by configuration profiles (see :ref:`profiles`).
+The previously supported cluster configuration has been replaced by configuration profiles (see :ref:`executing-profiles`).

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -842,7 +842,7 @@ Snakemake will always round the calculated value down (while enforcing a minimum
 
 Starting from version 3.7, threads can also be a callable that returns an ``int`` value. The signature of the callable should be ``callable(wildcards[, input])`` (input is an optional parameter).  It is also possible to refer to a predefined variable (e.g, ``threads: threads_max``) so that the number of cores for a set of rules can be changed with one change only by altering the value of the variable ``threads_max``.
 
-Both threads can be defined (or overwritten) upon invocation (without modifying the workflow code) via `--set-threads` see :ref:`all_options` and via workflow profiles, see :ref:`profiles`.
+Both threads can be defined (or overwritten) upon invocation (without modifying the workflow code) via `--set-threads` see :ref:`all_options` and via workflow profiles, see :ref:`executing-profiles`.
 To quickly exemplify the latter, you could provide the following workflow profile in a file ``profiles/default/config.yaml`` relative to the Snakefile or the current working directory:
 
 .. code-block:: yaml
@@ -957,7 +957,7 @@ Here, the value that the function ``get_mem_mb`` returns, grows linearly with th
 Of course, any other arithmetic could be performed in that function.
 
 Both threads and resources can be defined (or overwritten) upon invocation (without modifying the workflow code) via `--set-threads` and `--set-resources`, see :ref:`all_options`.
-Or they can be defined via workflow :ref:`profiles`, with the variables listed above in the signature for usable callables.
+Or they can be defined via workflow :ref:`executing-profiles`, with the variables listed above in the signature for usable callables.
 You could, for example, provide the following workflow profile in a file ``profiles/default/config.yaml`` relative to the Snakefile or the current working directory:
 
 .. code-block:: yaml


### PR DESCRIPTION
Since the inclusion of the migration guide, the linking to the `profiles` section on the CLI page was broken. This guide contains a heading of the name `profiles`, and Sphinx auto-generates links from headings. So this PR moves to the hyperlink target name `executing-profiles`, as this is what the documentation guidelines recommend, anyways.

In addition, it adds some essential info on the format used for the docs, with linkouts to the Sphinx documentation.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated label references from "profiles" to "executing-profiles" across several documentation sections for improved clarity on execution configurations.
	- Revised reference links in migration and configuration guides to direct users to the updated execution profiles information.
	- Enhanced contributor guidelines with additional details and links on using Sphinx and reStructuredText for improved documentation clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->