### PR TITLE
chore: Allow PuLP 3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "nbformat",
   "packaging",
   "psutil",
-  "pulp>=2.3.1,<3.1",
+  "pulp>=2.3.1,<3.2",
   "pyyaml",
   "requests>=2.8.1,<3.0",
   "reretry",


### PR DESCRIPTION
<!--Add a description of your PR here-->

This is a follow-up to https://github.com/snakemake/snakemake/pull/3466, which allowed PuLP 3.0. Now the current version is [3.1.1](https://github.com/coin-or/pulp/releases/tag/3.1.1). Nothing in the changes [from 3.0.2 to 3.1.0](https://github.com/coin-or/pulp/compare/3.0.2...3.1.0) seems like it should cause any obvious problems for Snakemake, so let’s try to keep up with the latest PuLP releases.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
