### PR TITLE
fix: setup_logfile in setup logger to ensure logfile handler is added

### DIFF
--- a/src/snakemake/api.py
+++ b/src/snakemake/api.py
@@ -590,8 +590,6 @@ class DAGApi(ApiBase):
             or not executor_plugin.common_settings.local_exec
         )
 
-        logger_manager.setup_logfile()
-
         workflow = self.workflow_api._workflow
         workflow.execution_settings = execution_settings
         workflow.remote_execution_settings = remote_execution_settings

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -645,8 +645,8 @@ class LoggerManager:
         stream_handler.name = "DefaultStreamHandler"
         return stream_handler
 
-    def get_logfile(self):
-        return self.logfile_handlers.values()
+    def get_logfile(self) -> list[str]:
+        return list(self.logfile_handlers.values())
 
     def logfile_hint(self):
         from snakemake_interface_executor_plugins.settings import ExecMode

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -664,6 +664,9 @@ class LoggerManager:
         if self.mode == ExecMode.DEFAULT:
             for handler in self.logfile_handlers.keys():
                 handler.close()
+                if hasattr(handler, "stream") and not handler.stream.closed:
+                    handler.stream.flush()
+                    handler.stream.close()
 
     def setup_logfile(self):
         from snakemake_interface_executor_plugins.settings import ExecMode

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -645,7 +645,7 @@ class LoggerManager:
         stream_handler.name = "DefaultStreamHandler"
         return stream_handler
 
-    def get_logfile(self) -> list[str]:
+    def get_logfile(self) -> List[str]:
         return list(self.logfile_handlers.values())
 
     def logfile_hint(self):

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -588,6 +588,9 @@ class LoggerManager:
         elif len(stream_handlers) == 0:
             # we dont have any stream_handlers from plugin(s) so give us the default one
             stream_handlers.append(self._default_streamhandler())
+
+        self.setup_logfile()
+
         all_handlers = (
             stream_handlers + other_handlers + list(self.logfile_handlers.keys())
         )
@@ -678,6 +681,7 @@ class LoggerManager:
                 )
                 handler = self._default_filehandler(logfile)
                 self.logfile_handlers[handler] = logfile
+
             except OSError as e:
                 self.logger.error(f"Failed to setup log file: {e}")
 

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -664,9 +664,6 @@ class LoggerManager:
         if self.mode == ExecMode.DEFAULT:
             for handler in self.logfile_handlers.keys():
                 handler.close()
-                if hasattr(handler, "stream") and not handler.stream.closed:
-                    handler.stream.flush()
-                    handler.stream.close()
 
     def setup_logfile(self):
         from snakemake_interface_executor_plugins.settings import ExecMode

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -663,6 +663,7 @@ class LoggerManager:
 
         if self.mode == ExecMode.DEFAULT:
             for handler in self.logfile_handlers.keys():
+                self.logger.removeHandler(handler)
                 handler.close()
 
     def setup_logfile(self):

--- a/tests/test_logfile/Snakefile
+++ b/tests/test_logfile/Snakefile
@@ -1,0 +1,10 @@
+rule all:
+    input:
+        expand("results/{i}.txt", i=range(5)),
+
+
+rule a:
+    output:
+        "results/{i}.txt",
+    shell:
+        "echo {wildcards.i} > {output}"

--- a/tests/test_logfile/Snakefile
+++ b/tests/test_logfile/Snakefile
@@ -1,3 +1,6 @@
+onsuccess:
+    shell("echo {log}")
+
 rule all:
     input:
         expand("results/{i}.txt", i=range(5)),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -36,6 +36,7 @@ from snakemake_interface_executor_plugins.settings import (
     SharedFSUsage,
 )
 
+
 def test_logfile():
     import glob
 
@@ -56,9 +57,9 @@ Finished jobid: 0 (Rule: all)
     with open(latest_log, "r") as f:
         log_content = f.read()
 
-    assert finished_stmt.strip() in log_content.strip(), (
-        f"Expected statement not found in log file. Log content: {log_content}"
-    )
+    assert (
+        finished_stmt.strip() in log_content.strip()
+    ), f"Expected statement not found in log file. Log content: {log_content}"
 
     shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -60,12 +60,12 @@ def test_github_issue_14():
     # Return temporary directory for inspection - we should keep scripts here
     tmpdir = run(dpath("test_github_issue_14"), cleanup=False, cleanup_scripts=False)
     assert os.listdir(os.path.join(tmpdir, ".snakemake", "scripts"))
-    shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 
     # And not here
     tmpdir = run(dpath("test_github_issue_14"), cleanup=False, cleanup_scripts=True)
     assert not os.listdir(os.path.join(tmpdir, ".snakemake", "scripts"))
-    shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 
 
 def test_issue956():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -36,6 +36,32 @@ from snakemake_interface_executor_plugins.settings import (
     SharedFSUsage,
 )
 
+def test_logfile():
+    import glob
+
+    tmpdir = run(dpath("test_logfile"), cleanup=False, check_results=False)
+    finished_stmt = """
+Finished jobid: 0 (Rule: all)
+6 of 6 steps (100%) done"""
+
+    log_dir = os.path.join(tmpdir, ".snakemake", "log")
+    assert os.path.exists(log_dir), "Log directory not found"
+
+    log_files = glob.glob(os.path.join(log_dir, "*.snakemake.log"))
+    assert log_files, "No log files found"
+
+    log_files.sort(key=os.path.getmtime, reverse=True)
+    latest_log = log_files[0]
+
+    with open(latest_log, "r") as f:
+        log_content = f.read()
+
+    assert finished_stmt.strip() in log_content.strip(), (
+        f"Expected statement not found in log file. Log content: {log_content}"
+    )
+
+    shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
+
 
 def test_list_untracked():
     run(dpath("test_list_untracked"))


### PR DESCRIPTION
Fixes oversight that resulted in empty log files. Will add a test soon.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test for verifying the existence and content of log files generated during execution.
	- Added a new workflow definition with rules for generating output files.

- **Refactor**
	- Enhanced the logging system to ensure log files are created during setup and improved the cleanup process by detaching handlers.

- **Bug Fixes**
	- Improved error handling during temporary directory cleanup, ensuring resources are properly released on Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->