### PR TITLE
docs: correct json-schema to http url to mirror referencing (0.37.0)

### DIFF
--- a/docs/snakefiles/configuration.rst
+++ b/docs/snakefiles/configuration.rst
@@ -145,7 +145,7 @@ the schema for validating the samples data frame looks like this:
 
 .. code-block:: yaml
 
-  $schema: "https://json-schema.org/draft-06/schema#"
+  $schema: "http://json-schema.org/draft-06/schema#"
   description: an entry in the sample sheet
   properties:
     sample:


### PR DESCRIPTION
<!--Add a description of your PR here-->

This PR closes #3963, which details an inconsistency between the documentation of snakemake and the [referencing package](https://github.com/python-jsonschema/referencing/blob/v0.37.0/referencing/jsonschema.py#L558-L592).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

#### Note

This first box in [QC](#qc) doesn't really apply to this change. I can tick it if it is required. I have checked that the pages continue to render properly locally (with `sphinx=8.2.3=pyhd8ed1ab_0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JSON Schema reference URL in configuration documentation to use the correct protocol version for validation schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->