### PR TITLE
fix: use proper callable when accessing rule proxy with associated path modifier

### DIFF
--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -1400,12 +1400,13 @@ class RuleProxy:
     @lazy_property
     def input(self):
         def modify_callable(item):
-            if is_callable(item):
-                # For callables ensure that the rule's original path modifier is applied as well.
+            assert isinstance(item, _IOFile)
+            if item.is_callable():
+                func = item._file.callable
 
                 def inner(wildcards):
                     return self.rule.apply_path_modifier(
-                        item(wildcards), self.rule.input_modifier, property="input"
+                        func(wildcards), self.rule.input_modifier, property="input"
                     )
 
                 return inner


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
