### PR TITLE
fix: pass correct local storage prefix in case an executor spawns an inner job

### DIFF
--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -273,15 +273,17 @@ class SpawnedJobArgsFactory:
 
         # base64 encode the prefix to ensure that eventually unexpanded env vars
         # are not replaced with values (or become empty if missing) by the shell
-        local_storage_prefix = (
-            w2a(
+        if executor_common_settings.non_local_exec and not self.workflow.remote_exec:
+            # this is used when the main process submits a job via a remote executor
+            local_storage_prefix = w2a(
                 "storage_settings.remote_job_local_storage_prefix",
                 flag="--local-storage-prefix",
                 base64_encode=True,
             )
-            if executor_common_settings.non_local_exec
-            else w2a("storage_settings.local_storage_prefix", base64_encode=True)
-        )
+        else:
+            # this is used in the main process when submitting jobs to a local executor
+            # or when a remote executor spawns an inner executor
+            local_storage_prefix = w2a("storage_settings.local_storage_prefix", base64_encode=True)
 
         args = [
             "--force",

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -283,7 +283,9 @@ class SpawnedJobArgsFactory:
         else:
             # this is used in the main process when submitting jobs to a local executor
             # or when a remote executor spawns an inner executor
-            local_storage_prefix = w2a("storage_settings.local_storage_prefix", base64_encode=True)
+            local_storage_prefix = w2a(
+                "storage_settings.local_storage_prefix", base64_encode=True
+            )
 
         args = [
             "--force",


### PR DESCRIPTION

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the job submission logic by clarifying the handling of local and remote execution modes, improving the transparency and maintainability of storage settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->