### PR TITLE
fix: reporting remote nodes number

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1381,10 +1381,16 @@ class Workflow(WorkflowExecutorInterface):
                     if shell_exec is not None:
                         logger.info(f"Using shell: {shell_exec}")
                     if not self.local_exec:
-                        logger.info(
-                            f"Provided remote nodes: {self.nodes}",
-                            extra=dict(event=LogEvent.RESOURCES_INFO, nodes=self.nodes),
-                        )
+                        if self.nodes == sys.maxsize:
+                            logger.info(
+                                "The number of remote nodes is set to be unlimited.",
+                                extra=dict(event=LogEvent.RESOURCES_INFO),
+                            )
+                        else:
+                            logger.info(
+                                f"Provided remote nodes: {self.nodes}",
+                                extra=dict(event=LogEvent.RESOURCES_INFO, nodes=self.nodes),
+                            )
                     else:
                         if self._cores is not None:
                             info = (

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1389,7 +1389,9 @@ class Workflow(WorkflowExecutorInterface):
                         else:
                             logger.info(
                                 f"Provided remote nodes: {self.nodes}",
-                                extra=dict(event=LogEvent.RESOURCES_INFO, nodes=self.nodes),
+                                extra=dict(
+                                    event=LogEvent.RESOURCES_INFO, nodes=self.nodes
+                                ),
                             )
                     else:
                         if self._cores is not None:

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1381,18 +1381,15 @@ class Workflow(WorkflowExecutorInterface):
                     if shell_exec is not None:
                         logger.info(f"Using shell: {shell_exec}")
                     if not self.local_exec:
-                        if self.nodes == sys.maxsize:
-                            logger.info(
-                                "The number of remote nodes is set to be unlimited.",
-                                extra=dict(event=LogEvent.RESOURCES_INFO),
-                            )
-                        else:
-                            logger.info(
-                                f"Provided remote nodes: {self.nodes}",
-                                extra=dict(
-                                    event=LogEvent.RESOURCES_INFO, nodes=self.nodes
-                                ),
-                            )
+                        nodes_str = (
+                            "unlimited"
+                            if self.nodes == sys.maxsize
+                            else str(self.nodes)
+                        )
+                        logger.info(
+                            f"Provided remote nodes: {nodes_str}",
+                            extra=dict(event=LogEvent.RESOURCES_INFO, nodes=self.nodes),
+                        )
                     else:
                         if self._cores is not None:
                             info = (


### PR DESCRIPTION
When passing `-j unlimited`, workflow.py reports `Provided remote nodes: 9223372036854775807` (this number happens to be my `sys.maxsize`. This is rather confusing. Hence, this PR which in this case just reports `The number of remote nodes is set to be unlimited.`. Hope that is fine. There are no additional tests or documentation setting necessary.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging clarity for remote execution by displaying "unlimited" when node allocation is unrestricted, and specific numeric values otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->