### PR TITLE
fix: catch OSError raised during benchmarking (e.g. when too many proc files are opened in highly parallel environments

### DIFF
--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -388,7 +388,8 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
                 io_in = None
                 io_out = None
             data_collected = True
-        except psutil.Error as e:
+        except (OSError, psutil.Error) as e:
+            # Also collect OSError, which can be raised when too many proc files are opened.
             self.bench_record.errors.append(str(e))
             return
 


### PR DESCRIPTION

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark recording reliability by enhancing error handling to gracefully manage system-level errors that may occur during process metric collection. Benchmark operations will now continue smoothly even when edge cases are encountered, ensuring consistent data collection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->