### PR TITLE
fix: fixed accidental None display when annotating access patterns in input/output file display

### DIFF
--- a/src/snakemake/io/fmt.py
+++ b/src/snakemake/io/fmt.py
@@ -20,7 +20,7 @@ def fmt_iofile(f, as_input: bool = False, as_output: bool = False):
         f_str = f
         storage_phrase = ""
 
-    def annotate(f_str, label=None):
+    def annotate(f_str, label=""):
         sep = ", " if label and storage_phrase else ""
         ann = f" ({label}{sep}{storage_phrase})" if label or storage_phrase else ""
         return f"{f_str}{ann}"


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of label values in annotation formatting to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->