### PR TITLE
fix: fix recent regression when printing remote storage output or log files (local path shown instead of query)

### DIFF
--- a/src/snakemake/io/fmt.py
+++ b/src/snakemake/io/fmt.py
@@ -20,7 +20,7 @@ def fmt_iofile(f, as_input: bool = False, as_output: bool = False):
         f_str = f
         storage_phrase = ""
 
-    def annotate(f_str, label):
+    def annotate(f_str, label=None):
         sep = ", " if label and storage_phrase else ""
         ann = f" ({label}{sep}{storage_phrase})" if label or storage_phrase else ""
         return f"{f_str}{ann}"
@@ -44,4 +44,6 @@ def fmt_iofile(f, as_input: bool = False, as_output: bool = False):
             return annotate(f_str, pattern)
         elif is_flagged(f, "checkpoint_target"):
             return TBDString()
+        else:
+            return annotate(f_str)
     return f


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of IO file annotations, ensuring that files without specific flags are now properly annotated.
- **Refactor**
	- Enhanced flexibility by making the label parameter optional in the annotation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->