### PR TITLE
fix: pass envvars defined via the envvars directive to remote jobs

### DIFF
--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, fields
 import hashlib
+from itertools import chain
 import os
 import sys
 from typing import Callable, Mapping, TypeVar, TYPE_CHECKING, Any
@@ -197,9 +198,12 @@ class SpawnedJobArgsFactory:
         return format_cli_arg(flag, value, base64_encode=base64_encode)
 
     def envvars(self) -> Mapping[str, str]:
+        assert self.workflow.remote_execution_settings is not None
         envvars = {
             var: os.environ[var]
-            for var in self.workflow.remote_execution_settings.envvars
+            for var in chain(
+                self.workflow.remote_execution_settings.envvars, self.workflow.envvars
+            )
         }
         envvars.update(self.get_storage_provider_envvars())
         return envvars


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by ensuring environment variables are correctly gathered from both remote execution settings and workflow settings.
- **Chores**
  - Enhanced internal checks to prevent errors when accessing remote execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->