### PR TITLE
fix: Raise WorkflowError on empty file path in _IOFile.check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_group: [1]
+        test_group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         # see pyprojec.toml: [tool.pixi.feature.test] for available test types
-        os: [ubuntu-latest] #  , macos-13 not supported yet
-        env: ["py313"]
+        os: [ubuntu-latest, windows-2022, macos-latest] #  , macos-13 not supported yet
+        env: ["py311", "py312", "py313"]
         exclude:
           - os: windows-2022
             env: "py312"
@@ -108,8 +108,10 @@ jobs:
       - name: Run Tests for Linux (os= 'Linux')
         if: runner.os == 'Linux'
         run: |
-          pixi run --environment ${{matrix.env}} \
-            pytest tests/tests_using_conda.py -k test_issue_3192 -vv \
+          pixi run --environment ${{matrix.env}} test-all \
+            --splits 10 \
+            --group ${{ matrix.test_group }} \
+            --splitting-algorithm=least_duration \
             --showlocals \
             --show-capture=all
 

--- a/src/snakemake/deployment/conda.py
+++ b/src/snakemake/deployment/conda.py
@@ -1017,13 +1017,6 @@ class CondaEnvSpecType(Enum):
         elif isinstance(spec, Path):
             spec = str(spec)
 
-        if not is_local_file(spec):
-            assert False, f"{is_local_file(spec)=}, {os.path.isdir(spec)=}"
-        st = os.stat(spec)
-        import stat
-
-        assert Path(spec).is_dir()
-        assert stat.S_ISDIR(st.st_mode), st
         if spec.endswith(".yaml") or spec.endswith(".yml"):
             return cls.FILE
         elif is_local_file(spec) and os.path.isdir(spec):

--- a/tests/tests_using_conda.py
+++ b/tests/tests_using_conda.py
@@ -325,14 +325,7 @@ def test_conda_run():
 def test_issue_3192():
     assert (
         sp.run(
-            "conda create -n test_issue3192 python -y",
-            shell=True,
-        ).returncode
-        == 0
-    )
-    assert (
-        sp.run(
-            "ls $CONDA_PREFIX/envs/test_issue3192",
+            "conda create -c conda-forge -n test_issue3192 python",
             shell=True,
         ).returncode
         == 0


### PR DESCRIPTION
fix #341

Now the file with empty string will never pass the check.
Or should this be a warning instead of a WorkflowError?

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early, clear error when an empty file path is provided, preventing downstream confusion.

* **Tests**
  * Updated a conda-related test to use the conda-forge channel and assert successful execution.

* **Chores**
  * Removed unused imports to reduce overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->