### PR TITLE
fix: rerun-trigger regression

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -721,7 +721,7 @@ def get_argument_parser(profiles=None):
         "--rerun-triggers",
         nargs="+",
         choices=RerunTrigger.choices(),
-        default=RerunTrigger.choices(),
+        default=RerunTrigger.all(),
         parse_func=RerunTrigger.parse_choices_set,
         help="Define what triggers the rerunning of a job. By default, "
         "all triggers are used, which guarantees that results are "


### PR DESCRIPTION
fixes #3491

Edit: This is reverting 4430e23, which changed the default for rerun-trigger for the docs. Presumably because `RerunTrigger.all()` gives the actual enum values which don't render nicely. 

Will need to find a better solution. Any thoughts @fgvieira?

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the CLI default so that all available triggers for job reruns are enabled by default, ensuring a more comprehensive and consistent behavior that aligns with workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->