### PR TITLE
fix: yield proper error message in case a local git source file is not retrievable

### DIFF
--- a/src/snakemake/sourcecache.py
+++ b/src/snakemake/sourcecache.py
@@ -458,10 +458,10 @@ class SourceCache:
                     .encode()
                 )
             except git.GitCommandError as e:
-               raise WorkflowError(
-                   f"Failed to get local git source file {log_path}: {e}. "
-                   "Is the local git clone up to date?"
-               )
+                raise WorkflowError(
+                    f"Failed to get local git source file {log_path}: {e}. "
+                    "Is the local git clone up to date?"
+                )
 
         path_or_uri = source_file.get_path_or_uri(secret_free=False)
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when loading workflow files from Git — messages now indicate a consistent, user-facing path and suggest that a local clone may be outdated when relevant.
  * Clarified failure reporting for non-Git file access to provide better traceability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->