### PR TITLE
docs: fixed wrong code example for collect() function

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -467,7 +467,7 @@ e.g.
 
 .. code-block:: python
 
-    collect("results/{item.sample}.txt", sample=lookup(query="someval > 2", within=samples))
+    collect("results/{item.sample}.txt", item=lookup(query="someval > 2", within=samples))
 
 Here, we take the file ``"results/{item.sample}.txt"`` with ``{item.sample}`` being replaced by the
 sample names that occur in all rows of the dataframe ``samples`` where the value of the ``someval`` column is greater than 2.


### PR DESCRIPTION
A very small PR fixing a wrong code example in the docs. 
``` collect()``` function takes the keyword "item", not "sample". The minimal example of the issue #3541 has been reproduced and the problem was confirmed. 

Fix #3541 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example documentation for collect rules to demonstrate proper parameter binding when using lookup results. Example now shows how to correctly reference bound values in subsequent wildcards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->