### PR TITLE
fix: shorten report ids (thus dir names) in order to avoid issues with path length on windows

### DIFF
--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -467,7 +467,9 @@ def shorten_ids(results: Mapping[Category, Mapping[Category, List[FileRecord]]])
             for rec in file_records:
                 rec.id = rec.id[:id_len]
             return
-    logger.warning("Obtained result IDs are non-unique. Certain results will be not accessible.")
+    logger.warning(
+        "Obtained result IDs are non-unique. Certain results will be not accessible."
+    )
 
 
 async def expand_labels(labels, wildcards, job):


### PR DESCRIPTION
### Description

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports now automatically shorten file identifiers to more readable lengths while preserving uniqueness across all records, improving clarity in generated reports and UI lists.
  * Shortened IDs are applied early in processing and again just before final report rendering, ensuring consistent, concise identifiers throughout the reporting flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->