### PR TITLE
fix: only use temporary persistence directory in remote jobs when persistence is not shared via the FS

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -835,6 +835,7 @@ class Workflow(WorkflowExecutorInterface):
                 self.storage_settings is not None
                 and SharedFSUsage.PERSISTENCE
                 not in self.storage_settings.shared_fs_usage
+                and self.remote_exec
             )
             else None
         )


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced workflow consistency by updating persistence handling. Persistence settings are now only applied during remote execution, ensuring more reliable operation in remote processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->