### PR TITLE
fix: expandvars for special profile keys

### DIFF
--- a/src/snakemake/profiles.py
+++ b/src/snakemake/profiles.py
@@ -26,7 +26,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
             )
 
         def format_one_level_dict(d):
-            return [f"{key}={val}" for key, val in d.items()]
+            return [f"{key}={os.path.expandvars(str(val))}" for key, val in d.items()]
 
         def format_two_level_dict(d, item: str):
             if not all(isinstance(val, dict) for val in d.values()):
@@ -34,7 +34,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                     f"Invalid {item} format in profile. Expected two-level mapping, got {d}"
                 )
             return [
-                f"{key}:{key2}={val2}"
+                f"{key}:{key2}={os.path.expandvars(str(val2))}"
                 for key, val in d.items()
                 for key2, val2 in val.items()
             ]


### PR DESCRIPTION
Fixes #3592 

Need to still add tests.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment variables within profile configuration values are now automatically expanded, ensuring correct values are used in configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->