### PR TITLE
docs: Updated Requirement Section of The Tutorial With Warning of Not Installing The Tools Manually

### DIFF
--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -38,7 +38,8 @@ Setup
 Requirements
 ::::::::::::
 
-To go through this tutorial, you need the following software installed:
+**Please wait to install the tools listed below, as this tutorial will guide you through better and more reliable setup processes in the next sections.**
+For your reference, the following tools will be used:
 
 * Python_ ≥3.5
 * Snakemake_ ≥5.24.1
@@ -51,7 +52,6 @@ To go through this tutorial, you need the following software installed:
 * NetworkX_ 2.5
 * Matplotlib_ 3.3
 
-However, don't install any of these this manually now, we guide you through better ways below.
 
 .. _tutorial-free-on-gitpod:
 


### PR DESCRIPTION
Updated requirement section docs in the tutorial, to guide the user to wait for preferred ways of installation of required tools to appear in the following sections and not to install the tools one by one by yourself through the terminal manually etc.

This was important as some users could do that as the warning may be hidden as in the original version of docs and secondly had grammatical mistake. 

Fixes #3582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved setup instructions in the tutorial to more clearly advise users to wait for guided installation steps, enhancing clarity and reducing confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->