### PR TITLE
docs: Add AI-assisted contributions policy to contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,16 @@
 
 * [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
 * [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
+* [ ] I, as a human being, have checked each line of code in this pull request
+
+### AI-assistance disclosure
+<!--
+If AI tools were involved in creating this PR, please check all boxes that apply
+below and make sure that you adhere to our AI-assisted contributions policy:
+https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
+-->
+I used AI assistance for:
+* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
+* [ ] Test/benchmark generation
+* [ ] Documentation (including examples)
+* [ ] Research and understanding

--- a/docs/project_info/contributing.rst
+++ b/docs/project_info/contributing.rst
@@ -88,6 +88,26 @@ If you want to create more pull requests, first run :code:`git checkout main` an
 
 Feel free to ask questions about this if you want to contribute to Snakemake :)
 
+AI-assisted contributions
+-------------------------
+
+We welcome the use of AI tools as part of the development process.
+They can be valuable aids for drafting, refactoring, documentation, and exploration.
+However, contributions to Snakemake require human judgment, contextual understanding, and familiarity with the project's structure, goals, and standards.
+
+When using AI tools:
+
+* **You remain the author of the contribution.** Review, understand, and test all AI-assisted code or documentation before submitting it under your name.
+  You should be able to explain and defend the changes on request.
+* **Avoid fully automated submissions.** Issues or pull requests generated end-to-end by automated tools, without meaningful human review or intent, are not appropriate.
+* **Be respectful of reviewers' time.** Ensure that both the content of the PR and its description reflect your own understanding.
+  Reviewers should not be expected to infer authorship or unknowingly interact with an AI during review.
+* **Disclose significant AI assistance.** If AI tools were used for a substantial portion of the contribution, please note this in the PR description.
+
+Contributors are responsible for the correctness, maintainability, and long-term impact of all submitted changes, regardless of whether AI tools were used.
+
+Pull requests that do not meet these expectations may be closed without review.
+
 .. _pixi-getting_started:
 
 Development with ``pixi``


### PR DESCRIPTION
* Add an AI-assisted contributions policy taken mostly from Awkward Array's (https://github.com/scikit-hep/awkward/), which was based on Scikit-learn's Automated Contributions Policy.
* Add AI-assistance disclosure checkboxes to pull request template.
* c.f.
   - https://github.com/scikit-hep/awkward/pull/3831
   - https://github.com/scikit-learn/scikit-learn/pull/32566

Note that the Awkward Array language is more pro-AI-usage while the Scikit-learn language is more neutral.

### Context

This was discussed in the AI section of the [2026 Snakemake Hackathon](https://indico.cern.ch/event/1574891/) at TUM ([GitHub project board](https://github.com/orgs/snakemake/projects/8)).

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [N/A] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "AI-assisted contributions" subsection to the contribution guide covering attribution, limits on automation, reviewer expectations, and when to disclose significant AI assistance.
  * Updated the pull request template to include an AI-assistance disclosure section and checklist to ensure contributors declare use of AI tools during submission and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->