### PR TITLE
fix: fix --consider-ancient for input functions (was not applied in those cases)

### DIFF
--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -578,6 +578,9 @@ class Rule(RuleInterface):
 
             item = default_flags.apply(item)
 
+            if mark_ancient:
+                item = flag(item, "ancient")
+
             inoutput.append(item)
             if name:
                 inoutput._add_name(name)


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the “ancient” flag is consistently applied to inputs and outputs after default flags are set.
  * Correctly propagates the “ancient” flag for both string and callable items, improving reliable rule evaluation and preventing unintended re-runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->