### PR TITLE
fix: Resolve issues with hashlib.md5() on systems in FIPS mode

### DIFF
--- a/src/snakemake/deployment/conda.py
+++ b/src/snakemake/deployment/conda.py
@@ -235,7 +235,7 @@ class Env:
         return self._content_hash
 
     def _get_hash(self, include_location: bool, include_container_img: bool) -> str:
-        md5hash = hashlib.md5()
+        md5hash = hashlib.md5(usedforsecurity=False)
         if self.name:
             md5hash.update(self.name.encode())
         elif self.dir:

--- a/src/snakemake/deployment/env_modules.py
+++ b/src/snakemake/deployment/env_modules.py
@@ -22,7 +22,7 @@ class EnvModules:
 
     @property
     def hash(self) -> str:
-        md5hash = hashlib.md5()
+        md5hash = hashlib.md5(usedforsecurity=False)
         for name in self.names:
             md5hash.update(name.encode())
         return md5hash.hexdigest()

--- a/src/snakemake/deployment/singularity.py
+++ b/src/snakemake/deployment/singularity.py
@@ -45,7 +45,7 @@ class Image:
 
     @lazy_property
     def hash(self):
-        md5hash = hashlib.md5()
+        md5hash = hashlib.md5(usedforsecurity=False)
         md5hash.update(self.url.encode())
         return md5hash.hexdigest()
 

--- a/src/snakemake/persistence.py
+++ b/src/snakemake/persistence.py
@@ -531,7 +531,7 @@ class Persistence(PersistenceExecutorInterface):
     def _software_stack_hash(self, job):
         # TODO move code for retrieval into software deployment plugin interface once
         # available
-        md5hash = hashlib.md5()
+        md5hash = hashlib.md5(usedforsecurity=False)
         if (
             DeploymentMethod.CONDA
             in self.dag.workflow.deployment_settings.deployment_method

--- a/tests/common.py
+++ b/tests/common.py
@@ -41,7 +41,7 @@ def md5sum(filename, ignore_newlines=False):
             data = f.read().strip().encode("utf8", errors="surrogateescape")
     else:
         data = open(filename, "rb").read().strip()
-    return hashlib.md5(data).hexdigest()
+    return hashlib.md5(data, usedforsecurity=False).hexdigest()
 
 
 # test skipping


### PR DESCRIPTION
<!--Add a description of your PR here-->

This change adds `usedforsecurity=False` to calls of `hashlib.md5()` to resolve issues with the availability of the MD5 hash algorithm on systems with (United States) Federal Information Processing Standards (FIPS) mode enabled. Snakemake does not work on systems with this security standard because the MD5 algorithm is considered unsafe. For more information, please see #3504.

Resolves #3504

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined several internal hashing routines to clearly indicate that they are not used for cryptographic security, ensuring more consistent behavior across the system.
- **Tests**
  - Updated test validations to align with the revised internal configuration.

No changes have been made to the public interfaces, so you should experience uninterrupted functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->