### PR TITLE
fix: enable docstring assignment in `use rule ... with:` block

### DIFF
--- a/tests/test_module_nested/Snakefile
+++ b/tests/test_module_nested/Snakefile
@@ -6,7 +6,8 @@ module shallow_module:
         "module_shallow.smk"
 
 
-use rule deep_work from shallow_module as shallow_work
+use rule deep_work from shallow_module as shallow_work with:
+    """a rule from deep module"""
 
 
 rule all:


### PR DESCRIPTION
will fix #1678 and fix #3677 

enable assign a docstring after `use rule ... with:`

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
