### PR TITLE
fix: unable to ignore code change for scripts

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1447,17 +1447,18 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                             # for determining any other changes than file modification dates, as it will
                             # change after evaluating the input function of the job in the second pass.
 
-                            # The list comprehension is needed below in order to
-                            # collect all the async generator items before
-                            # applying any().
-                            reason.code_changed = any(
-                                [
-                                    f
-                                    async for f in job.outputs_older_than_script_or_notebook()
-                                ]
-                            )
                             if not self.workflow.persistence.has_metadata(job):
                                 reason.no_metadata = True
+                                # The list comprehension is needed below in order to
+                                # collect all the async generator items before
+                                # applying any().
+                                # Ensure mtime of script/notebook no longer triggers the workflow (#3014 review)
+                                reason.code_changed = any(
+                                    [
+                                        f
+                                        async for f in job.outputs_older_than_script_or_notebook()
+                                    ]
+                                )
                             elif self.workflow.persistence.has_outdated_metadata(job):
                                 reason.outdated_metadata = True
                             else:
@@ -1470,7 +1471,12 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                                         self.workflow.persistence.input_changed(job)
                                     )
                                 if RerunTrigger.CODE in self.workflow.rerun_triggers:
-                                    reason.code_changed |= any(
+                                    reason.code_changed = any(
+                                        [
+                                            f
+                                            async for f in job.outputs_older_than_script_or_notebook()
+                                        ]
+                                    ) or any(
                                         self.workflow.persistence.code_changed(job)
                                     )
                                 if (


### PR DESCRIPTION
<!--Add a description of your PR here-->
Fix the issue mentioned in #3456, which code change cannot be ignored when using script. The issue in the original code is the following snippets will return `true` even if `rerun_triggers` do not include `RerunTrigger.CODE`
```py
reason.code_changed = any(
    [
            f
            async for f in job.outputs_older_than_script_or_notebook()
    ]
)
if not self.workflow.persistence.has_metadata(job):
...
```

My approch should be able to handle #3148 as well.
                            
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of when tasks need rerunning by refining metadata, code-change and output-age checks, reducing unnecessary or missed reruns in edge cases.

* **Style**
  * Clarified internal comments and cleaned up related log/message formatting for clearer, more maintainable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->