### PR TITLE
refactor: Minor Logging Improvements

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -961,17 +961,15 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
         for f in unneeded_files():
             if self.workflow.dryrun:
-                if (
-                    not self.workflow.output_settings.quiet
-                    or Quietness.RULES not in self.workflow.output_settings.quiet
-                ):
-                    logger.info(f"Would remove temporary output {fmt_iofile(f)}")
+                logger.info(
+                    f"Would remove temporary output {fmt_iofile(f)}",
+                    extra={"quietness": Quietness.RULES},
+                )
             else:
-                if (
-                    not self.workflow.output_settings.quiet
-                    or Quietness.RULES not in self.workflow.output_settings.quiet
-                ):
-                    logger.info(f"Removing temporary output {fmt_iofile(f)}.")
+                logger.info(
+                    f"Removing temporary output {fmt_iofile(f)}.",
+                    extra={"quietness": Quietness.RULES},
+                )
                 await f.remove(remove_non_empty_dir=True)
 
     async def handle_log(self, job):

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -30,6 +30,7 @@ from snakemake_interface_executor_plugins.dag import DAGExecutorInterface
 from snakemake_interface_report_plugins.interfaces import DAGReportInterface
 from snakemake_interface_storage_plugins.storage_object import StorageObjectTouch
 from snakemake_interface_logger_plugins.common import LogEvent
+from snakemake.settings.enums import Quietness
 
 from snakemake import workflow as _workflow
 from snakemake.common import (
@@ -960,9 +961,11 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
         for f in unneeded_files():
             if self.workflow.dryrun:
-                logger.info(f"Would remove temporary output {fmt_iofile(f)}", extra=dict(event=LogEvent.JOB_INFO))
+                if not self.workflow.output_settings.quiet or Quietness.RULES not in self.workflow.output_settings.quiet:
+                    logger.info(f"Would remove temporary output {fmt_iofile(f)}")
             else:
-                logger.info(f"Removing temporary output {fmt_iofile(f)}.", extra=dict(event=LogEvent.JOB_INFO))
+                if not self.workflow.output_settings.quiet or Quietness.RULES not in self.workflow.output_settings.quiet:
+                    logger.info(f"Removing temporary output {fmt_iofile(f)}.")
                 await f.remove(remove_non_empty_dir=True)
 
     async def handle_log(self, job):

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -960,9 +960,9 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
         for f in unneeded_files():
             if self.workflow.dryrun:
-                logger.info(f"Would remove temporary output {fmt_iofile(f)}")
+                logger.info(f"Would remove temporary output {fmt_iofile(f)}", extra=dict(event=LogEvent.JOB_INFO))
             else:
-                logger.info(f"Removing temporary output {fmt_iofile(f)}.")
+                logger.info(f"Removing temporary output {fmt_iofile(f)}.", extra=dict(event=LogEvent.JOB_INFO))
                 await f.remove(remove_non_empty_dir=True)
 
     async def handle_log(self, job):

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -961,10 +961,16 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
 
         for f in unneeded_files():
             if self.workflow.dryrun:
-                if not self.workflow.output_settings.quiet or Quietness.RULES not in self.workflow.output_settings.quiet:
+                if (
+                    not self.workflow.output_settings.quiet
+                    or Quietness.RULES not in self.workflow.output_settings.quiet
+                ):
                     logger.info(f"Would remove temporary output {fmt_iofile(f)}")
             else:
-                if not self.workflow.output_settings.quiet or Quietness.RULES not in self.workflow.output_settings.quiet:
+                if (
+                    not self.workflow.output_settings.quiet
+                    or Quietness.RULES not in self.workflow.output_settings.quiet
+                ):
                     logger.info(f"Removing temporary output {fmt_iofile(f)}.")
                 await f.remove(remove_non_empty_dir=True)
 

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -384,6 +384,10 @@ class DefaultFilter:
         if Quietness.ALL in self.quiet and not self.dryrun:
             return False
 
+        if hasattr(record, "quietness"):
+            if record.quietness in self.quiet:
+                return False
+
         quietness_map = {
             LogEvent.JOB_INFO: Quietness.RULES,
             LogEvent.GROUP_INFO: Quietness.RULES,

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -134,11 +134,9 @@ class DefaultFormatter(logging.Formatter):
         self,
         quiet: "Quietness",
         show_failed_logs: bool = False,
-        printshellcmds: bool = False,
     ):
         self.quiet = set() if quiet is None else quiet
         self.show_failed_logs = show_failed_logs
-        self.printshellcmds = printshellcmds
         self.last_msg_was_job_info = False
 
     def format(self, record):
@@ -245,9 +243,7 @@ class DefaultFormatter(logging.Formatter):
 
     def format_shellcmd(self, msg):
         """Format for shellcmd log."""
-        if self.printshellcmds:
-            return msg["msg"]
-        return ""
+        return msg["msg"]
 
     def format_d3dag(self, msg):
         """Format for d3dag log."""
@@ -629,7 +625,6 @@ class LoggerManager:
         return DefaultFormatter(
             self.settings.quiet,
             self.settings.show_failed_logs,
-            self.settings.printshellcmds,
         )
 
     def _default_filehandler(self, logfile):

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -506,7 +506,7 @@ class ColorizingTextHandler(logging.StreamHandler):
                     # Reset flag if the message is not a 'job_info'
                     self.last_msg_was_job_info = False
                 formatted_message = self.format(record)
-                if formatted_message == "None" or formatted_message=="":
+                if formatted_message == "None" or formatted_message == "":
                     return
                 # Apply color to the formatted message
                 self.stream.write(self.decorate(record, formatted_message))

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -505,7 +505,7 @@ class ColorizingTextHandler(logging.StreamHandler):
                     # Reset flag if the message is not a 'job_info'
                     self.last_msg_was_job_info = False
                 formatted_message = self.format(record)
-                if formatted_message == "None":
+                if formatted_message == "None" or formatted_message=="":
                     return
                 # Apply color to the formatted message
                 self.stream.write(self.decorate(record, formatted_message))

--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -70,7 +70,9 @@ class JobScheduler(JobSchedulerExecutorInterface):
         self._toerror = []
         self.handle_job_success = True
         self.update_resources = True
-        self.print_progress = (not self.quiet or Quietness.PROGRESS not in self.quiet) and not self.dryrun
+        self.print_progress = (
+            not self.quiet or Quietness.PROGRESS not in self.quiet
+        ) and not self.dryrun
         self.update_checkpoint_dependencies = not self.dryrun
         self.job_rate_limiter = (
             JobRateLimiter(self.workflow.scheduling_settings.max_jobs_per_timespan)

--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -21,6 +21,7 @@ from snakemake_interface_logger_plugins.common import LogEvent
 from snakemake.common import async_run
 
 from snakemake.exceptions import RuleException, WorkflowError, print_exception
+from snakemake.settings.enums import Quietness
 from snakemake.logging import logger
 from snakemake.jobs import GroupJob
 
@@ -69,7 +70,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         self._toerror = []
         self.handle_job_success = True
         self.update_resources = True
-        self.print_progress = not self.quiet and not self.dryrun
+        self.print_progress = (not self.quiet or Quietness.PROGRESS not in self.quiet) and not self.dryrun
         self.update_checkpoint_dependencies = not self.dryrun
         self.job_rate_limiter = (
             JobRateLimiter(self.workflow.scheduling_settings.max_jobs_per_timespan)


### PR DESCRIPTION
I am using SnakeMake with wildcards for a very large number of files. I observed that executimg `snakemake --quiet rules` would still leave blank lines corresponding to the space where the rules would have been.

![image](https://github.com/user-attachments/assets/528e72d7-f6cd-4096-82df-5a10b3d5068f)

I am not fully fammiliar with the snakemake logging setup but i narrowed down the problem to the `emit` mehod of `ColorizingTextHandler`. My solution was to check for an empty `formatted_message`.


Our large number of files also use a corresponding number of temp files which results in thousands of print messages about which temporary files would be remove. I purpose adding `LogEvent.JOB_INFO`  to the temporary file messages in order to allow quieting these messages.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging to prevent empty or "None" messages from appearing in the output.
  - Refined logging behavior to respect quiet mode settings, reducing unnecessary log messages during temporary file removal and job scheduling progress updates.
  - Enhanced control over shell command and progress log visibility based on specific quietness flags for a clearer user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->