### PR TITLE
Rerun rule if timestamp updated, even if checksum same (rerun-trigger mtime)

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1428,7 +1428,9 @@ class DAG(DAGExecutorInterface, DAGReportInterface):
                             if (
                                 await f.exists()
                                 and await f.is_newer(output_mintime_)
-                                and not await is_same_checksum(f, job)
+                                and (RerunTrigger.MTIME in self.workflow.rerun_triggers
+                                     or
+                                     not await is_same_checksum(f, job))
                             ):
                                 yield f
 

--- a/tests/test_github_issue2011/Snakefile
+++ b/tests/test_github_issue2011/Snakefile
@@ -1,0 +1,14 @@
+
+rule all:
+    input:
+        'out.txt'
+
+rule compose:
+    input:
+        'in.txt',
+    output:
+        'out.txt',
+    shell:
+        r"""
+        touch {output}
+        """

--- a/tests/test_github_issue3095/Snakefile
+++ b/tests/test_github_issue3095/Snakefile
@@ -1,0 +1,8 @@
+rule second:
+    input: "first.txt"
+    output: "second.txt"
+    shell: "echo second > {output}"
+
+rule first:
+    output: "first.txt"
+    shell: "echo first > {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2476,4 +2476,38 @@ def test_github_issue2011():
     # check that output file was updated
     assert outfile_timestamp_orig != outfile_timestamp_new, "Output file was not updated despite input file timestamp change and with --rerun-triggers mtime"
 
+    os.utime(input_file) # update timestamp once more
+    # now run without any --rerun-triggers, which should include mtime by default and update output file
+    run(dpath("test_github_issue2011"), shellcmd="snakemake -c1", tmpdir=tmpdir, cleanup=False, check_results=False)
+    outfile_timestamp_new = os.path.getmtime(outfile_path)
+    # check that output file was updated
+    assert outfile_timestamp_orig != outfile_timestamp_new, "Output file was not updated despite input file timestamp change and with --rerun-triggers mtime"
+
+    shutil.rmtree(tmpdir)
+
+def test_github_issue3095():
+    tmpdir = run(dpath("test_github_issue3095"), shellcmd="snakemake -c1", cleanup=False, check_results=False)
+    outfile_path = os.path.join(tmpdir, "second.txt")
+    outfile_timestamp_orig = os.path.getmtime(outfile_path)
+
+    # force rerunning of the first rule
+    run(dpath("test_github_issue3095"), shellcmd="snakemake -c1 --force first", tmpdir=tmpdir, cleanup=False, check_results=False)
+
+    run(dpath("test_github_issue3095"), shellcmd="snakemake -c1 --rerun-triggers code input params software-env", tmpdir=tmpdir, cleanup=False, check_results=False)
+    outfile_timestamp_new = os.path.getmtime(outfile_path)
+    # check that output file was not updated
+    assert outfile_timestamp_orig == outfile_timestamp_new, "Output file was updated despite input file not having changed (checksum, without --rerun-triggers mtime)"
+
+    run(dpath("test_github_issue3095"), shellcmd="snakemake -c1 --rerun-triggers mtime", tmpdir=tmpdir, cleanup=False, check_results=False)
+    outfile_timestamp_new = os.path.getmtime(outfile_path)
+    # check that output file was updated
+    assert outfile_timestamp_orig != outfile_timestamp_new, "Output file was not updated despite input file timestamp change and with --rerun-triggers mtime"
+
+    # force rerun first rule again, to check that it works without any --rerun-triggers
+    run(dpath("test_github_issue3095"), shellcmd="snakemake -c1 --force first", tmpdir=tmpdir, cleanup=False, check_results=False)
+    run(dpath("test_github_issue3095"), shellcmd="snakemake -c1", tmpdir=tmpdir, cleanup=False, check_results=False)
+    outfile_timestamp_new = os.path.getmtime(outfile_path)
+    # check that output file was updated
+    assert outfile_timestamp_orig != outfile_timestamp_new, "Output file was not updated despite input file timestamp change and with --rerun-triggers mtime"
+
     shutil.rmtree(tmpdir)


### PR DESCRIPTION
Previously, a rule would not be rerun even with newer input files (according to file timestamps) if the checksums were unchanged. This may be unexpected and problematic especially for empty "touch" files. 
There are at least two open issues (#2011 , #3095 ) on the tracker, so I understand this is not the intended behaviour. Also this issue [was discussed](https://github.com/snakemake/snakemake/issues/1694#issuecomment-1986701139) after rerun changes were implemented.

With the minor changes in this PR, if the mtime rerun-trigger is set, checksums are only checked if the timestamp is not newer. Because the mtime rerun trigger is set by default, this also changes default behaviour.
For the old behaviour, only the other rerun-triggers need to be set ("--rerun-triggers code input params software-env"). I believe this is in line with the current documentation and the issues seem to show that some people expected this behaviour. Otherwise, I would suggest to not set the mtime rerun-trigger by default.

Also added test cases to reproduce the two tracker issues.

### QC
* [X] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [X] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
