### PR TITLE
chore: work around issue with unavailable license file in one the of the report assets

### DIFF
--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -148,11 +148,13 @@ class Assets:
         # The license file included in the NPM package does not exist directly
         # in https://github.com/DefinitelyTyped/DefinitelyTyped, so we use an
         # unpkg URL to reference the contents of the NPM package instead.
-        "@types-estree/LICENSE": Asset(
-            url="https://unpkg.com/@types/estree@{version}/LICENSE",
-            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-            version="0.0.50",
-        ),
+        # TODO estree license is not present on unpkg anymore.
+        # TODO Also, the repo referenced about _does_ contain a license.
+        # "@types-estree/LICENSE": Asset(
+        #     url="https://unpkg.com/@types/estree@{version}/LICENSE",
+        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+        #     version="0.0.50",
+        # ),
         # Via vega-force
         "d3-force/LICENSE": Asset(
             url="https://raw.githubusercontent.com/d3/d3-force/refs/tags/v{version}/LICENSE",

--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -363,11 +363,13 @@ class Assets:
         ),
         # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
         # Versions from https://github.com/vega/vega-lite/blob/v5.2.0/yarn.lock.
-        "@types-clone/LICENSE": Asset(
-            url="https://unpkg.com/@types/clone@{version}/LICENSE",
-            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-            version="2.1.1",
-        ),
+        # TODO: file not present on unpkg, disable for now and seek for a better source
+        # in the future
+        # "@types-clone/LICENSE": Asset(
+        #     url="https://unpkg.com/@types/clone@{version}/LICENSE",
+        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+        #     version="2.1.1",
+        # ),
         "array-flat-polyfill/LICENSE": Asset(
             # Releases are not tagged in git; we use the commit hash
             # corresponding to the 1.0.1 release

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -60,9 +60,10 @@ def get_packages():
             "d3-scale": Package(
                 license_path="d3-scale/LICENSE",
             ),
-            "@types-estree": Package(
-                license_path="@types-estree/LICENSE",
-            ),
+            # TODO reactivate once we have a license again in the assets
+            # "@types-estree": Package(
+            #     license_path="@types-estree/LICENSE",
+            # ),
             "d3-force": Package(
                 license_path="d3-force/LICENSE",
             ),

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -140,9 +140,10 @@ def get_packages():
             ),
             # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
             # (excluding those shared with vega and therefore already documented)
-            "@types-clone": Package(
-                license_path="@types-estree/LICENSE",
-            ),
+            # TODO reactivate once we have a license again in the assets
+            # "@types-clone": Package(
+            #     license_path="@types-estree/LICENSE",
+            # ),
             "array-flat-polyfill": Package(
                 license_path="array-flat-polyfill/LICENSE",
             ),


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Revised asset management by commenting out outdated licensing references for `@types-estree` and `@types-clone`.
  - Added internal guidance notes for potential future evaluations.
  - Core functionality remains unchanged, ensuring a seamless user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->