### PR TITLE
perf: for caching source files under potential race conditions, use rsync like file writing in order to improve performance on distributed filesystems like glusterfs

### DIFF
--- a/src/snakemake/common/__init__.py
+++ b/src/snakemake/common/__init__.py
@@ -10,11 +10,10 @@ import operator
 import platform
 import hashlib
 import inspect
-import random
 import shutil
 import sys
 from tempfile import NamedTemporaryFile
-from typing import Callable, List, Optional, Self, Tuple
+from typing import Callable, List, Optional, Tuple
 import uuid
 import os
 import asyncio
@@ -400,7 +399,7 @@ class LockFreeWritableFile:
             prefix=f".{orig_path.name}.",
         )
 
-    def __enter__(self) -> Self:
+    def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/snakemake/common/__init__.py
+++ b/src/snakemake/common/__init__.py
@@ -407,6 +407,7 @@ class LockFreeWritableFile:
         if not exc_type:
             if self._permissions is not None:
                 os.chmod(self.temp_file.name, self._permissions)
+            if self._times is not None:
                 os.utime(self.temp_file.name, self._times)
             # atomic move
             os.replace(self.temp_file.name, self.orig_path)

--- a/src/snakemake/snakemake.code-workspace
+++ b/src/snakemake/snakemake.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": ".."
-		}
-	],
-	"settings": {}
-}


### PR DESCRIPTION
Network filesystems can be slow with certain operations. For example, gluster has issues with move/rename.
However, the write-then-rename pattern is very effective to avoid race conditions and partially written files, e.g. when performing cache operations.
The probably most popular tool that does this is rsync. In order to speed up the process and benefit from optimizations systems like GlusterFS make for rsync, Snakemake now uses the same naming scheme as rsync for temp files in the write-then-rename pattern (with one tiny exception: the random suffix is 8 chars long instead of 6, because Python temp file handling does it like that).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds atomic, lock-free file writes for outputs and cache entries to avoid partial files on failure.
  - Commits now preserve file permissions and timestamps for consistent results.

- Refactor
  - Simplifies cache write flow to use atomic commits, reducing temporary artifacts and edge-case failures.

- Chores
  - Removes an editor workspace configuration file from the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->