### PR TITLE
fix: only trigger script with CODE label

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1448,7 +1448,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                             # change after evaluating the input function of the job in the second pass.
 
                             if RerunTrigger.CODE in self.workflow.rerun_triggers:
-                                # Prefer script/notebook mtime over metadata when CODE trigger is enabled.
+                                # Always check script/notebook mtime unless CODE trigger is disabled.
                                 # Short-circuit on first older output to avoid building a list.
                                 reason.code_changed = False
                                 async for (

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1447,15 +1447,15 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                             # for determining any other changes than file modification dates, as it will
                             # change after evaluating the input function of the job in the second pass.
 
-                            # The list comprehension is needed below in order to
-                            # collect all the async generator items before
-                            # applying any().
-                            reason.code_changed = any(
-                                [
-                                    f
-                                    async for f in job.outputs_older_than_script_or_notebook()
-                                ]
-                            )
+                            if RerunTrigger.CODE in self.workflow.rerun_triggers:
+                                # job metadata can be missed, but the separate scripts don't.
+                                # but it should not work if unwanted
+                                reason.code_changed = any(
+                                    [
+                                        f
+                                        async for f in job.outputs_older_than_script_or_notebook()
+                                    ]
+                                )
                             if not self.workflow.persistence.has_metadata(job):
                                 reason.no_metadata = True
                             elif self.workflow.persistence.has_outdated_metadata(job):

--- a/tests/common.py
+++ b/tests/common.py
@@ -50,7 +50,7 @@ def is_connected():
     try:
         urllib.request.urlopen("http://www.google.com", timeout=1)
         return True
-    except urllib.request.URLError:
+    except (urllib.request.URLError, TimeoutError):
         return False
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,7 +13,7 @@ import time
 from os.path import join
 import tempfile
 import hashlib
-import urllib
+import urllib.request
 import pytest
 import glob
 import subprocess

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -485,9 +485,10 @@ def test_script_python():
     # update timestamp but not contents of script
     script_file = os.path.join(tmpdir, "scripts/test_explicit_import.py")
     os.utime(script_file)
-    shell(f"snakemake -s {tmpdir}/Snakefile -d {tmpdir} --rerun-triggers mtime -c 1")
+    smkfile = os.path.join(tmpdir, "Snakefile")
+    shell(f"snakemake -s {smkfile} -d {tmpdir} --rerun-triggers mtime -c 1")
     assert outfile_timestamp_orig == os.path.getmtime(outfile_path)
-    shell(f"snakemake -s {tmpdir}/Snakefile -d {tmpdir} -c 1")
+    shell(f"snakemake -s {smkfile} -d {tmpdir} -c 1")
     assert outfile_timestamp_orig != os.path.getmtime(outfile_path)
     shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -479,7 +479,19 @@ def test_empty_include():
 
 
 def test_script_python():
-    run(dpath("test_script_py"))
+    tmpdir = run(dpath("test_script_py"), cleanup=False)
+    outfile_path = os.path.join(tmpdir, "test.out")
+    outfile_timestamp_orig = os.path.getmtime(outfile_path)
+    # update timestamp but not contents of input file
+    script_file = os.path.join(tmpdir, "scripts/test.py")
+    os.utime(script_file)
+    run(
+        dpath("test_script_py"),
+        rerun_triggers=frozenset([RerunTrigger.MTIME]),
+        cleanup=False,
+    )
+    outfile_timestamp_new = os.path.getmtime(outfile_path)
+    assert outfile_timestamp_orig == outfile_timestamp_new
 
 
 @skip_on_windows  # Test relies on perl

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -480,17 +480,26 @@ def test_empty_include():
 
 def test_script_python():
     tmpdir = run(dpath("test_script_py"), cleanup=False)
+    # update timestamp of script
+    os.utime(os.path.join(tmpdir, "scripts/test_explicit_import.py"))
     outfile_path = os.path.join(tmpdir, "explicit_import.py.out")
     outfile_timestamp_orig = os.path.getmtime(outfile_path)
-    # update timestamp but not contents of script
-    script_file = os.path.join(tmpdir, "scripts/test_explicit_import.py")
-    os.utime(script_file)
-    smkfile = os.path.join(tmpdir, "Snakefile")
-    shell(f"snakemake -s {smkfile} -d {tmpdir} --rerun-triggers mtime -c 1")
+    # won't update output without trigger CODE
+    run(
+        dpath("test_script_py"),
+        cleanup=False,
+        tmpdir=tmpdir,
+        shellcmd="snakemake -c1 --rerun-triggers mtime",
+    )
     assert outfile_timestamp_orig == os.path.getmtime(outfile_path)
-    shell(f"snakemake -s {smkfile} -d {tmpdir} -c 1")
+    run(
+        dpath("test_script_py"),
+        cleanup=False,
+        tmpdir=tmpdir,
+        shellcmd="snakemake -c1",
+    )
     assert outfile_timestamp_orig != os.path.getmtime(outfile_path)
-    shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
+    # shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 
 
 @skip_on_windows  # Test relies on perl

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -480,18 +480,16 @@ def test_empty_include():
 
 def test_script_python():
     tmpdir = run(dpath("test_script_py"), cleanup=False)
-    outfile_path = os.path.join(tmpdir, "test.out")
+    outfile_path = os.path.join(tmpdir, "explicit_import.py.out")
     outfile_timestamp_orig = os.path.getmtime(outfile_path)
-    # update timestamp but not contents of input file
-    script_file = os.path.join(tmpdir, "scripts/test.py")
+    # update timestamp but not contents of script
+    script_file = os.path.join(tmpdir, "scripts/test_explicit_import.py")
     os.utime(script_file)
-    run(
-        dpath("test_script_py"),
-        rerun_triggers=frozenset([RerunTrigger.MTIME]),
-        cleanup=False,
-    )
-    outfile_timestamp_new = os.path.getmtime(outfile_path)
-    assert outfile_timestamp_orig == outfile_timestamp_new
+    shell(f"snakemake -s {tmpdir}/Snakefile -d {tmpdir} --rerun-triggers mtime -c 1")
+    assert outfile_timestamp_orig == os.path.getmtime(outfile_path)
+    shell(f"snakemake -s {tmpdir}/Snakefile -d {tmpdir} -c 1")
+    assert outfile_timestamp_orig != os.path.getmtime(outfile_path)
+    shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
 
 
 @skip_on_windows  # Test relies on perl


### PR DESCRIPTION
This PR is inspired by #3706, resolves issues #3456 and #3474, and addresses the concern raised in https://github.com/snakemake/snakemake/pull/3148#discussion_r1837990293_

In brief, commit e502312 made changes so that the modification time (mtime) of script and notebook files no longer triggers a rerun of the workflow, later, commit e8a0b83 reversed this, making mtime changes always trigger reruns -- even when RerunTrigger.CODE is not specified in `--rerun-triggers`.
This created an undesirable situation: legitimate and common scenarios (e.g., copying scripts or pulling them from a Git repository) could unnecessarily trigger reruns — as reported in #3474.

To make the behavior more intuitive, the `outputs_older_than_script_or_notebook` condition should take precedence over metadata checks. However, this condition should still be governed by the presence of `RerunTrigger.CODE`.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code-change reruns now only run when the CODE rerun trigger is enabled; code-change detection correctly accumulates signals from multiple sources to avoid missed or spurious reruns.

* **Tests**
  * Added an MTIME-triggered rerun test validating that outputs retain timestamps when only input mtimes change.

* **Chores**
  * Fixed a test import path and broadened connectivity error handling to include timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->