### PR TITLE
fix: don't print "Building DAG" for DOT output

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -969,7 +969,7 @@ class Workflow(WorkflowExecutorInterface):
             ignore_incomplete=True,
             lock_warn_only=True,
         )
-        self._build_dag()
+        self._build_dag(verbose=False)
         print(self.dag)
 
     def printrulegraph(self):
@@ -979,7 +979,7 @@ class Workflow(WorkflowExecutorInterface):
             ignore_incomplete=True,
             lock_warn_only=True,
         )
-        self._build_dag()
+        self._build_dag(verbose=False)
         print(self.dag.rule_dot())
 
     def printfilegraph(self):
@@ -989,7 +989,7 @@ class Workflow(WorkflowExecutorInterface):
             ignore_incomplete=True,
             lock_warn_only=True,
         )
-        self._build_dag()
+        self._build_dag(verbose=False)
         print(self.dag.filegraph_dot())
 
     def printd3dag(self):
@@ -999,7 +999,7 @@ class Workflow(WorkflowExecutorInterface):
             ignore_incomplete=True,
             lock_warn_only=True,
         )
-        self._build_dag()
+        self._build_dag(verbose=False)
 
         self.dag.d3dag()
 
@@ -1160,8 +1160,9 @@ class Workflow(WorkflowExecutorInterface):
             rulegraph = simple_rulegraph()
             logger.info(None, extra=dict(event=LogEvent.RULEGRAPH, rulegraph=rulegraph))
 
-    def _build_dag(self):
-        logger.info("Building DAG of jobs...")
+    def _build_dag(self, verbose=True):
+        if verbose:
+            logger.info("Building DAG of jobs...")
         async_run(self.dag.init())
         async_run(self.dag.update_checkpoint_dependencies())
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

Using `--rulegraph` etc would contain a line at the start for "Building DAG of jobs...", that seemed to be printed to stdout along with the actual DOT output, so one could no longer pipe `snakemake --rulegraph | dot -Tsvg > rulegraph.svg`. I think these changes cover all the different DAG-plotting outputs, although this is potentially an ugly fix for an easy problem.
 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added configurable output control for workflow visualizations, allowing users to suppress extraneous logging messages during graph generation for a cleaner display experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->