### PR TITLE
docs: Use snakemake logo as favicon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ html_permalinks_icon = Icons.permalinks_icon
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-# html_favicon = None
+html_favicon = "logo-snake.svg"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
<!--Add a description of your PR here-->

Tiny docs PR that sets the snakemake logo as the favicon in `docs/conf.py`. This makes it easier to spot snakemake documentation tabs with multiple tabs open.

It seems to work fine with a local build, but I cannot test an actual build on RTD (or at least I don't know how with a branch on a fork).

Thank you!

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
*  [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation favicon to display a custom snake logo.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->