### PR TITLE
docs: Fix typo when generating DAG

### DIFF
--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -280,7 +280,7 @@ By executing
 
 .. code:: console
 
-    $ snakemake --dag sorted_reads/{A,B}.bam.bai | dot -Tsvg > dag.svg
+    $ snakemake sorted_reads/{A,B}.bam.bai --dag | dot -Tsvg > dag.svg
 
 
 .. note::

--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -280,7 +280,7 @@ By executing
 
 .. code:: console
 
-    $ snakemake --dag dot sorted_reads/{A,B}.bam.bai | dot -Tsvg > dag.svg
+    $ snakemake --dag sorted_reads/{A,B}.bam.bai | dot -Tsvg > dag.svg
 
 
 .. note::


### PR DESCRIPTION
<!--Add a description of your PR here-->
Fixes #3567 by removing the incorrect syntax for generating a DAG in the tutorial.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the example command for generating a DAG visualization by removing the explicit `--dag dot` option and repositioning the `--dag` flag for clearer usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->