### PR TITLE
fix: revert breaking change in 9.11.9 disallowing empty input files even when unused

### DIFF
--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -467,10 +467,13 @@ class _IOFile(str, AnnotatedStringInterface):
         if callable(self._file):
             return
         if self._file == "":
-            raise WorkflowError(
-                "Empty file path encountered. Snakemake cannot understand this. "
-                "If you want to indicate 'no file', please use an empty list ([]) instead of an empty string ('').",
-                rule=self.rule,
+            if self.rule is not None:
+                spec = f"rule {self.rule.name}, line {self.rule.lineno}, {self.rule.snakefile}: "
+            else:
+                spec = ""
+            logger.warning(
+                f"{spec}Empty file path encountered. Snakemake cannot understand this. "
+                "If you want to indicate 'no file', please use an empty list ([]) instead of an empty string ('')."
             )
         hint = (
             "It can also lead to inconsistent results of the file-matching "


### PR DESCRIPTION
Reverts a breaking change introduced in version 9.11.9 where all input files were required to be non-empty, even if they were not actually used by a rule.

#3801 suggested that it would be acceptable to raise an error for this in the future, as long as there is a deprecation warning period or it comes with a major version bump, and a warning sounds good for now.

Thanks @corneliusroemer for pointing this out, and apologies for my earlier overzealous modification.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty file paths by providing informative guidance instead of raising an error. The system now logs a warning message directing users to use an empty list ([]) to indicate no files, making workflows more forgiving and easier to debug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->