### PR TITLE
fix: Fix map call in report creation

### DIFF
--- a/src/snakemake/report/html_reporter/template/components/abstract_results.js
+++ b/src/snakemake/report/html_reporter/template/components/abstract_results.js
@@ -98,7 +98,7 @@ class AbstractResults extends React.Component {
             return { data: data, toggles };
         }, function () {
             if (_this.state.data.resultPathsToEntryLabels.has(_this.props.app.state.resultPath)) {
-                let toggleLabels = Array.from(data.toggleLabels.keys().map((label) => _this.state.toggles.get(label)));
+                let toggleLabels = Array.from(data.toggleLabels.keys()).map((label) => _this.state.toggles.get(label));
                 let entryLabels = _this.state.data.resultPathsToEntryLabels.get(_this.props.app.state.resultPath);
                 let targetPath = _this.state.data.entries.get(arrayKey(entryLabels)).get(arrayKey(toggleLabels));
                 _this.toggleViewManager.handleSelectedResult(targetPath);


### PR DESCRIPTION
This pull request includes a small change to the `src/snakemake/report/html_reporter/template/components/abstract_results.js` file. The change corrects the syntax for mapping over `data.toggleLabels.keys()` to ensure proper functionality.

* Corrected the syntax for mapping over `data.toggleLabels.keys()` in the `AbstractResults` class.