### PR TITLE
fix: only warn upon positional parameter overwrite with "use rule"  in case the number of positional parameters changes

### DIFF
--- a/src/snakemake/ruleinfo.py
+++ b/src/snakemake/ruleinfo.py
@@ -80,7 +80,9 @@ class RuleInfo:
                         modifier_positional, modifier_keyword = value
                         positional = original_positional
                         if modifier_positional:
-                            if original_positional:
+                            if original_positional and (
+                                len(original_positional) != len(modifier_positional)
+                            ):
                                 logger.warning(
                                     f"Overwriting positional arguments {original_positional} "
                                     f"with {modifier_positional} in rule {rulename}"


### PR DESCRIPTION


<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation logic to ensure warnings are triggered only when input discrepancies occur, reducing unnecessary alerts and helping maintain a cleaner output during configuration modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->