### PR TITLE
fix: format output files in job cleanup message such that their remote query is shown instead of the local copy

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -2415,7 +2415,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                                 ),
                                 False,
                             )
-                    except MissingRuleException as ex:
+                    except MissingRuleException:
                         # no dependency found
                         yield PotentialDependency(file, None, False)
 

--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -957,9 +957,10 @@ class Job(AbstractJob, SingleJobExecutorInterface, JobReportInterface):
             ]
         )
         if to_remove:
+            formatted = ", ".join(map(fmt_iofile, to_remove))
             logger.info(
-                "Removing output files of failed job {}"
-                " since they might be corrupted:\n{}".format(self, ", ".join(to_remove))
+                f"Removing output files of failed job {self}"
+                f" since they might be corrupted:\n{formatted}"
             )
             for f in to_remove:
                 await f.remove()


### PR DESCRIPTION

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved exception handling for cleaner code readability.
  - Enhanced log message formatting for clearer output during job cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->