### PR TITLE
fix: create potentially missing .snakemake folder in case of very long command lines for spawned jobs

### DIFF
--- a/src/snakemake/shell.py
+++ b/src/snakemake/shell.py
@@ -243,6 +243,7 @@ class shell:
 
         tmpdir = None
         if len(cmd.replace("'", r"'\''")) + 2 > MAX_ARG_LEN:
+            os.makedirs(".snakemake", exist_ok=True)
             tmpdir = tempfile.mkdtemp(dir=".snakemake", prefix="shell_tmp.")
             script = os.path.join(os.path.abspath(tmpdir), "script.sh")
             with open(script, "w") as script_fd:

--- a/tests/test_shadow/Snakefile
+++ b/tests/test_shadow/Snakefile
@@ -141,6 +141,14 @@ rule minimal_symbolic:
         ln -s minimal_real.out minimal_symbolic.out
         """
 
+# Test huge command line in shadow: "minimal"
+rule minimal_huge_cmd:
+    output: "outdir/minimal_huge.out"
+    params: huge_cmd="#" * 16 * 4096
+    shadow: "minimal"
+    shell:
+        "touch {output}; {params.huge_cmd}"
+
 # Tests absolute input/output
 rule minimal_absolute:
     input:
@@ -157,6 +165,7 @@ rule minimal_ok:
     input:  "simple_minimal.out",
             "outdir/minimal.out",
             "outdir/minimal_symbolic.out",
+            "outdir/minimal_huge.out",
             os.path.join(os.getcwd(),"outdir/minimal_absolute.out")
     output: "minimal_ok.out"
     shell:


### PR DESCRIPTION
<!--Add a description of your PR here-->
will fix #3891 by force to create the .snakemake folder for the script

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness when executing shell commands with very long argument strings by ensuring proper directory initialization.

* **Tests**
  * Added test coverage for handling extremely long command-line arguments in shadow mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->