### PR TITLE
fix: use proper default and fallback LP solver in scheduler settings (thanks @raffienficiaud)

### DIFF
--- a/src/snakemake/scheduling/milp.py
+++ b/src/snakemake/scheduling/milp.py
@@ -10,17 +10,17 @@ from snakemake_interface_common.io import AnnotatedStringInterface
 
 
 def get_lp_solvers():
-    default = ["PULP_CBC_CMD"]
+    default = "PULP_CBC_CMD"
     try:
         import pulp
 
-        return default + sorted(
+        return [default] + sorted(
             solver
             for solver in pulp.listSolvers(onlyAvailable=True)
             if solver != default
         )
     except Exception:
-        return default
+        return [default]
 
 
 lp_solvers = get_lp_solvers()


### PR DESCRIPTION
fixes #3719

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default MILP solver is now chosen automatically from solvers available in your environment.

* **Improvements**
  * Solver selection is more robust by using an ordered list of available solvers instead of a fixed default.
  * Falls back to a sensible bundled solver when others aren’t available.
  * Users can still pick a solver explicitly via settings or configuration.

* **Bug Fixes**
  * Reduces failures on systems where the previously assumed default solver was missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->