### PR TITLE
chore: Revert "chore: work around issue with unavailable license file in one…

### DIFF
--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -148,13 +148,11 @@ class Assets:
         # The license file included in the NPM package does not exist directly
         # in https://github.com/DefinitelyTyped/DefinitelyTyped, so we use an
         # unpkg URL to reference the contents of the NPM package instead.
-        # TODO estree license is not present on unpkg anymore.
-        # TODO Also, the repo referenced about _does_ contain a license.
-        # "@types-estree/LICENSE": Asset(
-        #     url="https://unpkg.com/@types/estree@{version}/LICENSE",
-        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-        #     version="0.0.50",
-        # ),
+        "@types-estree/LICENSE": Asset(
+            url="https://unpkg.com/@types/estree@{version}/LICENSE",
+            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+            version="0.0.50",
+        ),
         # Via vega-force
         "d3-force/LICENSE": Asset(
             url="https://raw.githubusercontent.com/d3/d3-force/refs/tags/v{version}/LICENSE",
@@ -363,13 +361,11 @@ class Assets:
         ),
         # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
         # Versions from https://github.com/vega/vega-lite/blob/v5.2.0/yarn.lock.
-        # TODO: file not present on unpkg, disable for now and seek for a better source
-        # in the future
-        # "@types-clone/LICENSE": Asset(
-        #     url="https://unpkg.com/@types/clone@{version}/LICENSE",
-        #     sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
-        #     version="2.1.1",
-        # ),
+        "@types-clone/LICENSE": Asset(
+            url="https://unpkg.com/@types/clone@{version}/LICENSE",
+            sha256="c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383",
+            version="2.1.1",
+        ),
         "array-flat-polyfill/LICENSE": Asset(
             # Releases are not tagged in git; we use the commit hash
             # corresponding to the 1.0.1 release

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -60,10 +60,9 @@ def get_packages():
             "d3-scale": Package(
                 license_path="d3-scale/LICENSE",
             ),
-            # TODO reactivate once we have a license again in the assets
-            # "@types-estree": Package(
-            #     license_path="@types-estree/LICENSE",
-            # ),
+            "@types-estree": Package(
+                license_path="@types-estree/LICENSE",
+            ),
             "d3-force": Package(
                 license_path="d3-force/LICENSE",
             ),
@@ -141,10 +140,9 @@ def get_packages():
             ),
             # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
             # (excluding those shared with vega and therefore already documented)
-            # TODO reactivate once we have a license again in the assets
-            # "@types-clone": Package(
-            #     license_path="@types-estree/LICENSE",
-            # ),
+            "@types-clone": Package(
+                license_path="@types-estree/LICENSE",
+            ),
             "array-flat-polyfill": Package(
                 license_path="array-flat-polyfill/LICENSE",
             ),

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -141,7 +141,7 @@ def get_packages():
             # Begin dependencies for vega-lite, included in vega-lite/vega-lite.js
             # (excluding those shared with vega and therefore already documented)
             "@types-clone": Package(
-                license_path="@types-estree/LICENSE",
+                license_path="@types-clone/LICENSE",
             ),
             "array-flat-polyfill": Package(
                 license_path="array-flat-polyfill/LICENSE",


### PR DESCRIPTION
… the of the report assets (#3464)"

This reverts commit 55202ba53896109e92fec323dfc8a9f5005a26e9.

The unpkg URLs have started working again.

<!--Add a description of your PR here-->

This simply reverts 55202ba53896109e92fec323dfc8a9f5005a26e9. Since the unpkg URLs have started working again, this is a viable alternative to https://github.com/snakemake/snakemake/pull/3472.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case. **N/A**
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **N/A**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Activated management of license details, incorporating verified metadata (URL, checksum, version) for two third-party assets: `@types-estree` and `@types-clone`.
  - Updated package listings to include these licenses, ensuring improved tracking and retrieval of license information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->