### PR TITLE
chore: Use data: URLs to work around DefinitelyTyped license discrepancies

### DIFF
--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.resources
 from pathlib import Path
 from typing import Dict, Optional
+import urllib.parse
 import urllib.request
 import urllib.error
 
@@ -146,15 +147,42 @@ class Assets:
         ),
         # Via vega-expression (vega-lite also depends on vega-expression)
         # The license file included in the NPM package does not exist directly
-        # in https://github.com/DefinitelyTyped/DefinitelyTyped, so we use an
-        # unpkg URL to reference the contents of the NPM package instead.
-        # TODO estree license is not present on unpkg anymore.
-        # TODO Also, the repo referenced about _does_ contain a license.
-        # "@types-estree/LICENSE": Asset(
-        #     url="https://unpkg.com/@types/estree@{version}/LICENSE",
-        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-        #     version="0.0.50",
-        # ),
+        # in https://github.com/DefinitelyTyped/DefinitelyTyped, so (lacking
+        # any other usable URL) we use a data: URL to provide the precise
+        # license text that is in the actual NPM package.
+        # See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50580
+        "@types-clone/LICENSE": Asset(
+            url="data:text/plain;charset=US-ASCII,{}".format(
+                urllib.parse.quote(
+                    """    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+""",
+                    safe="",
+                    encoding="ascii",
+                )
+            ),
+            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+            version="0.0.50",
+        ),
         # Via vega-force
         "d3-force/LICENSE": Asset(
             url="https://raw.githubusercontent.com/d3/d3-force/refs/tags/v{version}/LICENSE",
@@ -363,13 +391,43 @@ class Assets:
         ),
         # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
         # Versions from https://github.com/vega/vega-lite/blob/v5.2.0/yarn.lock.
-        # TODO: file not present on unpkg, disable for now and seek for a better source
-        # in the future
-        # "@types-clone/LICENSE": Asset(
-        #     url="https://unpkg.com/@types/clone@{version}/LICENSE",
-        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-        #     version="2.1.1",
-        # ),
+        # The license file included in the NPM package does not exist directly
+        # in https://github.com/DefinitelyTyped/DefinitelyTyped, so (lacking
+        # any other usable URL) we use a data: URL to provide the precise
+        # license text that is in the actual NPM package.
+        # See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50580
+        "@types-estree/LICENSE": Asset(
+            url="data:text/plain;charset=US-ASCII,{}".format(
+                urllib.parse.quote(
+                    """    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+""",
+                    safe="",
+                    encoding="ascii",
+                )
+            ),
+            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+            version="2.1.1",
+        ),
         "array-flat-polyfill/LICENSE": Asset(
             # Releases are not tagged in git; we use the commit hash
             # corresponding to the 1.0.1 release

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -60,10 +60,9 @@ def get_packages():
             "d3-scale": Package(
                 license_path="d3-scale/LICENSE",
             ),
-            # TODO reactivate once we have a license again in the assets
-            # "@types-estree": Package(
-            #     license_path="@types-estree/LICENSE",
-            # ),
+            "@types-estree": Package(
+                license_path="@types-estree/LICENSE",
+            ),
             "d3-force": Package(
                 license_path="d3-force/LICENSE",
             ),
@@ -141,10 +140,9 @@ def get_packages():
             ),
             # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
             # (excluding those shared with vega and therefore already documented)
-            # TODO reactivate once we have a license again in the assets
-            # "@types-clone": Package(
-            #     license_path="@types-estree/LICENSE",
-            # ),
+            "@types-clone": Package(
+                license_path="@types-estree/LICENSE",
+            ),
             "array-flat-polyfill": Package(
                 license_path="array-flat-polyfill/LICENSE",
             ),

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -141,7 +141,7 @@ def get_packages():
             # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
             # (excluding those shared with vega and therefore already documented)
             "@types-clone": Package(
-                license_path="@types-estree/LICENSE",
+                license_path="@types-clone/LICENSE",
             ),
             "array-flat-polyfill": Package(
                 license_path="array-flat-polyfill/LICENSE",


### PR DESCRIPTION
See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/50580. While https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/LICENSE and the estree license (https://www.npmjs.com/package/@types/estree?activeTab=code) are both `MIT`, they don’t have the same copyright statement, and the MIT license does require reproducing that.

See also: https://github.com/snakemake/snakemake/commit/55202ba53896109e92fec323dfc8a9f5005a26e9

I’m not sure why unpkg no longer seems to be serving contents of some packages, breaking our previous workaround, but my suggestion is to use [`data:` URLs](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data) in `snakemake/assets/__init__.py` to work around the lack of suitable remote URLs for license text for these two packages.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case. **N/A**
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **N/A**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - License information is now embedded directly, ensuring that legal details display reliably without needing external links.
  - Reactivated package entries for `@types-estree` and `@types-clone`, now including their respective license paths.
- **Chores**
  - Removed outdated external references to streamline the handling of license data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->