### PR TITLE
fix: print secs as numeric in jsonl benchmark format

### DIFF
--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -173,7 +173,7 @@ class BenchmarkRecord:
                 "Benchmark: unable to collect cpu and memory benchmark statistics"
             )
         record = [
-            f"{self.running_time:.4f}",
+            round(self.running_time, 4),
             self.timedelta_to_str(datetime.timedelta(seconds=self.running_time)),
             self.max_rss if self.data_collected else "NA",
             self.max_vms if self.data_collected else "NA",


### PR DESCRIPTION
<!--Add a description of your PR here-->

Currently, benchmarks in `jsonl` format have the `s` field as a string:
```
{
  "cpu_time": 0.0,
  "cpu_usage": 0.0,
  "h:m:s": "0:00:10",
  "input_size_mb": {
    "a.in": 5.834963798522949
  },
  "io_in": 0.0,
  "io_out": 0.0,
  "jobid": 0,
  "max_pss": 0.6533203125,
  "max_rss": 3.7109375,
  "max_uss": 0.46875,
  "max_vms": 19.86328125,
  "mean_load": 0.0,
  "params": {},
  "resources": {
    "_cores": 1,
    "_nodes": 1,
    "tmpdir": "/tmp"
  },
  "rule_name": "all",
  "s": "10.0083",
  "threads": 1,
  "wildcards": {}
}
```

This PR fixes this by keeping it as a float.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected benchmark export formats: Running time values in TSV output now display with updated precision, and JSON exports render running times as numeric values for proper data type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->