### PR TITLE
WIP: fix: avoid checking output files in immediate-submit mode

### DIFF
--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -1232,7 +1232,7 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
                 )
                 if not error:
                     self.dag.handle_protected(self)
-            elif not shared_input_output and not wait_for_local and not error:
+            elif not shared_input_output and not wait_for_local and not error and not ignore_missing_output:
                 expanded_output = list(self.output)
                 if self.benchmark:
                     expanded_output.append(self.benchmark)

--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -356,6 +356,9 @@ class JobScheduler(JobSchedulerExecutorInterface):
     def _finish_jobs(self):
         # must be called from within lock
         # clear the global tofinish such that parallel calls do not interfere
+
+        # shortcut to "--immediate-submit" flag
+        immediate_submit = self.workflow.remote_execution_settings.immediate_submit 
         async def postprocess():
             for job in self._tofinish:
                 # IMPORTANT: inside of this loop, there may be no calls that have
@@ -368,13 +371,14 @@ class JobScheduler(JobSchedulerExecutorInterface):
                                 store_in_storage=not self.touch,
                                 handle_log=True,
                                 handle_touch=not self.touch,
-                                ignore_missing_output=self.touch,
+                                ignore_missing_output=self.touch or immediate_submit,
                             )
                         elif self.workflow.exec_mode == ExecMode.SUBPROCESS:
                             await job.postprocess(
                                 store_in_storage=False,
                                 handle_log=True,
                                 handle_touch=True,
+                                ignore_missing_output=immediate_submit,
                             )
                         else:
                             await job.postprocess(
@@ -384,12 +388,13 @@ class JobScheduler(JobSchedulerExecutorInterface):
                                 store_in_storage=False,
                                 handle_log=True,
                                 handle_touch=True,
+                                ignore_missing_output=immediate_submit,
                             )
                     except (RuleException, WorkflowError) as e:
                         # if an error occurs while processing job output,
                         # we do the same as in case of errors during execution
                         print_exception(e, self.workflow.linemaps)
-                        await job.postprocess(error=True)
+                        await job.postprocess(error=True, ignore_missing_output=immediate_submit)
                         self._handle_error(job, postprocess_job=False)
                         continue
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

Disable checking output files when snakemake is run with flag `--immediate-submit`.
Notes:
 * The flag `--notemp` should be additionally indicated (the CLI suggests for it)
 * The flag `--not-retrieve-storage` should be indicated to avoid snakemake to try retrieving remote data that may not yet exist
 * `localrule`s keep failing because cluster logic has no control on them. It would be nice to have some logic or flag to skip them all instead of letting them fail.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
