### PR TITLE
fix: use queue_input_wait_time when updating queue input jobs

### DIFF
--- a/src/snakemake/scheduling/job_scheduler.py
+++ b/src/snakemake/scheduling/job_scheduler.py
@@ -458,7 +458,10 @@ class JobScheduler(JobSchedulerExecutorInterface):
 
     def update_queue_input_jobs(self):
         currtime = time.time()
-        if currtime - self._last_update_queue_input_jobs >= 10:
+        if (
+            currtime - self._last_update_queue_input_jobs
+            >= self.workflow.execution_settings.queue_input_wait_time
+        ):
             self._last_update_queue_input_jobs = currtime
             async_run(self.workflow.dag.update_queue_input_jobs())
 


### PR DESCRIPTION
Fixes #3696 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The interval for updating queued input jobs is now configurable via execution settings (replacing the previous fixed 10-second interval). Users can tune this value to optimize responsiveness or reduce scheduling overhead based on their workload and infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->