### PR TITLE
feat: make shutil available in resource expressions (i.e. for --default-resources and --set-resources), can be used to e.g. dynamically decide about the tmpdir to be used based on shutil.disk_usage(system_tmpdir)

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -2002,7 +2002,6 @@ def args_to_api(args, parser):
             storage_settings = StorageSettings(
                 default_storage_provider=args.default_storage_provider,
                 default_storage_prefix=args.default_storage_prefix,
-                default_storage_for_output=args.default_storage_for_output,
                 local_storage_prefix=args.local_storage_prefix,
                 remote_job_local_storage_prefix=args.remote_job_local_storage_prefix,
                 shared_fs_usage=args.shared_fs_usage,

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -618,7 +618,10 @@ def get_argument_parser(profiles=None):
             "the system temporary directory (as given by $TMPDIR, $TEMP, or $TMP) is used for the tmpdir resource. "
             "The tmpdir resource is automatically used by shell commands, scripts and wrappers to store temporary data (as it is "
             "mirrored into $TMPDIR, $TEMP, and $TMP for the executed subprocesses). "
-            "If this argument is not specified at all, Snakemake just uses the tmpdir resource as outlined above."
+            "If this argument is not specified at all, Snakemake just uses the tmpdir resource as outlined above. "
+            "The tmpdir resource can also be overwritten in the same way as e.g. mem_mb above. "
+            "Thereby, it is even possible to use shutil.disk_usage(system_tmpdir).free and comparing this to input.size in order to "
+            "determine if one can expect the system_tmpdir to be big enough and switch to another tmpdir in case it is not. "
         ),
     )
 

--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1474,7 +1474,8 @@ def get_argument_parser(profiles=None):
         "--local-storage-prefix",
         default=".snakemake/storage",
         type=maybe_base64(expandvars(Path)),
-        help="Specify prefix for storing local copies of storage files and folders (e.g. local scratch disk). Environment variables will be expanded.",
+        help="Specify prefix for storing local copies of storage files and folders "
+        "(e.g. local scratch disk). Environment variables will be expanded.",
     )
     group_behavior.add_argument(
         "--remote-job-local-storage-prefix",
@@ -2001,6 +2002,7 @@ def args_to_api(args, parser):
             storage_settings = StorageSettings(
                 default_storage_provider=args.default_storage_provider,
                 default_storage_prefix=args.default_storage_prefix,
+                default_storage_for_output=args.default_storage_for_output,
                 local_storage_prefix=args.local_storage_prefix,
                 remote_job_local_storage_prefix=args.remote_job_local_storage_prefix,
                 shared_fs_usage=args.shared_fs_usage,

--- a/src/snakemake/resources.py
+++ b/src/snakemake/resources.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import itertools as it
 import operator as op
 import re
+import shutil
 import tempfile
 import math
 from typing import Any
@@ -526,6 +527,7 @@ def eval_resource_expression(val, threads_arg=True):
             "input": kwargs["input"],
             "attempt": kwargs["attempt"],
             "system_tmpdir": tempfile.gettempdir(),
+            "shutil": shutil,
         }
         if threads_arg:
             args["threads"] = kwargs["threads"]


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced help text for the `--default-resources` argument with detailed explanations on tmpdir resource usage.
  - Improved readability of the help text for the `--local-storage-prefix` command-line argument.

- **New Features**
  - Resource expressions now support access to the `shutil` module, enabling more flexible resource evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->