### PR TITLE
docs: rewrite the mpi job execution section

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -3116,6 +3116,7 @@ But because it can make sense to use another MPI launch command in some circumst
 
 Here, you provide the MPI wrapper command used to launch the program under ``resources: mpi=``.
 This enables users to override this command if their execution environment requires this, via providing the ``mpi`` resource in :ref:`executing-profiles` or via the command line option |set-resources|_.
+While ``mpirun`` `should work in most compute environments, including cluster systems like Slurm, LSF or PBS <https://docs.open-mpi.org/en/v5.0.x/launching-apps/quickstart.html>`_, the exact MPI wrapper command to launch programs may differ on your system.
 To find out if and which command your execution environment provides, you will have to consult local documentation, check out if any known mpi wrapper commands are available or ask your system's administrators.
 A good reference point for getting mpirun to work on your execution environment is the `documentation of the mpirun prerequisites <https://docs.open-mpi.org/en/v5.0.x/launching-apps/prerequisites.html>`_.
 


### PR DESCRIPTION
This pull request tries to make the explanations in this section a bit clearer and provides a number of useful linkouts, especially to the Open MPI docs, but also to the snakemake executor plugins. Along the way, it also fixes the syntax of existing links.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved and expanded the MPI support documentation for Snakemake workflows, including clearer explanations, updated examples, and guidance on customizing MPI launcher commands.
  - Added references to external MPI and cluster documentation for further assistance.
  - Enhanced instructions for overriding MPI resources and passing additional parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->