### PR TITLE
chore: migrate to renamed github actions windows image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,10 @@ jobs:
       matrix:
         test_group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         # see pyprojec.toml: [tool.pixi.feature.test] for available test types
-        os: [ubuntu-latest, windows-latest, macos-latest] #  , macos-13 not supported yet
+        os: [ubuntu-latest, windows-2022, macos-latest] #  , macos-13 not supported yet
         env: ["py311", "py312", "py313"]
         exclude:
-          - os: windows-latest
+          - os: windows-2022
             env: "py311"
           - os: macos-latest
             env: "py311"


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration to use the Windows 2022 runner, replacing the previous Windows configuration.
  - Adjusted test matrix exclusions to align with the new Windows runner.
  - Other platform configurations (Ubuntu, macOS) remain unchanged.
  - No impact on application functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->