### PR TITLE
fix: allow relative imports from modules

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1644,6 +1644,11 @@ class Workflow(WorkflowExecutorInterface):
 
         snakefile = infer_source_file(snakefile, basedir)
 
+        if basedir is None:
+            path = snakefile.get_basedir().get_path_or_uri(secret_free=False)
+            self.modifier.module_type.__path__ = [path]
+            self.modifier.module_type.__spec__.submodule_search_locations = [path]
+
         if not self.modifier.is_module and snakefile in self.included:
             logger.info(f"Multiple includes of {snakefile} ignored")
             return
@@ -1665,6 +1670,7 @@ class Workflow(WorkflowExecutorInterface):
             print(code)
             return
 
+        # TODO remove at next major release to ban absolute local imports in Snakefile
         snakefile_path_or_uri = snakefile.get_basedir().get_path_or_uri(
             secret_free=False
         )

--- a/tests/test_modules_local_import/Snakefile
+++ b/tests/test_modules_local_import/Snakefile
@@ -1,0 +1,20 @@
+shell.executable("bash")
+
+from . import bar
+
+module test:
+    snakefile:
+        "module-test/Snakefile"
+
+use rule inner from test
+
+rule outer:
+    output:
+        "outer.txt"
+    shell:
+        f"echo bar={bar.data} > {{output}}"
+
+rule all:
+    input:
+        "inner.txt",
+        "outer.txt"

--- a/tests/test_modules_local_import/bar.py
+++ b/tests/test_modules_local_import/bar.py
@@ -1,0 +1,1 @@
+data = "outer-bar"

--- a/tests/test_modules_local_import/expected-results/inner.txt
+++ b/tests/test_modules_local_import/expected-results/inner.txt
@@ -1,0 +1,1 @@
+bar=inner-bar foo=inner-foo

--- a/tests/test_modules_local_import/expected-results/outer.txt
+++ b/tests/test_modules_local_import/expected-results/outer.txt
@@ -1,0 +1,1 @@
+bar=outer-bar

--- a/tests/test_modules_local_import/module-test/Snakefile
+++ b/tests/test_modules_local_import/module-test/Snakefile
@@ -1,0 +1,10 @@
+shell.executable("bash")
+
+from . import foo
+from . import bar
+
+rule inner:
+    output:
+        "inner.txt",
+    shell:
+        f"echo bar={bar.data} foo={foo.data} > {{output}}"

--- a/tests/test_modules_local_import/module-test/bar.py
+++ b/tests/test_modules_local_import/module-test/bar.py
@@ -1,0 +1,1 @@
+data = "inner-bar"

--- a/tests/test_modules_local_import/module-test/foo.py
+++ b/tests/test_modules_local_import/module-test/foo.py
@@ -1,0 +1,1 @@
+data = "inner-foo"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1706,6 +1706,10 @@ def test_modules_prefix_local():
     )
 
 
+def test_modules_local_import():
+    run(dpath("test_modules_local_import"), targets=["all"])
+
+
 @connected
 @skip_on_windows  # filenames too long on windows
 def test_module_with_script():


### PR DESCRIPTION
Fixes #3951 .

This PR turns each of the different snakemake modules into packages, so that relative imports in the Snakefile or *.smk files are always resolved relative to the snakefile of the current module.

This means that the name-clashes reported in #3951 , can be resolved using relative imports, `from . import foo`, instead, which resolve correctly in each module.

### Notes

1. The imports are relative to the snakefile of the current module, ie.
    ```
    ├── rules
    │   └── a.smk
    ├── scripts
    │   └── _helpers.py
    ├── Snakefile
    ```

    One should use
    ```python
    from .scripts._helpers import y
    ```
    from within `a.smk` as from within `Snakefile`.

2. I left the sys.path.insert statement in `workflow.include(...)` intact so that this change is backwards-compatible; but i added a note to remove it with the next major release; this will then make absolute imports not resolve locally anymore.
 
3. I am currently only setting the paths correctly for Snakefile's which are identified by `LocalSourceFile` and `str`, i guess some of the other `SourceFile` variants should also have local paths, but i did not know which. Help appreciated.

4. I think the `WorkflowModifier` needs a refactor to disentangle path modifications from module encapsulation; i did not dare do that at the same time.
### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Snakemake modules and included files now support importing local Python modules from their directory, enabling better code organization and modularity in workflows.

* **Tests**
  * Added test coverage for local module imports within Snakemake workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->