### PR TITLE
fix: restore accidentally changed behavior of --cores. If not specified, Snakemake now complains again, asking for --cores to be specified (of --jobs in case of remote exec). As before, if a default is desired, it can be easily set via a profile

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1964,9 +1964,6 @@ def args_to_api(args, parser):
             args.cores = 1
             args.jobs = None
 
-    if args.cores is None:
-        args.cores = available_cpu_count()
-
     # start profiler if requested
     if args.runtime_profile:
         import yappi

--- a/tests/common.py
+++ b/tests/common.py
@@ -448,7 +448,8 @@ def run(
                 snakemake_api.print_exception(exception)
             print("Workdir:")
             print_tree(tmpdir, exclude=".snakemake/conda")
-            raise exception
+            if exception is not None:
+                raise exception
         assert success, "expected successful execution"
 
     if check_results:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -281,7 +281,7 @@ def test_ancient():
 def test_ancient_cli():
     run(
         dpath("test_ancient_cli"),
-        shellcmd="snakemake --consider-ancient A=0 B=x",
+        shellcmd="snakemake --consider-ancient A=0 B=x --cores 1",
     )
 
 
@@ -2261,7 +2261,7 @@ def test_github_issue_3374():
 def test_issue3361_pass():
     run(
         dpath("test_issue3361_pass"),
-        shellcmd="snakemake --sdm apptainer",
+        shellcmd="snakemake --sdm apptainer --cores 1",
         targets=["all"],
     )
 


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for assigning CPU cores, removing the automatic fallback to available CPU count when not explicitly set.
- **Bug Fixes**
  - Improved error handling to avoid raising null exceptions after failed executions.
- **Tests**
  - Modified test commands to explicitly specify single-core usage during runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->