### PR TITLE
fix: detect DAG paths in job groups that first exit and then return to the group; they are invalid, now leading to an error

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1675,7 +1675,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                     for job in self.bfs(self._dependencies, dep, stop=stop_if)
                     if job is not dep
                 )
-            if external_but_returning_rules:
+            if external_but_returning_rules and returned_to:
                 raise WorkflowError(
                     f"Error in group {job.group}. Job of rule {job.rule.name} "
                     f"depends on rule(s) {','.join(external_but_returning_rules)} "

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1654,7 +1654,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 external_but_returning_rules = set()
                 for dep in self._dependencies[job]:
                     external_but_returning_rules.update(job.rule.name for job in self.bfs(self._dependencies, dep, stop=lambda j: groups.get(j) == group))
-                if external_but_returning_jobs:
+                if external_but_returning_rules:
                     raise WorkflowError(
                         f"Error in group {job.group}. Job of rule {job.rule.name} "
                         f"depends on {','.join(external_but_returning_rules)} from "

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1647,6 +1647,26 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 # Since groups might have been merged, we need
                 # to update each job j in group.
                 groups[j] = group
+        
+        # check if all groups are valid
+        for group, jobs in groupby(groups, key=lambda job: groups[job]):
+            for job in jobs:
+                external_but_returning_rules = set()
+                for dep in self._dependencies[job]:
+                    external_but_returning_rules.update(job.rule.name for job in self.bfs(self._dependencies, dep, stop=lambda j: groups.get(j) == group))
+                if external_but_returning_jobs:
+                    raise WorkflowError(
+                        f"Error in group {job.group}. Job of rule {job.rule.name} "
+                        f"depends on {','.join(external_but_returning_rules)} from "
+                        f"outside the group, but they in turn depend on job(s) "
+                        f"inside the group again. This is not allowed. Ensure that "
+                        "those rules are part of the group as well, either by "
+                        "using further --group statements or by adding them to the "
+                        "same group in the workflow definition. Note that for "
+                        "rules that are generic and might be used in multiple groups "
+                        "you can use rule inheritance to obtain multiple instances "
+                        "of the same rule with different group assignments."
+                    )
 
         self._group = groups
 
@@ -1753,6 +1773,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             if job in self._ready_jobs or job in self._running:
                 # job has been seen before or is running, no need to process again
                 continue
+            logger.debug(f"{job.output}: {self._ready(job)} {self._n_until_ready[job]}")
             if (
                 not self.finished(job)
                 and self._ready(job)
@@ -1786,7 +1807,10 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 yield group
 
     async def postprocess(
-        self, update_needrun=True, update_incomplete_input_expand_jobs=True
+        self,
+        update_needrun=True,
+        update_incomplete_input_expand_jobs=True,
+        check_initial=False,
     ):
         """Postprocess the DAG. This has to be invoked after any change to the
         DAG topology."""
@@ -1819,6 +1843,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                 return
 
         self.update_ready()
+
+        if check_initial:
+            assert not (not self.ready_jobs and any(self.needrun_jobs())), (
+                "bug: DAG contains jobs that have to be executed but no such job is "
+                "ready for execution."
+            )
 
     def handle_pipes_and_services(self):
         """Use pipes and services to determine job groups. Check if every pipe has exactly
@@ -1953,6 +1983,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
     def _ready(self, job):
         """Return whether the given job is ready to execute."""
         group = self._group.get(job, None)
+
         if group is None:
             return self._n_until_ready[job] == 0
         else:

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1225,7 +1225,7 @@ class Workflow(WorkflowExecutorInterface):
         self._build_dag()
 
         with self.persistence.lock():
-            async_run(self.dag.postprocess(update_needrun=False))
+            async_run(self.dag.postprocess(update_needrun=False, check_initial=True))
             if not self.dryrun:
                 # deactivate IOCache such that from now on we always get updated
                 # size, existence and mtime information


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation to prevent illegal cyclic dependencies across group boundaries, improving workflow reliability.
  - Introduced enhanced debug logging for job readiness status.
  - Added an internal consistency check to ensure that jobs needing to run are always ready when expected.

- **Bug Fixes**
  - Improved detection and prevention of dependency cycles involving grouped jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->