### PR TITLE
fix: show failed logs in generated unit tests

### DIFF
--- a/src/snakemake/unit_tests/templates/ruletest.py.jinja2
+++ b/src/snakemake/unit_tests/templates/ruletest.py.jinja2
@@ -42,6 +42,7 @@ def test_{{ ruletest.name }}(conda_prefix):
                 {% endif %}
                 "-f",
                 "--notemp",
+                "--show-failed-logs",
                 "-j1",
                 "--target-files-omit-workdir-adjustment",
                 {% if configfiles %}


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled automatic display of failed logs in Snakemake rule tests by adding the --show-failed-logs flag to the test invocation.
  * Improves visibility into failure causes during test runs without altering existing test behavior or configuration.
  * No changes to test logic; only command-line execution updated for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->