### PR TITLE
fix: fix iofile formatting to always display the storage query if it is set, also in case of missing input exceptions

### DIFF
--- a/src/snakemake/io/fmt.py
+++ b/src/snakemake/io/fmt.py
@@ -14,7 +14,7 @@ def fmt_iofile(f, as_input: bool = False, as_output: bool = False):
         elif as_output:
             storage_phrase = "send to storage"
         else:
-            storage_phrase = ""
+            storage_phrase = "in storage"
         f_str = f.storage_object.print_query
     else:
         f_str = f
@@ -46,4 +46,5 @@ def fmt_iofile(f, as_input: bool = False, as_output: bool = False):
             return TBDString()
         else:
             return annotate(f_str)
-    return f
+    else:
+        return annotate(f_str)


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Formatted file references now clearly indicate when a file is in storage by appending “in storage” where applicable.
* **Bug Fixes**
  * Standardized the return of formatted file paths: in non-input/output contexts, formatting now consistently returns the annotated string representation, ensuring predictable display and messaging across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->