### PR TITLE
fix: local_storage_prefix path in container

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -2113,7 +2113,7 @@ class Workflow(WorkflowExecutorInterface):
     def runtime_paths(self) -> List[Path]:
         assert self.storage_settings is not None
         return [
-            self.storage_settings.local_storage_prefix,
+            self.storage_settings.local_storage_prefix.absolute(),
             self.sourcecache.cache_path,
         ]
 


### PR DESCRIPTION
Fixes #3958 .

Following #3840 , rules would still fail when using container deployment and storage plugins because the `local_storage_prefix` path used by storage plugins is relative by default https://github.com/snakemake/snakemake/blob/main/src/snakemake/settings/types.py#L235 which is not allowed for container binding, usage of absolute paths is required at runtime.

This PR fixes `local_storage_prefix` as an absolute path at runtime.

I have not added a test case, let me know if I should add one.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime storage path resolution to use absolute paths, improving file system reliability and preventing potential path-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->