### PR TITLE
docs: Update pixi setup section of tutorial

### DIFF
--- a/docs/tutorial/setup.rst
+++ b/docs/tutorial/setup.rst
@@ -149,7 +149,7 @@ extract it, and move the pixi binary to ``~/.pixi/bin``.
 If this directory does not already exist, the script will create it.
 
 The script will also update your ``~/.bashrc`` or ``~/.zshrc`` to include ``~/.pixi/bin`` in your PATH,
-allowing you to invoke the ``pixi`` command from anywhere.
+allowing you to invoke the ``pixi`` command from anywhere after opening a **new terminal** window.
 
 Please also see the official `Pixi installation`_ instructions for more information.
 


### PR DESCRIPTION
This pull request includes a minor update to the `docs/tutorial/setup.rst` file. The change clarifies that users need to open a new terminal window to invoke the `pixi` command after installation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that a new terminal window must be opened after installation for the `pixi` command to become available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->