### PR TITLE
fix: Fix map call in report creation

### DIFF
--- a/src/snakemake/report/html_reporter/template/components/abstract_results.js
+++ b/src/snakemake/report/html_reporter/template/components/abstract_results.js
@@ -282,7 +282,7 @@ class AbstractResults extends React.Component {
         let state = this.state;
 
         return data.entryLabelValues.map(function (entryLabels) {
-            let toggleLabels = Array.from(data.toggleLabels.keys().map((label) => state.toggles.get(label)));
+            let toggleLabels = Array.from(data.toggleLabels.keys()).map((label) => state.toggles.get(label));
             let entryPath = data.entries.get(arrayKey(entryLabels)).get(arrayKey(toggleLabels));
 
             let actions = e(


### PR DESCRIPTION
This pull request includes a small but important fix to the `src/snakemake/report/html_reporter/template/components/abstract_results.js` file. The change corrects the mapping of `data.toggleLabels.keys()` to ensure proper retrieval of toggle states.

* [`src/snakemake/report/html_reporter/template/components/abstract_results.js`](diffhunk://#diff-9dc0845743ccae31714e1a4ea05bbe7e6ddf11d4859779dd6bb74c2122a58593L285-R285): Fixed the mapping of `data.toggleLabels.keys()` by removing an erroneous `Array.from` call, which ensures correct toggle state retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal handling of display data to enhance efficiency without affecting the current user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->