### PR TITLE
fix: skip unnecessary schema validation inside of remote jobs

### DIFF
--- a/src/snakemake/utils.py
+++ b/src/snakemake/utils.py
@@ -43,8 +43,10 @@ def validate(data, schema, set_default=True):
     frame = inspect.currentframe().f_back
     workflow = frame.f_globals.get("workflow")
 
-    if workflow and workflow.modifier.skip_validation:
-        # skip if a corresponding modifier has been defined
+    if workflow and (workflow.modifier.skip_validation or workflow.remote_exec):
+        # skip if a corresponding modifier has been defined or if this is a 
+        # remote job. In the latter case, the schema has been already  validated by the
+        # main process.
         return
 
     try:


### PR DESCRIPTION

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
