### PR TITLE
chore: Allow PuLP 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "nbformat",
   "packaging",
   "psutil",
-  "pulp>=2.3.1,<2.10",
+  "pulp>=2.3.1,<3.1",
   "pyyaml",
   "requests>=2.8.1,<3.0",
   "reretry",


### PR DESCRIPTION
Widen the version bounds on the `pulp` dependency to allow releases in the 3.0.x series. Continue to respect the existing practice of pinning to the minor release. Therefore, `"pulp>=2.3.1,<2.10"` becomes `"pulp>=2.3.1,<3.1"`.

Looking at the changes in https://github.com/coin-or/pulp/compare/2.9.0...3.0.0, there were some minor changes in model-specific APIs. For example, the `strong` keyword to the `COIN_CMD` initializer was changed from a `bool` to an `int`. However, I did not see anything that looked like it would affect the generic APIs used in Snakemake, and the tests that I was able to run locally (not all of them, to be sure) did not show any obvious pulp-related regressions.

The current release of PuLP is [3.0.2](https://pypi.org/project/PuLP/3.0.2/).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).