### PR TITLE
fix: don't rate limit jobs when touching

### DIFF
--- a/src/snakemake/scheduler.py
+++ b/src/snakemake/scheduler.py
@@ -76,7 +76,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         self.update_checkpoint_dependencies = not self.dryrun
         self.job_rate_limiter = (
             JobRateLimiter(self.workflow.scheduling_settings.max_jobs_per_timespan)
-            if not self.dryrun
+            if not (self.dryrun or self.touch)
             and self.workflow.scheduling_settings.max_jobs_per_timespan
             else None
         )


### PR DESCRIPTION
Came across this while `--touch`ing many files, but it seems having something like `max-jobs-per-timespan: "100/1m"` in a profile will also limit the rate for files getting touched (which is a very different operation to actually submitting jobs). 

Previously you would get many messages for
> Job rate limit reached, waiting for free slots.

Whereas now you should only encounter that message if you are not in dryrun or touch mode.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Touch mode now bypasses job submission rate limiting, enabling faster execution when only updating timestamps.
  * Users with a configured submission cap will no longer experience artificial delays in touch runs; normal runs continue to honor rate limits, and dry-run behavior is unchanged.
  * Scheduling order and resource checks remain the same; only the rate limiting is skipped in touch mode, improving responsiveness without altering other execution semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->