### PR TITLE
fix: fix bug causing --precommand to not being executed before each remote job

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -2203,6 +2203,7 @@ def args_to_api(args, parser):
                                 envvars=args.envvars,
                                 immediate_submit=args.immediate_submit,
                                 job_deploy_sources=args.job_deploy_sources,
+                                precommand=args.precommand,
                             ),
                             scheduling_settings=SchedulingSettings(
                                 prioritytargets=args.prioritize,


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a pre-command to be executed before each remote job when running workflows with remote execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->