### PR TITLE
fix: in the report, do not render toggle labels if there is more than one label eligible for a toggle

### DIFF
--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+from asyncio import TaskGroup
 from dataclasses import InitVar, dataclass, field
 import os
 import sys
@@ -13,12 +14,9 @@ import datetime
 import io
 from typing import List, Optional
 import uuid
-import json
-import time
 import itertools
 from collections import defaultdict
 import hashlib
-from zipfile import ZipFile, ZIP_DEFLATED
 from pathlib import Path
 import numbers
 
@@ -113,7 +111,7 @@ def report(
     if outmime != "text/html":
         raise ValueError("Path to report output has to be an HTML file.")
     definitions = textwrap.dedent(
-        """
+        """[]
     .. role:: raw-html(raw)
        :format: html
 
@@ -187,11 +185,21 @@ def report(
     )
 
 
-def expand_report_argument(item, wildcards, job):
+async def expand_report_argument(item, wildcards, job):
     if is_callable(item):
         aux_params = get_input_function_aux_params(
             item, {"params": job.params, "input": job.input, "output": job.output}
         )
+        io_items = ["input", "output"]
+        if any(io_item in aux_params for io_item in io_items):
+            # retreive all input or output files from storage before evaluating function
+            async with TaskGroup() as tg:
+                for io_item in io_items:
+                    if io_item in aux_params:
+                        for f in aux_params[io_item]:
+                            if f.is_storage:
+                                tg.create_task(f.retrieve_from_storage())
+
         try:
             item = item(wildcards, **aux_params)
         except Exception as e:
@@ -216,8 +224,6 @@ class Category(CategoryInterface):
     id: str = field(init=False)
 
     def __post_init__(self, wildcards, job):
-        if self.name is not None:
-            self.name = expand_report_argument(self.name, wildcards, job)
         if self.name is None:
             self.name = "Other"
 
@@ -447,10 +453,10 @@ class FileRecord(FileRecordInterface):
         return self.job.rule.workflow
 
 
-def expand_labels(labels, wildcards, job):
+async def expand_labels(labels, wildcards, job):
     if labels is None:
         return None
-    labels = expand_report_argument(labels, wildcards, job)
+    labels = await expand_report_argument(labels, wildcards, job)
 
     if labels is None:
         return None
@@ -469,7 +475,7 @@ def expand_labels(labels, wildcards, job):
             rule=job.rule,
         )
     return {
-        name: expand_report_argument(col, wildcards, job)
+        name: await expand_report_argument(col, wildcards, job)
         for name, col in labels.items()
     }
 
@@ -541,7 +547,7 @@ async def auto_report(
                     )
                 report_obj = get_flag_value(f, "report")
 
-                def register_file(
+                async def register_file(
                     f,
                     parent_path=None,
                     wildcards_overwrite=None,
@@ -549,13 +555,26 @@ async def auto_report(
                     name_overwrite=None,
                 ):
                     wildcards = wildcards_overwrite or job.wildcards
+
+                    async def expand_cat_name(cat_name):
+                        if cat_name is not None:
+                            return await expand_report_argument(
+                                cat_name, wildcards, job
+                            )
+                        else:
+                            return cat_name
+                    
                     category = Category(
-                        name=report_obj.category, wildcards=wildcards, job=job
+                        name=await expand_cat_name(report_obj.category),
+                        wildcards=wildcards,
+                        job=job,
                     )
                     subcategory = Category(
-                        name=report_obj.subcategory, wildcards=wildcards, job=job
+                        name=await expand_cat_name(report_obj.subcategory),
+                        wildcards=wildcards,
+                        job=job,
                     )
-                    labels = expand_labels(report_obj.labels, wildcards, job)
+                    labels = await expand_labels(report_obj.labels, wildcards, job)
 
                     results[category][subcategory].append(
                         FileRecord(
@@ -577,7 +596,7 @@ async def auto_report(
                 if f.is_storage:
                     await f.retrieve_from_storage()
                 if os.path.isfile(f):
-                    register_file(f)
+                    await register_file(f)
                 elif os.path.isdir(f):
                     if report_obj.htmlindex:
                         aux_files = []
@@ -598,7 +617,7 @@ async def auto_report(
                                 "Given htmlindex {} not found in directory "
                                 "marked for report".format(report_obj.htmlindex)
                             )
-                        register_file(
+                        await register_file(
                             os.path.join(f, report_obj.htmlindex),
                             aux_files=aux_files,
                             name_overwrite=f"{os.path.basename(f)}.html",
@@ -621,7 +640,7 @@ async def auto_report(
                                 w.update(job.wildcards_dict)
                                 w = Wildcards(fromdict=w)
                                 subfile = apply_wildcards(pattern, w)
-                                register_file(
+                                await register_file(
                                     subfile, parent_path=f, wildcards_overwrite=w
                                 )
                         if not found_something:

--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -563,7 +563,7 @@ async def auto_report(
                             )
                         else:
                             return cat_name
-                    
+
                     category = Category(
                         name=await expand_cat_name(report_obj.category),
                         wildcards=wildcards,

--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -217,13 +217,11 @@ async def expand_report_argument(item, wildcards, job):
 
 @dataclass(slots=True)
 class Category(CategoryInterface):
-    wildcards: InitVar
-    job: InitVar
     name: Optional[str]
     is_other: bool = field(init=False)
     id: str = field(init=False)
 
-    def __post_init__(self, wildcards, job):
+    def __post_init__(self):
         if self.name is None:
             self.name = "Other"
 
@@ -556,7 +554,7 @@ async def auto_report(
                 ):
                     wildcards = wildcards_overwrite or job.wildcards
 
-                    async def expand_cat_name(cat_name):
+                    async def expand_cat_name(cat_name, wildcards, job):
                         if cat_name is not None:
                             return await expand_report_argument(
                                 cat_name, wildcards, job
@@ -565,14 +563,12 @@ async def auto_report(
                             return cat_name
 
                     category = Category(
-                        name=await expand_cat_name(report_obj.category),
-                        wildcards=wildcards,
-                        job=job,
+                        name=await expand_cat_name(report_obj.category, wildcards, job),
                     )
                     subcategory = Category(
-                        name=await expand_cat_name(report_obj.subcategory),
-                        wildcards=wildcards,
-                        job=job,
+                        name=await expand_cat_name(
+                            report_obj.subcategory, wildcards, job
+                        ),
                     )
                     labels = await expand_labels(report_obj.labels, wildcards, job)
 

--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -192,7 +192,7 @@ async def expand_report_argument(item, wildcards, job):
         )
         io_items = ["input", "output"]
         if any(io_item in aux_params for io_item in io_items):
-            # retreive all input or output files from storage before evaluating function
+            # retrieve all input or output files from storage before evaluating function
             async with TaskGroup() as tg:
                 for io_item in io_items:
                     if io_item in aux_params:

--- a/src/snakemake/report/html_reporter/template/components/abstract_results.js
+++ b/src/snakemake/report/html_reporter/template/components/abstract_results.js
@@ -190,6 +190,10 @@ class AbstractResults extends React.Component {
                 }
             });
         }
+        // Only allow one toggle label for now, in order to avoid confusion in the UI
+        if (toggleLabels.size > 1) {
+            toggleLabels = new Map();
+        }
 
         let entries = new Map();
         let entryLabelValues = [];

--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -937,8 +937,12 @@ class Rule(RuleInterface):
                 return TBDString()
             else:
                 raise WorkflowError(
-                    "Rule parameter depends on checkpoint but checkpoint output is not defined as input file for the rule. "
-                    "Please add the output of the respective checkpoint to the rule inputs."
+                    "Rule parameter depends on checkpoint but checkpoint output is not "
+                    "defined as input file for the rule. Please add the output of the "
+                    "respective checkpoint to the rule inputs. "
+                    f"Input: {','.join(input)} "
+                    f"Checkpoint file: {exception.targetfile}",
+                    rule=self,
                 )
 
         # We make sure that resources are only evaluated if a param function


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Report generation now leverages concurrent processing for a more responsive experience.
- **Bug Fixes**
  - Improved results display by limiting toggle options to one, reducing potential confusion.
  - Enhanced error notifications for checkpoint issues by providing clearer contextual guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->