### PR TITLE
fix ambiguous rule bug

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -19,6 +19,7 @@ from snakemake.utils import min_version  # import so we can patch out if needed
 
 from snakemake.settings.types import Batch
 from snakemake.shell import shell
+from snakemake.exceptions import AmbiguousRuleException
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -2439,3 +2440,11 @@ def test_censored_path():
 
 def test_params_empty_inherit():
     run(dpath("test_params_empty_inherit"))
+
+
+def test_ambiguousruleexception():
+    try:
+        run(dpath("test_ambiguousruleexception"))
+    except AmbiguousRuleException:
+        return
+    assert False, "This is an ambiguous case! Should have raised an error..."


### PR DESCRIPTION
<!--Add a description of your PR here-->

I noticed an edge case where unused temporary output of different rules would go to the same file. This can introduce nasty side effects, and also made it so that my rules needed to be re-run all the times. This is now detected.

I'm not sure how this affects performance or other stuff, let me know if sth needs changes or if this is actually wanted behaviour :smile: 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
