### PR TITLE
fix(config): restore $ref resolution for schemas

### DIFF
--- a/src/snakemake/utils.py
+++ b/src/snakemake/utils.py
@@ -50,6 +50,7 @@ def validate(data, schema, set_default=True):
     import jsonschema
     from jsonschema import Draft202012Validator, validators
     from referencing import Registry, Resource
+    from urllib.parse import urlparse
 
     schemafile = infer_source_file(schema)
 
@@ -65,8 +66,40 @@ def validate(data, schema, set_default=True):
 
     schema = _load_configfile(source, filetype="Schema")
 
+    # Inject $id to enforce local reference resolution.
+    # Ensures all relative $ref's are resolved relative to this local file,
+    # even if it defines an explicit $id pointing to a remote location.
+    # This is required because the retrieve_uri function (see below) does not
+    # handle remote files.
+    # This allows to mostly restores pre-9.6.0 behavior fixing the regression
+    # caused by https://github.com/snakemake/snakemake/pull/3420 and reported
+    # in https://github.com/snakemake/snakemake/issues/3648.
+    # Note that the old (RefResolver based) implementation did handle remote
+    # URI fetching and could therefore respect remote URIs defined as ID
+    # withing the config file schema.
+    # To fully restore that behaviour, retrieve_uri would have to be expanded
+    # to fetch remote resources and this injection would have to be condition
+    # on the schema not defining an ID.
+    # However, in the context of config file validation, resolving a reference
+    # defined in a local schema file through a remote request seems to solve no
+    # purpose: Either the schemas are identical, in which relying on the local,
+    # known-to-exist version is more efficient, or they differ for some reason
+    # in which case not using the ref text from the local schema file might
+    # cause very surprising and hard to track down behaviour.
+    # Therefore, the new (resolving based) implementation purposefully breaks
+    # backwards-compatibility with the former (RefResolver based) one.
+    # This is also made explicit through the
+    # test_config_ref_relative_with_remote_id test added to test_schema.py.
+    schema["$id"] = "file://" + os.path.abspath(source)
+
     def retrieve_uri(uri):
-        return Resource.from_contents(contents=_load_configfile(uri, filetype="Schema"))
+        # Note:
+        # Relative $ref's are resolved against the (referencing) schema's $id
+        # by the referencing library before calling retrieve.
+        # Above, this was set to the local file's (absolute) file:// URI.
+        # Since _load_configfile expects a file handle/path, and not a URI,
+        # it must be parsed to strip off the (URI) schema.
+        return Resource.from_contents(contents=_load_configfile(urlparse(uri).path, filetype="Schema"))
 
     resource = Resource.from_contents(contents=schema)
     registry = Registry(retrieve=retrieve_uri).with_resource(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from snakemake.utils import validate
+from snakemake.exceptions import WorkflowError
 import pandas as pd
 
 CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
@@ -55,6 +56,106 @@ properties:
 required:
   - sample
   - condition
+"""
+
+RELATIVE_CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  bar:
+    $ref: "bar.schema.yaml"
+"""
+
+NESTED_BAR_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  baz:
+    $ref: "baz.schema.yaml"
+required: ["baz"]
+"""
+
+NESTED_BAZ_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  qux:
+    type: integer
+    default: 42
+required: ["qux"]
+"""
+
+REMOTE_ID_CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+$id: "https://example.com/config.schema.yaml"
+type: object
+properties:
+  bar:
+    $ref: "bar.schema.yaml"
+"""
+
+EXTERNAL_BAR_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  foo:
+    type: string
+required: ["foo"]
+"""
+
+FRAGMENT_BAR_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+definitions:
+  frag_obj:
+    type: object
+    properties:
+      baz:
+        type: string
+    required: ["baz"]
+"""
+
+FRAGMENT_CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  bar:
+    $ref: "bar.schema.yaml#/definitions/frag_obj"
+required: ["bar"]
+"""
+
+ALLOF_CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+type: object
+properties:
+  foo:
+    allOf:
+      - type: object
+        properties:
+          bar:
+            type: integer
+            default: 42
+          required: ['bar']
+      - type: object
+        properties:
+          foo:
+            type: string
+            default: "foo"
+        required: ["foo"]
+"""
+
+DEFS_CONFIG_SCHEMA = """$schema: "https://json-schema.org/draft/2020-12/schema#"
+$defs:
+  bar:
+    type: object
+    properties:
+      qux:
+        type: string
+        default: "qux"
+  baz:
+    type: object
+    properties:
+      qux:
+        type: integer
+        default: 42
+    required: ["qux"]
+type: object
+properties:
+  foo:
+    anyOf:
+      - $ref: "#/$defs/bar"
+      - $ref: "#/$defs/baz"
 """
 
 
@@ -116,6 +217,69 @@ def config_schema_ref(schemadir, bar_schema, json_bar_schema):
     return p
 
 
+@pytest.fixture
+def config_schema_relative(schemadir):
+    p = schemadir.join("config.relative.schema.yaml")
+    p.write(RELATIVE_CONFIG_SCHEMA)
+    bar = schemadir.join("bar.schema.yaml")
+    bar.write(EXTERNAL_BAR_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_relative_nested(schemadir):
+    p = schemadir.join("config.relative.nested.schema.yaml")
+    p.write(RELATIVE_CONFIG_SCHEMA)
+    bar = schemadir.join("bar.schema.yaml")
+    bar.write(NESTED_BAR_SCHEMA)
+    baz = schemadir.join("baz.schema.yaml")
+    baz.write(NESTED_BAZ_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_relative_ref_with_remote_id(schemadir):
+    p = schemadir.join("config.relative_ref.remote_id.schema.yaml")
+    p.write(REMOTE_ID_CONFIG_SCHEMA)
+    bar = schemadir.join("bar.schema.yaml")
+    bar.write(EXTERNAL_BAR_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_relative_ref_with_fragment(schemadir):
+    p = schemadir.join("config.relative_ref.fragment.schema.yaml")
+    p.write(FRAGMENT_CONFIG_SCHEMA)
+    bar = schemadir.join("bar.schema.yaml")
+    bar.write(FRAGMENT_BAR_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_relative_nested_with_default(schemadir):
+    p = schemadir.join("config.relative.nested.default.schema.yaml")
+    p.write(RELATIVE_CONFIG_SCHEMA)
+    bar = schemadir.join("bar.schema.yaml")
+    bar.write(NESTED_BAR_SCHEMA)
+    baz = schemadir.join("baz.schema.yaml")
+    baz.write(NESTED_BAZ_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_allof_default(schemadir):
+    p = schemadir.join("config.allof.default.schema.yaml")
+    p.write(ALLOF_CONFIG_SCHEMA)
+    return p
+
+
+@pytest.fixture
+def config_schema_defs(schemadir):
+    p = schemadir.join("config.defs.schema.yaml")
+    p.write(DEFS_CONFIG_SCHEMA)
+    return p
+
+
 def test_config(config_schema):
     config = {}
     validate(config, str(config_schema), False)
@@ -133,7 +297,6 @@ def test_config_ref(config_schema_ref):
     # Make sure regular validator works
     config["param"]["bar"] = 1
     config["param"]["jsonbar"] = 2
-    from snakemake.exceptions import WorkflowError
 
     with pytest.raises(WorkflowError):
         validate(config, str(config_schema_ref), False)
@@ -146,3 +309,48 @@ def test_dataframe(df_schema):
     validate(df, str(df_schema))
     assert sorted(df.columns) == sorted(["sample", "condition", "case", "date"])
     assert df.case.loc[0]
+
+
+def test_config_ref_relative(config_schema_relative):
+    config = {"bar": {}}
+    with pytest.raises(WorkflowError):
+        validate(config, str(config_schema_relative), set_default=False)
+    config = {"bar": {"foo": "baz"}}
+    validate(config, str(config_schema_relative), set_default=False)
+
+
+def test_config_ref_relative_nested(config_schema_relative_nested):
+    config = {"bar": {"baz": {}}}
+    with pytest.raises(WorkflowError):
+        validate(config, str(config_schema_relative_nested), set_default=False)
+    config = {"bar": {"baz": {"qux": 19}}}
+    validate(config, str(config_schema_relative_nested), set_default=False)
+
+
+def test_config_ref_relative_with_remote_id(config_schema_relative_ref_with_remote_id):
+    config = {"bar": {}}
+    with pytest.raises(WorkflowError):
+        validate(config, str(config_schema_relative_ref_with_remote_id), set_default=False)
+    config = {"bar": {"foo": "baz"}}
+    validate(config, str(config_schema_relative_ref_with_remote_id), set_default=False)
+
+
+def test_config_ref_relative_with_fragment(config_schema_relative_ref_with_fragment):
+    config = {"bar": None}
+    with pytest.raises(WorkflowError):
+        validate(config, str(config_schema_relative_ref_with_fragment), set_default=False)
+    config = {"bar": {"baz": "value"}}
+    validate(config, str(config_schema_relative_ref_with_fragment), set_default=False)
+
+
+def test_config_allof_default(config_schema_allof_default):
+    config = {"foo": {}}
+    validate(config, str(config_schema_allof_default), set_default=True)
+    assert config["foo"]["bar"] == 42
+    assert config["foo"]["foo"] == "foo"
+
+
+def test_config_anyof_via_defs_default(config_schema_defs):
+    config = {"foo": {}}
+    validate(config, str(config_schema_defs), set_default=True)
+    assert config["foo"]["qux"] == "qux"


### PR DESCRIPTION
This PR fixes a regression introduced in Snakemake 9.6.0 where relative `$ref` references in local config schemas were not correctly resolved during validation.

This regression was introduced when refactoring the config validation from the (deprecated) `RefResolver` to the (current) `resolving` API in https://github.com/snakemake/snakemake/pull/3420.

The two required changes were:

1. Injection of an absolute `file://` `$id` in schemas to enforce proper local reference resolution.
2. A follow-up update to retrieve_uri to correctly load subschemas (as it now receives a `file://` URI).

In addition, to prevent future regressions, this PR adds tests for (nested) `$ref`s, `$ref` with remote `$id` (see below), fragment references, `allOf`/`anyOf` defaults, and `$def`s.

This commit restores pre-9.6.0 behavior and prevents ValidationError when nested schemas are referenced.

Caveat: This PR intentionally does *not* restore one specific aspect of the old (`RefResolver` based) implementation:
If a schema file contains an explicit `$id` pointing to a remote copy of the schema, the old implementation would fetch any references (in- or external) from that remote URI.
Instead, the implementation introduced by this PR always resolves references based on the local schema file.
This behaviour is demonstrated (and validated) with the remote `$id` test mentioned above.

The following checks have been performed to ensure the correctness of this patch:

1. All tests (but the remote `$id` one, see above) where successfully run at commit `960f6a89eaa31da6014e810dfcf08f635ac03a6e` (last ancestor of current `main` that still uses the old `RefResolver` implementation), proving that they cover pre-9.6.0 behaviour.
2. Re-running the same tests at commit `cf724272eefcd9b30fb625d2e16380727bef9c3e` (direct child of the above, introducing the changes from PR #3420), the three (nested) `$ref`s test fail, verifying this commit/PR caused the regression and the tests added in this commit catch that regression.
3. The same tests still fail at commit `f1517e83a6a4a193a1148543fc06177eeb11ecb5` (current `main`), demonstrating that the regression has not been fixed yet.
4. All tests pass after applying the changes from this PR, validating it fixes the regression.

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

#### Notes:

This is my first contribution to the project. Thus, I am not familiar with the codebase.
It is also my first time dealing with `jsonschema` and the both, its (deprecated) `RefResolver` API (to analyse the old implementation and design tests accordingly), and its current `resolving` API (to fix the regression).
Please let me know if you have any adjustments you want/need me to do.

Also, I started from a standalone POC script to make sure I understand the API, defined tests and then worked on the actual fix off that.
Initially, I overestimated the power of pre-9.6.0's implementation of the `validate` function and designed a test that tested defaults propagation across (nested) `$ref`s. Thus, my intermediate solution was much more complex (and powerful) than this simple (minimal) fix.
I do have a local branch with that work in case anybody is interested in implementing more powerful defaults value handling during config validation. Please reach out if there is interest.

---
fixes https://github.com/snakemake/snakemake/issues/3648