### PR TITLE
fix: if asset is present and no sha256 provided assume pass

### DIFF
--- a/src/snakemake/assets/__init__.py
+++ b/src/snakemake/assets/__init__.py
@@ -541,7 +541,7 @@ class Assets:
             if target_path.exists():
                 with open(target_path, "rb") as fin:
                     # file is already present, check if it is up to date
-                    if (asset.sha256 is not None) and (
+                    if (asset.sha256 is None) or (
                         asset.sha256 == hashlib.sha256(fin.read()).hexdigest()
                     ):
                         continue


### PR DESCRIPTION
see https://github.com/snakemake/snakemake/issues/3684

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asset redeployment by skipping files with missing SHA256 checksums, reducing unnecessary redeployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->