### PR TITLE
fix: remove id field in notebook cells created by nbformat, thereby increasing compatibility with different jupyter versions

### DIFF
--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -17,7 +17,7 @@ from snakemake.utils import format
 KERNEL_STARTED_RE = re.compile(r"Kernel started: (?P<kernel_id>\S+)")
 KERNEL_SHUTDOWN_RE = re.compile(r"Kernel shutdown: (?P<kernel_id>\S+)")
 
-NBFORMAT_VERSION = 5
+NBFORMAT_VERSION = 4
 
 
 def get_cell_sources(source):

--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -139,6 +139,7 @@ class JupyterNotebook(ScriptBase):
 
         preamble_cell = nbformat.v4.new_code_cell(preamble)
         preamble_cell["metadata"]["tags"] = ["snakemake-job-properties"]
+        preamble_cell.pop("id", None)  # remove id if present, it causes issues in some jupyter versions
         notebook["cells"].insert(0, preamble_cell)
 
     def remove_preamble_cell(self, notebook):

--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -17,6 +17,8 @@ from snakemake.utils import format
 KERNEL_STARTED_RE = re.compile(r"Kernel started: (?P<kernel_id>\S+)")
 KERNEL_SHUTDOWN_RE = re.compile(r"Kernel shutdown: (?P<kernel_id>\S+)")
 
+NBFORMAT_VERSION = 5
+
 
 def get_cell_sources(source):
     import nbformat
@@ -42,7 +44,7 @@ class JupyterNotebook(ScriptBase):
         os.makedirs(os.path.dirname(self.local_path), exist_ok=True)
 
         with open(self.local_path, "wb") as out:
-            out.write(nbformat.writes(nb).encode())
+            out.write(nbformat.writes(nb, version=NBFORMAT_VERSION).encode())
 
     def draft_and_edit(self, listen):
         self.draft()
@@ -54,12 +56,12 @@ class JupyterNotebook(ScriptBase):
     def write_script(self, preamble, fd):
         import nbformat
 
-        nb = nbformat.reads(self.source, as_version=nbformat.NO_CONVERT)
+        nb = nbformat.reads(self.source, as_version=NBFORMAT_VERSION)
 
         self.remove_preamble_cell(nb)
         self.insert_preamble_cell(preamble, nb)
 
-        fd.write(nbformat.writes(nb).encode())
+        fd.write(nbformat.writes(nb, version=NBFORMAT_VERSION).encode())
 
     def execute_script(self, fname, edit=None):
         import nbformat
@@ -121,7 +123,7 @@ class JupyterNotebook(ScriptBase):
                     shutil.copyfile(fname, fname_out)
 
                 logger.info("Saving modified notebook.")
-                nb = nbformat.read(fname, as_version=4)
+                nb = nbformat.read(fname, as_version=NBFORMAT_VERSION)
 
                 self.remove_preamble_cell(nb)
 
@@ -132,14 +134,13 @@ class JupyterNotebook(ScriptBase):
                     if "execution_count" in cell:
                         cell["execution_count"] = None
 
-                nbformat.write(nb, self.local_path)
+                nbformat.write(nb, self.local_path, version=NBFORMAT_VERSION)
 
     def insert_preamble_cell(self, preamble, notebook):
         import nbformat
 
         preamble_cell = nbformat.v4.new_code_cell(preamble)
         preamble_cell["metadata"]["tags"] = ["snakemake-job-properties"]
-        preamble_cell.pop("id", None)  # remove id if present, it causes issues in some jupyter versions
         notebook["cells"].insert(0, preamble_cell)
 
     def remove_preamble_cell(self, notebook):


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized notebook read/write to a single, consistent nbformat version to reduce format mismatch issues and improve interoperability.
  * Added a stable, public notebook format version reference for consistent I/O behavior.
  * Improved compatibility with various Jupyter versions by omitting cell ID metadata when inserting the preamble cell, reducing related errors or warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->