### PR TITLE
fix: only inform about storage cleanup in case of --verbose mode

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -506,7 +506,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                             and f not in cleaned
                             and not f.should_keep_local
                         ):
-                            logger.info(
+                            logger.debug(
                                 "Cleaning up local remainders of "
                                 f"{f.storage_object.print_query}"
                             )


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Adjusted logging behavior related to storage cleanup operations to reduce routine log messages. Now, detailed logging information is shown only when advanced logging is enabled, leading to a cleaner and more focused log output during normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->