### PR TITLE
Fix:dag mermaid-js edges (bug:#3556)

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -2665,10 +2665,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
             f"\tstyle id{index} fill:{rulecolor[str(node)]},stroke-width:2px,color:#333333{node2style(node)}"
             for index, node in enumerate(graph)
         ]
+        # node ids
+        ids = {node: i for i, node in enumerate(graph)}
         edges = [
-            f"\tid{index} --> id{index_dep}"
-            for index, (_, deps) in enumerate(graph.items())
-            for index_dep, _ in enumerate(deps)
+            f"\tid{ids[dep]} --> id{ids[node]}"
+            for node, deps in graph.items()
+            for dep in deps
         ]
         return (
             textwrap.dedent(


### PR DESCRIPTION
I noticed that `DAG._dot()` renders the edges correctly, but `DAG._mermaid_js()` makes a mess out of it.

- I copied the bit from the _dot part to the _mermaid_js part
- modified the f"" stretch to use the correct numbers

This fixed the mermaid output so it matches the dot one.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

Unfortunately, I could not figure out how to add a good test for the issue.
I was trying to add this to `tests/test.py`:

```python
def test_github_issue3556():
    run(dpath("test_github_issue3556"), shellcmd="snakemake --dag mermaid-js >stdout.txt")
```

If we need to add a test, I would appreciate some help in how to capture the DAG output to STDOUT and compare it to the expected output.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the direction of edges in the Mermaid.js graph representation, ensuring dependencies are accurately visualized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->