### PR TITLE
fix: properly fall back to greedy scheduler in case of pulp/cbc errors

### DIFF
--- a/src/snakemake/scheduling/job_scheduler.py
+++ b/src/snakemake/scheduling/job_scheduler.py
@@ -157,6 +157,7 @@ class JobScheduler(JobSchedulerExecutorInterface):
         # Choose job selector (greedy or ILP)
         self.job_selector_greedy = self._greedy_scheduler.select_jobs
         self._job_selector = scheduler.select_jobs
+        self._scheduler = scheduler
 
         self._user_kill = None
         try:


### PR DESCRIPTION
fixes #3719 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic fallback to a greedy scheduler when the ILP solver fails or times out, ensuring continued progress.
  - More informative logging that clearly indicates when and why a fallback occurs.

- Bug Fixes
  - Improved robustness by gracefully handling solver errors and timeouts, preventing crashes or stalls during scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->