### PR TITLE
fix: fix backup for output marked by `update`

### DIFF
--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -839,7 +839,7 @@ class Job(
                 os.makedirs(self.resources.tmpdir, exist_ok=True)
 
             for f in self.output:
-                if is_flagged(f, "update"):
+                if is_flagged(f, "update") and await f.exists():
                     self.rule.workflow.persistence.backup_output(Path(f))
                 f.prepare()
 

--- a/src/snakemake/persistence.py
+++ b/src/snakemake/persistence.py
@@ -311,8 +311,8 @@ class Persistence(PersistenceExecutorInterface):
     def restore_output(self, path: Path) -> None:
         backup_path = self._get_backup_path(path)
         if not backup_path.exists():
-            raise WorkflowError(f"Cannot restore {path}: no backup found.")
-        if backup_path.is_dir():
+            logger.warning(f"Cannot restore {path}: no backup found.")
+        elif backup_path.is_dir():
             if path.exists():
                 shutil.rmtree(path)
             shutil.copytree(backup_path, path)


### PR DESCRIPTION
When an output file is marked to be updated snakemake fails if that file does not exist. That might happen when a file needs to be created by the rule before being updated in later workflow executions. This is fixed by validating if the output exists before creating a backup. In addition the behavior of restoring a backup after an error has been thrown needs to be adjusted. Previously an error was raised when no backup file exists for a file marked with `update`. As the newly introduced scenario might not have created a backup a waring is thrown instead of an error.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced backup restoration to issue warnings instead of errors when backups are unavailable
  * Improved backup efficiency by only backing up files that exist
  * Refined directory backup handling to better preserve backup data after restoration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->