### PR TITLE
docs: explain how to pass nested config via CLI

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -670,7 +670,9 @@ def get_argument_parser(profiles=None):
             "Set or overwrite values in the workflow config object. "
             "The workflow config object is accessible as variable config inside "
             "the workflow. Default values can be set by providing a YAML JSON file "
-            "(see `--configfile` and Documentation)."
+            "(see `--configfile` and Documentation). "
+            "Nested values must be defined in Python dict format, e.g., "
+            "`--config \"foo={'bar': 42}\"`."
         ),
     )
     group_exec.add_argument(


### PR DESCRIPTION
I struggled to pass in nested config (the first thing I tried was dot format, like foo.bar=42) until I found [this SO post](https://stackoverflow.com/questions/64271392/overwrite-nested-config-options-on-command-line).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x]  N/A The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced help text for the --config option with improved guidance on nested value formatting and practical usage examples to assist users in proper configuration definition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->