### PR TITLE
chore: Adjust the version in the URL for tailwindcss/LICENSE

### DIFF
--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -60,7 +60,7 @@ class Assets:
         "tailwindcss/LICENSE": Asset(
             url="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/refs/tags/v{version}/LICENSE",
             sha256="60e0b68c0f35c078eef3a5d29419d0b03ff84ec1df9c3f9d6e39a519a5ae7985",
-            version="3.0.23",
+            version="3.4.16",
         ),
         "tailwindcss/tailwind.css": Asset(
             url="https://cdn.tailwindcss.com/{version}?plugins=forms@0.5.9,typography@0.5.2",


### PR DESCRIPTION
Make it match the version of `tailwindcss/tailwind.css`. The license text is unchanged.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case. **N/A**
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **N/A**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Tailwind CSS license asset version from 3.0.23 to 3.4.16, ensuring assets align with the latest standards. This internal update supports better compatibility with external dependencies and maintains the consistency of asset references without altering user-facing functionality.
  - Users will not notice any visible changes due to this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->