### PR TITLE
fix: fix bug in workflow.source_path causing non-cached source files when called from input functions

### DIFF
--- a/src/snakemake/sourcecache.py
+++ b/src/snakemake/sourcecache.py
@@ -39,7 +39,7 @@ def _check_git_args(tag: str = None, branch: str = None, commit: str = None):
 
 class SourceFile(ABC):
     @abstractmethod
-    def get_path_or_uri(self): ...
+    def get_path_or_uri(self) -> str: ...
 
     @abstractmethod
     def is_persistently_cacheable(self): ...
@@ -87,7 +87,7 @@ class GenericSourceFile(SourceFile):
     def __init__(self, path_or_uri):
         self.path_or_uri = path_or_uri
 
-    def get_path_or_uri(self):
+    def get_path_or_uri(self) -> str:
         return self.path_or_uri
 
     def get_filename(self):
@@ -105,7 +105,7 @@ class LocalSourceFile(SourceFile):
     def __init__(self, path):
         self.path = path
 
-    def get_path_or_uri(self):
+    def get_path_or_uri(self) -> str:
         return self.path
 
     def is_persistently_cacheable(self):
@@ -145,7 +145,7 @@ class LocalGitFile(SourceFile):
         self.repo_path = repo_path
         self.path = path
 
-    def get_path_or_uri(self):
+    def get_path_or_uri(self) -> str:
         return "git+file://{}/{}@{}".format(
             os.path.abspath(self.repo_path), self.path, self.ref
         )
@@ -286,7 +286,7 @@ class GithubFile(HostingProviderFile):
             )
         self.token = os.environ.get("GITHUB_TOKEN", "")
 
-    def get_path_or_uri(self):
+    def get_path_or_uri(self) -> str:
         auth = f":{self.token}@" if self.token else ""
         # TODO find out how this URL looks like with Github enterprise server and support
         # self.host being not none by removing the check in __post_init__
@@ -299,7 +299,7 @@ class GitlabFile(HostingProviderFile):
             self.host = "gitlab.com"
         self.token = os.environ.get("GITLAB_TOKEN", "")
 
-    def get_path_or_uri(self):
+    def get_path_or_uri(self) -> str:
         from urllib.parse import quote
 
         auth = f"&private_token={self.token}" if self.token else ""
@@ -312,7 +312,7 @@ class GitlabFile(HostingProviderFile):
         )
 
 
-def infer_source_file(path_or_uri, basedir: SourceFile = None):
+def infer_source_file(path_or_uri, basedir: Optional[SourceFile] = None) -> SourceFile:
     if isinstance(path_or_uri, SourceFile):
         if basedir is None or isinstance(path_or_uri, HostingProviderFile):
             return path_or_uri
@@ -390,7 +390,6 @@ class SourceCache:
         file_cache_path = source_file.get_cache_path()
         assert file_cache_path
 
-        # TODO add git support to smart_open!
         if source_file.is_persistently_cacheable():
             # check cache
             return self.cache_path / file_cache_path

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1496,7 +1496,7 @@ class Workflow(WorkflowExecutorInterface):
         """Basedir of currently parsed Snakefile."""
         assert self.included_stack
         snakefile = self.included_stack[-1]
-        return self._get_basedir(snakefile)    
+        return self._get_basedir(snakefile)
 
     def _get_basedir(self, snakefile: SourceFile) -> SourceFile:
         basedir = snakefile.get_basedir()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1033,44 +1033,6 @@ def test_scopes_submitted_to_cluster(mocker):
 
 
 @skip_on_windows
-def test_resources_submitted_to_cluster(mocker):
-    from snakemake_interface_executor_plugins.executors.base import AbstractExecutor
-
-    spy = mocker.spy(AbstractExecutor, "get_resource_declarations_dict")
-    run(
-        dpath("test_group_jobs_resources"),
-        cluster="./qsub",
-        cores=6,
-        resources={"mem_mb": 60000},
-        max_threads=1,
-        group_components={0: 5},
-        default_resources=DefaultResources(["mem_mb=0"]),
-    )
-
-    assert_resources(
-        spy.spy_return, mem_mb=60000, fake_res=1200, global_res=3000, disk_mb=3000
-    )
-
-
-@skip_on_windows
-def test_excluded_resources_not_submitted_to_cluster(mocker):
-    from snakemake_interface_executor_plugins.executors.base import AbstractExecutor
-
-    spy = mocker.spy(AbstractExecutor, "get_resource_declarations_dict")
-    run(
-        dpath("test_group_jobs_resources"),
-        cluster="./qsub",
-        cores=6,
-        resources={"mem_mb": 60000},
-        max_threads=1,
-        overwrite_resource_scopes={"fake_res": "excluded"},
-        group_components={0: 5},
-        default_resources=DefaultResources(["mem_mb=0"]),
-    )
-    assert_resources(spy.spy_return, mem_mb=60000, global_res=3000, disk_mb=3000)
-
-
-@skip_on_windows
 def test_group_job_resources_with_pipe(mocker):
     import copy
     from snakemake_interface_executor_plugins.executors.real import RealExecutor


### PR DESCRIPTION

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal management of included files for more consistent and direct access.
  - Enhanced handling of file paths and base directories in workflow operations.

- **Style**
  - Updated method and function signatures with explicit type annotations for improved clarity.

- **Chores**
  - Removed outdated comments to keep the codebase clean.

- **Tests**
  - Removed specific tests related to resource submission and exclusion in cluster workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->