### PR TITLE
Add support for pathlib in `notebook` field

### DIFF
--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -278,6 +278,8 @@ def notebook(
     Load a script from the given basedir + path and execute it.
     """
     draft = False
+    if isinstance(path, Path):
+        path = str(path)
     path = format(path, wildcards=wildcards, params=params)
     if edit is not None:
         if is_local_file(path):


### PR DESCRIPTION
The following:

```python
from pathlib import Path

DIR = Path("scripts")

rule my_rule:
    input:
        "data.csv",
    output:
        "result.csv",
    notebook:
        DIR / "process_data.ipynb"
```

Produces an error:

```pycon
TypeError in file "C:\Users\staadeck\Software\pyoframe\Snakefile", line 61:
expected str, got WindowsPath
  File "C:\Users\staadeck\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\string.py", line 190, in format
  File "C:\Users\staadeck\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\string.py", line 194, in vformat
  File "C:\Users\staadeck\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\string.py", line 204, in _vformat
  File "C:\Users\staadeck\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\string.py", line 288, in parse
```

This PR adds support for `Path` objects in the `notebook` field. **I did not have time (to learn how) to make a test case.**