### PR TITLE
fix: image posting

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           access-token: ${{ secrets.MASTODONBOT }}
           pr-title: ${{ github.event.head_commit.message }}
-          image: "${{ github.workspace }}/images/logo_dark.png"
+          image: "logo_dark.png"
           image-description: "Snakemake HPC logo for Mastodon"
           message: |
             BEEP, BEEP - I am your friendly #Snakemake release announcement bot.


### PR DESCRIPTION
The mastodon release action has accidentally not been updated. So, no logo image has been appended. This is now fixed upstream. Yet, the image path does not to be indicated as the announcement post action crawls for it (hopefully ;-) ).
