### PR TITLE
fix: unify error logging in scheduler, fixing a missing attribute error for group jobs

### DIFF
--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -218,13 +218,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
                         if not user_kill:
                             logger.error(_ERROR_MSG_FINAL)
                             for job in self.failed:
-                                if isinstance(job, GroupJob):
-                                    job.log_error()
-                                else:
-                                    logger.error(
-                                        f"Error in jobid: {self.workflow.dag.jobid(job)}",
-                                        extra=job.get_log_error_info(),
-                                    )
+                                job.log_error()
                         return False
                     continue
 
@@ -241,10 +235,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
                     if errors:
                         logger.error(_ERROR_MSG_FINAL)
                         for job in self.failed:
-                            logger.error(
-                                f"Error in jobid: {self.workflow.dag.jobid(job)}",
-                                extra=job.get_log_error_info(),
-                            )
+                            job.log_error()
                     # we still have unfinished jobs. this is not good. direct
                     # user to github issue
                     if self.remaining_jobs and not self.keepgoing:


### PR DESCRIPTION


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Revised error logging in the job scheduling process by removing distinctions based on job type. All failed jobs are now handled uniformly, leading to more consistent and clear error reporting. These changes facilitate improved diagnostics and system maintainability, ultimately supporting a transparent and reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->