### PR TITLE
fix: log scheduler waiting to debug, make statements more accurate

### DIFF
--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -332,8 +332,10 @@ class JobScheduler(JobSchedulerExecutorInterface):
                 if not self.dryrun:
 
                     if self._run_performed is None or self._run_performed:
-                        logger.info("Waiting for more resources.")
-                    self._run_performed = False
+                        if self.running:
+                            logger.debug("Waiting for running jobs to complete.")
+                        else:
+                            logger.debug("Waiting for more resources.")
                     if self.job_rate_limiter is not None:
                         # need to reevaluate because after the timespan we can
                         # schedule more jobs again


### PR DESCRIPTION
<!--Add a description of your PR here-->
Fixes #3471.

Provide more accurate log info when scheduler is waiting for jobs/resources. Move these statements to debug to prevent flooding of stderr.
### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
