### PR TITLE
docs: typo in the migration table breaking a pip install command

### DIFF
--- a/docs/getting_started/migration.rst
+++ b/docs/getting_started/migration.rst
@@ -498,7 +498,7 @@ Moreover, some options have been renamed:
                         Specify a custom executor, available via an executor
                         plugin: snakemake_executor_<name> (default: None)
      - New designed: Now if you want to use ``--cluster CMD``, please use ``--executor cluster-generic --cluster-generic-submit-cmd CMD`` instead.
-        Note you should install ``cluster-generic`` using command ``pip install snakemake-executor-cluster-generic``
+        Note you should install ``cluster-generic`` using command ``pip install snakemake-executor-plugin-cluster-generic``
    * - --cluster CMD
      -
                         Execute snakemake rules with the given submit command,


### PR DESCRIPTION
This very very minor PR fixes a small typo in the table that lists differences in the interfaces between the versions. In the pip install description, the word “plugin” was omitted in the pip install command ```pip install snakemake-executor-plugin-cluster-generic```.

Fix #3827


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the recommended pip package name for the cluster-generic executor plugin in the migration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->