### PR TITLE
fix: Addressed race condition in workdir_handler.py

### DIFF
--- a/src/snakemake/common/workdir_handler.py
+++ b/src/snakemake/common/workdir_handler.py
@@ -16,7 +16,7 @@ class WorkdirHandler:
             self.olddir = Path.cwd()
             if not self.workdir.exists():
                 logger.info(f"Creating specified working directory {self.workdir}.")
-                self.workdir.mkdir(parents=True)
+                self.workdir.mkdir(parents=True, exist_ok=True)
             os.chdir(self.workdir)
 
     def change_back(self):


### PR DESCRIPTION
Race condition existed in workdir_handler.py when for some reason (such as testing suites that might run in parallel) snakemake is run in parallel, and change_to is called, an exception is called, though control-flow can continue as normal without any issues.

Here is a more thorough description of how the race condition can occur

For reference, take a look at mkdir from pathlib

```python
    def mkdir(self, mode=0o777, parents=False, exist_ok=False):
        """
        Create a new directory at this given path.
        """
        try:
            os.mkdir(self, mode)
        except FileNotFoundError:
            if not parents or self.parent == self:
                raise
            self.parent.mkdir(parents=True, exist_ok=True)
            self.mkdir(mode, parents=False, exist_ok=exist_ok)
        except OSError:
            # Cannot rely on checking for EEXIST, since the operating system
            # could give priority to other errors like EACCES or EROFS
            if not exist_ok or not self.is_dir():
                raise
```

Take two threads that are run on snakemake, and both try to cd into "/fake/address"

Thread 1 and 2:
checks if "/fake/address" (returns False)
calls self.workdir.mkdir(parents=True) (with exists_ok defaulting to false)
inside the try block: tries to mkdir  "/fake/address" which fails with FileNotFoundError because "/fake" does not exist
catches exception

Thread 1:
calls `self.parent.mkdir(parents=True, exist_ok=True)`
successfully creates "/fake"

Thread 2:
calls  `self.parent.mkdir(parents=True, exist_ok=True)`
"/fake" already exists, but that is not a problem
calls `self.mkdir(mode, parents=False, exist_ok=exist_ok)` to create "/fake/address"
succeeds

Thread 1:
calls `self.mkdir(mode, parents=False, exist_ok=exist_ok)` to create "/fake/address"
fails because "/fake/address" exists

Whereby there is no problem here that "/fake/address" exists. 

Not sure if I should write a test for this, I personally wouldn't even know how to begin testing this issue, but it seems to have already been solved by pathlib, so just adding this small param should fix this niche issue. 

This PR does not change intended behavior.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced working directory handling to gracefully manage scenarios where directories already exist, improving reliability during concurrent operations and preventing unnecessary errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->