### PR TITLE
fix: consider software deployment method upon --touch; before, touch always stored no software deployment upon execution, causing metadata records that triggered a software-triggered rerun upon the next real execution.

### DIFF
--- a/src/snakemake/api.py
+++ b/src/snakemake/api.py
@@ -580,10 +580,6 @@ class DAGApi(ApiBase):
             if execution_settings.debug:
                 raise ApiError("debug mode cannot be used with non-local execution")
 
-        if executor_plugin.common_settings.touch_exec:
-            # no actual execution happening, hence we can omit any deployment
-            self.workflow_api.deployment_settings.deployment_method = frozenset()
-
         execution_settings.use_threads = (
             execution_settings.use_threads
             or (os.name not in ["posix"])

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -508,8 +508,9 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
     def create_conda_envs(self, dryrun=False, quiet=False):
         dryrun |= self.workflow.dryrun
+        touch = self.workflow.touch
         for env in self.conda_envs.values():
-            if (not dryrun or not quiet) and not env.is_externally_managed:
+            if not touch and (not dryrun or not quiet) and not env.is_externally_managed:
                 env.create(self.workflow.dryrun)
 
     def update_container_imgs(self):
@@ -527,7 +528,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
     def pull_container_imgs(self, quiet=False):
         for img in self.container_imgs.values():
-            if not self.workflow.dryrun or not quiet:
+            if not self.workflow.touch and (not self.workflow.dryrun or not quiet):
                 img.pull(self.workflow.dryrun)
 
     def update_output_index(self):

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -510,7 +510,11 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
         dryrun |= self.workflow.dryrun
         touch = self.workflow.touch
         for env in self.conda_envs.values():
-            if not touch and (not dryrun or not quiet) and not env.is_externally_managed:
+            if (
+                not touch
+                and (not dryrun or not quiet)
+                and not env.is_externally_managed
+            ):
                 env.create(self.workflow.dryrun)
 
     def update_container_imgs(self):


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
