### PR TITLE
chore: bump logger interface version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "snakemake-interface-common>=1.20.1,<2.0",
   "snakemake-interface-storage-plugins>=4.1.0,<5.0",
   "snakemake-interface-report-plugins>=1.2.0,<2.0.0",
-  "snakemake-interface-logger-plugins>=1.1.0,<2.0.0",
+  "snakemake-interface-logger-plugins>=2.0.0,<3.0.0",
   "snakemake-interface-scheduler-plugins>=2.0.0,<3.0.0",
   "tabulate",
   "throttler",


### PR DESCRIPTION
The logger plugin interface is now at 2.0.0, bumping the version required here.