### PR TITLE
fix: typo in CondaEnvDirSpec.__eq__ (issue #3192)

### DIFF
--- a/src/snakemake/deployment/conda.py
+++ b/src/snakemake/deployment/conda.py
@@ -967,7 +967,7 @@ class CondaEnvDirSpec(CondaEnvSpec):
         return hash(self.path)
 
     def __eq__(self, other):
-        return self.path == other.file
+        return self.path == other.path
 
 
 class CondaEnvNameSpec(CondaEnvSpec):

--- a/tests/test_issue3192/Snakefile
+++ b/tests/test_issue3192/Snakefile
@@ -1,0 +1,25 @@
+conda_env = Path(os.environ['CONDA_PREFIX']) / 'envs' / 'test_issue3192'
+
+rule all:
+    input:
+        "c.txt"
+
+rule a2b:
+    input:
+        "a.txt"
+    output:
+        "b.txt"
+    conda:
+        conda_env
+    script:
+        "script.py"
+
+rule b2c:
+    input:
+        "b.txt"
+    output:
+        "c.txt"
+    conda:
+        conda_env
+    script:
+        "script.py"

--- a/tests/test_issue3192/a.txt
+++ b/tests/test_issue3192/a.txt
@@ -1,0 +1,1 @@
+some text

--- a/tests/test_issue3192/expected-results/c.txt
+++ b/tests/test_issue3192/expected-results/c.txt
@@ -1,0 +1,1 @@
+some text

--- a/tests/test_issue3192/script.py
+++ b/tests/test_issue3192/script.py
@@ -1,0 +1,5 @@
+import shutil
+
+shutil.copyfile(
+    snakemake.input[0],
+    snakemake.output[0])

--- a/tests/tests_using_conda.py
+++ b/tests/tests_using_conda.py
@@ -327,10 +327,8 @@ def test_issue_3192():
         "conda create -n test_issue3192 python",
         shell=True,
     )
-    run(
-        dpath("test_issue3192"),
-        deployment_method={DeploymentMethod.CONDA}
-    )
+    run(dpath("test_issue3192"), deployment_method={DeploymentMethod.CONDA})
+
 
 # Test that container and conda can be run independently using sdm
 @skip_on_windows

--- a/tests/tests_using_conda.py
+++ b/tests/tests_using_conda.py
@@ -321,6 +321,17 @@ def test_conda_run():
     run(dpath("test_conda_run"), deployment_method={DeploymentMethod.CONDA})
 
 
+@conda
+def test_issue_3192():
+    sp.run(
+        "conda create -n test_issue3192 python",
+        shell=True,
+    )
+    run(
+        dpath("test_issue3192"),
+        deployment_method={DeploymentMethod.CONDA}
+    )
+
 # Test that container and conda can be run independently using sdm
 @skip_on_windows
 @apptainer


### PR DESCRIPTION
Issue #3192 is related to a typo in `CondaEnvDirSpec.__eq__`. This PR fixes this issue and add a test case.
Fixes #3192

### QC
<!-- Make sure that you can tick the boxes below. -->

* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of conda environment directory comparisons to ensure correct behavior when matching environment paths.

- **Tests**
  - Added a new test workflow to verify conda environment handling, including sample input, expected output, and supporting scripts.
  - Introduced a dedicated test to validate the new conda environment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->