### PR TITLE
fix: apptainer command not recognized when singularity is absent 

### DIFF
--- a/src/snakemake/deployment/singularity.py
+++ b/src/snakemake/deployment/singularity.py
@@ -63,7 +63,7 @@ class Image:
             try:
                 p = subprocess.check_output(
                     [
-                        "singularity",
+                        self.singularity.binary,
                         "pull",
                         "--name",
                         f"{self.hash}.simg",
@@ -139,8 +139,10 @@ def shellcmd(
                     f"non-existent path {str(b)!r}"
                 )
 
-    cmd = "{} singularity {} exec --home {} {} {} {} -c '{}'".format(
+    binary = Singularity().binary or "singularity"
+    cmd = "{} {} {} exec --home {} {} {} {} -c '{}'".format(
         envvars,
+        binary,
         "--quiet --silent" if quiet else "",
         repr(os.getcwd()),
         args,
@@ -164,8 +166,11 @@ class Singularity:
             return inst
 
     def __init__(self):
-        self.checked = False
-        self._version = None
+        if not hasattr(self, "_initialized"):
+            self.checked = False
+            self._version = None
+            self.binary = None
+            self._initialized = True
 
     @property
     def version(self):
@@ -198,7 +203,11 @@ class Singularity:
         from packaging.version import parse
 
         if not self.checked:
-            if not shutil.which("singularity"):
+            if shutil.which("apptainer"):
+                self.binary = "apptainer"
+            elif shutil.which("singularity"):
+                self.binary = "singularity"
+            else:
                 raise WorkflowError(
                     "The apptainer or singularity command has to be "
                     "available in order to use apptainer/singularity "
@@ -206,7 +215,7 @@ class Singularity:
                 )
             try:
                 v = subprocess.check_output(
-                    ["singularity", "--version"], stderr=subprocess.PIPE
+                    [self.binary, "--version"], stderr=subprocess.PIPE
                 ).decode()
             except subprocess.CalledProcessError as e:
                 raise WorkflowError(


### PR DESCRIPTION
## What does this fix?
Closes #3860                                                                  
                                                                                
  ## Problem                                                                    
  Snakemake only checks for a binary named `singularity` when using `--sdm      
  apptainer`. Users who have `apptainer` installed (but not `singularity`) get the error:   
  "The apptainer or singularity command has to be available in order to use apptainer/singularity integration."                                           
                                                                                
  ## Solution                                                                   
  Updated `singularity.py` to check for both `apptainer` and `singularity` binaries, preferring `apptainer` (the modern name). All hardcoded `"singularity"` references replaced with the dynamically detected binary name.

  ## Changes
  - `snakemake/deployment/singularity.py` — Detection checks `apptainer` first,
  then `singularity`. Updated `check()`, `pull()`, `shellcmd()`, and `__init__()` to use the detected binary name.

  ### QC
  * [x]  The changes are already covered by an existing test case test_container
  * No documentation update needed — this is a bug fix, not a behavior change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for apptainer container runtime alongside singularity. The system automatically detects and uses whichever runtime is available on the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->