### PR TITLE
fix: only modify wrapper URI if imported rule actually uses a wrapper

### DIFF
--- a/src/snakemake/ruleinfo.py
+++ b/src/snakemake/ruleinfo.py
@@ -106,7 +106,8 @@ class RuleInfo:
         self.path_modifier = path_modifier
 
         # modify wrapper if requested
-        self.wrapper = modifier.modify_wrapper_uri(self.wrapper)
+        if self.wrapper is not None:
+            self.wrapper = modifier.modify_wrapper_uri(self.wrapper)
 
         if modifier.parent_modifier is not None:
             self.apply_modifier(modifier.parent_modifier, rulename=rulename)


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where rules without a wrapper could error during modifier application; the wrapper is now only modified when present.
  * No behavioral changes for rules that already use a wrapper.
  * Reduces unexpected failures during pipeline execution and improves error resilience, especially in scenarios with optional wrapper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->