### PR TITLE
feat: allow md5 and sha256 in ensure() flag 

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1913,7 +1913,7 @@ Above, the output file ``test.txt`` is marked as non-empty.
 If the command ``somecommand`` happens to generate an empty output,
 the job will fail with an error listing the unexpected empty file.
 
-A sha256 checksum can be compared as follows:
+A sha256 (or md5 or sha1) checksum can be compared as follows (using corresponding keyword arguments ``sha256=``, ``md5=``, or ``sha1=``).:
 
 .. code-block:: python
 


### PR DESCRIPTION
related to #1972 (solves it in part)

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for verifying file checksums using multiple algorithms (SHA256, MD5, and SHA1) when ensuring output file properties.

- **Documentation**
  - Updated documentation to clarify that checksum verification now supports SHA256, MD5, and SHA1 algorithms, with instructions on how to specify each type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->