### PR TITLE
fix: invalid escape sequences in a doc string

### DIFF
--- a/src/snakemake/resources.py
+++ b/src/snakemake/resources.py
@@ -662,7 +662,7 @@ def infer_resources(name, value, resources: dict):
 
 
 def is_ordinary_string(val):
-    """
+    r"""
     Check if a string is an ordinary string.
     Ordinary strings are not evaluated and are not
     expected to be python expressions and be returned as is.


### PR DESCRIPTION
Make the doc string for `snakemake.resources.is_ordinary_string` a raw string to avoid interpreting backslashes in regexes represented within the docstring as Python string escape sequences.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case. **(In my environment, these invalid escape sequences cause `test_lint` to fail, and this PR fixes that.)**
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). **N/A**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated docstring formatting to use raw string literals.
  - Clarifies representation of backslashes in documentation strings.
  - No changes to functionality, behavior, or configuration.
  - No impact on public APIs or compatibility.
  - Affects internal documentation only; runtime remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->