### PR TITLE
fix: upon source deployment, only validate storage plugin settings if they are not None

### DIFF
--- a/src/snakemake/api.py
+++ b/src/snakemake/api.py
@@ -197,7 +197,8 @@ class SnakemakeApi(ApiBase):
             storage_settings.default_storage_provider
         ).get_settings(None)
 
-        plugin.validate_settings(plugin_settings)
+        if plugin_settings is not None:
+            plugin.validate_settings(plugin_settings)
 
         provider_instance = plugin.storage_provider(
             logger=logger,


### PR DESCRIPTION
fixes https://github.com/snakemake/snakemake-executor-plugin-kubernetes/issues/33

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where deploying sources could cause errors if no plugin settings were provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->