### PR TITLE
revert: Config validation skip for remote jobs

### DIFF
--- a/src/snakemake/utils.py
+++ b/src/snakemake/utils.py
@@ -40,10 +40,8 @@ def validate(data, schema, set_default=True):
     frame = inspect.currentframe().f_back
     workflow = frame.f_globals.get("workflow")
 
-    if workflow and (workflow.modifier.skip_validation or workflow.remote_exec):
-        # skip if a corresponding modifier has been defined or if this is a
-        # remote job. In the latter case, the schema has been already  validated by the
-        # main process.
+    if workflow and workflow.modifier.skip_validation:
+        # skip if a corresponding modifier has been defined
         return
 
     from snakemake.sourcecache import LocalSourceFile, infer_source_file


### PR DESCRIPTION
This reverts commit 91296543360e276a2317c8831b6635c29839afd2.

Config validation can't be skipped entirely because workflows may rely on default setting during validation.

See <https://github.com/snakemake/snakemake/issues/3614> and <https://github.com/snakemake/snakemake/issues/3923>.

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case. *I'd love to add a test case, but don't know how to test remote execution.*
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake). *Not necessary as default setting during validation is already documented [here](https://snakemake.readthedocs.io/en/v9.14.6/snakefiles/configuration.html#validation).*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote execution validation improved. Previously, remote job execution would bypass validation checks; this has been corrected. Validation is now consistently applied to all workflows regardless of execution type, enhancing reliability and error detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->