### PR TITLE
feat: normalize code before comparing for change detection

### DIFF
--- a/src/snakemake/persistence.py
+++ b/src/snakemake/persistence.py
@@ -3,6 +3,7 @@ __copyright__ = "Copyright 2022, Johannes Köster"
 __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
+import ast
 import asyncio
 from dataclasses import dataclass, field
 import hashlib
@@ -10,6 +11,7 @@ import os
 import shutil
 import json
 import stat
+import textwrap
 import tempfile
 import time
 from base64 import urlsafe_b64encode, b64encode
@@ -35,6 +37,28 @@ from snakemake.settings.types import DeploymentMethod
 
 UNREPRESENTABLE = object()
 RECORD_FORMAT_VERSION = 6
+
+
+def _normalize_python_code(source: str) -> str:
+    """Return a canonical AST string for Python source, ignoring comments/whitespace."""
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+        for node in ast.walk(tree):
+            if hasattr(node, "type_comment"):
+                node.type_comment = None
+        return ast.dump(tree, annotate_fields=True, include_attributes=False)
+    except SyntaxError:
+        return source
+
+
+def _normalize_shell_code(source: str) -> str:
+    """Return normalized shell source, ignoring comments and blank lines."""
+    lines = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            lines.append(stripped)
+    return "\n".join(lines)
 
 
 class Persistence(PersistenceExecutorInterface):
@@ -551,7 +575,13 @@ class Persistence(PersistenceExecutorInterface):
             # no reliable code stored
             return False
         recorded = self.code(file)
-        return recorded is not None and recorded != self._code(job.rule)
+        current = self._code(job.rule)
+        if recorded is None or current is None:
+            return recorded is not None
+        if job.rule.shellcmd is not None:
+            return _normalize_shell_code(recorded) != _normalize_shell_code(current)
+        else:
+            return _normalize_python_code(recorded) != _normalize_python_code(current)
 
     def _input_changed(self, job, file=None):
         assert file is not None

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,8 +1,12 @@
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from snakemake.persistence import Persistence
+from snakemake.persistence import (
+    Persistence,
+    _normalize_python_code,
+    _normalize_shell_code,
+)
 
 
 class TestCleanupContainers:
@@ -49,3 +53,141 @@ rule foo:
 
             assert required_img_path.exists()
             assert not unrequired_img_path.exists()
+
+
+class TestCodeChanged:
+    """Tests for Persistence._code_changed with mocked dependencies."""
+
+    def _make_persistence(self, recorded_code, fmt_version=6):
+        p = MagicMock()
+        p.record_format_version.return_value = fmt_version
+        p.code.return_value = recorded_code
+        p._code = lambda rule: Persistence._code(p, rule)
+        return p
+
+    def _make_job(self, shellcmd=None, run_func_src=None):
+        job = MagicMock()
+        job.rule.shellcmd = shellcmd
+        job.rule.run_func_src = run_func_src
+        return job
+
+    def test_shell_rule_cosmetic_change_not_detected(self):
+        recorded = "echo hello\n# old comment\n"
+        current = "echo hello\n# new comment\n"
+        p = self._make_persistence(recorded)
+        job = self._make_job(shellcmd=current)
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_shell_rule_real_change_detected(self):
+        recorded = "echo hello\n"
+        current = "echo goodbye\n"
+        p = self._make_persistence(recorded)
+        job = self._make_job(shellcmd=current)
+        assert Persistence._code_changed(p, job, file="out.txt") is True
+
+    def test_python_rule_cosmetic_change_not_detected(self):
+        recorded = "x = 1\n# old\n"
+        current = "x = 1\n# new\n"
+        p = self._make_persistence(recorded)
+        job = self._make_job(run_func_src=current)
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_python_rule_real_change_detected(self):
+        recorded = "x = 1\n"
+        current = "x = 2\n"
+        p = self._make_persistence(recorded)
+        job = self._make_job(run_func_src=current)
+        assert Persistence._code_changed(p, job, file="out.txt") is True
+
+    def test_old_format_version_returns_false(self):
+        p = self._make_persistence("anything", fmt_version=2)
+        job = self._make_job(shellcmd="echo hi")
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_no_format_version_returns_false(self):
+        p = self._make_persistence("anything", fmt_version=None)
+        job = self._make_job(shellcmd="echo hi")
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_no_recorded_code_returns_false(self):
+        p = self._make_persistence(recorded_code=None)
+        job = self._make_job(shellcmd="echo hi")
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_indented_python_rule_cosmetic_change_not_detected(self):
+        """run_func_src from real Snakefiles is indented."""
+        recorded = "        x = 1\n        # old\n"
+        current = "        x = 1\n        # new\n"
+        p = self._make_persistence(recorded)
+        job = self._make_job(run_func_src=current)
+        assert Persistence._code_changed(p, job, file="out.txt") is False
+
+    def test_recorded_exists_but_current_is_none(self):
+        """Script/notebook rule where _code returns None — recorded is stale."""
+        p = self._make_persistence("old code")
+        job = self._make_job(shellcmd=None, run_func_src=None)
+        assert Persistence._code_changed(p, job, file="out.txt") is True
+
+
+class TestNormalizePythonCode:
+    def test_comment_change_ignored(self):
+        a = "x = 1\n# old comment\ny = 2\n"
+        b = "x = 1\n# new comment\ny = 2\n"
+        assert _normalize_python_code(a) == _normalize_python_code(b)
+
+    def test_whitespace_change_ignored(self):
+        a = "x = 1\ny = 2\n"
+        b = "x  =  1\n\n\ny  =  2\n"
+        assert _normalize_python_code(a) == _normalize_python_code(b)
+
+    def test_reformatting_ignored(self):
+        a = "result = foo(a,b,c)\n"
+        b = "result = foo(\n    a,\n    b,\n    c,\n)\n"
+        assert _normalize_python_code(a) == _normalize_python_code(b)
+
+    def test_variable_rename_detected(self):
+        a = "x = 1\n"
+        b = "y = 1\n"
+        assert _normalize_python_code(a) != _normalize_python_code(b)
+
+    def test_value_change_detected(self):
+        a = "x = 1\n"
+        b = "x = 2\n"
+        assert _normalize_python_code(a) != _normalize_python_code(b)
+
+    def test_logic_change_detected(self):
+        a = "if x > 0:\n    print(x)\n"
+        b = "if x < 0:\n    print(x)\n"
+        assert _normalize_python_code(a) != _normalize_python_code(b)
+
+    def test_indented_comment_change_ignored(self):
+        """Real run_func_src is indented; normalization must handle this."""
+        a = "        x = 1\n        # old comment\n        y = 2\n"
+        b = "        x = 1\n        # new comment\n        y = 2\n"
+        assert _normalize_python_code(a) == _normalize_python_code(b)
+
+    def test_syntax_error_falls_back_to_raw(self):
+        bad = "def foo(:\n"
+        assert _normalize_python_code(bad) == bad
+
+
+class TestNormalizeShellCode:
+    def test_comment_lines_ignored(self):
+        a = "echo hello\n# this is a comment\necho world\n"
+        b = "echo hello\necho world\n"
+        assert _normalize_shell_code(a) == _normalize_shell_code(b)
+
+    def test_blank_lines_ignored(self):
+        a = "echo hello\n\n\necho world\n"
+        b = "echo hello\necho world\n"
+        assert _normalize_shell_code(a) == _normalize_shell_code(b)
+
+    def test_leading_trailing_whitespace_ignored(self):
+        a = "  echo hello  \n  echo world  \n"
+        b = "echo hello\necho world\n"
+        assert _normalize_shell_code(a) == _normalize_shell_code(b)
+
+    def test_command_change_detected(self):
+        a = "echo hello\n"
+        b = "echo goodbye\n"
+        assert _normalize_shell_code(a) != _normalize_shell_code(b)


### PR DESCRIPTION
I wanted to take a crack at #3819 as I think it makes a lot of sense. This PR compares run/shell blocks by semantic content rather than raw text, so that adding comments, reformatting whitespace, or running a formatter no longer triggers unnecessary reruns.

Note that this does not apply to code inside script files as this would require larger changes. I think it would make sense to extend this further to script files and would be willing to address separately.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of change detection for rules, now properly handling formatting and whitespace variations.

* **Tests**
  * Added comprehensive test coverage for code normalization and change-detection behaviors across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->