### PR TITLE
docs(codebase): Update & simplify plugin architecture section

### DIFF
--- a/docs/project_info/codebase.rst
+++ b/docs/project_info/codebase.rst
@@ -144,6 +144,8 @@ Plugin catalog
 Leveraging this standardized naming, Snakemake automatically collects all plugins from pypi and presents them in the `Snakemake plugin catalog <https://snakemake.github.io/snakemake-plugin-catalog>`__.
 The catalog automatically generates usage documentation for each plugin, gives credit to authors, and provides links to the respective github repositories.
 Plugin authors can extend the catalog documentation for their plugin by providing markdown files ``docs/intro.md`` and ``docs/further.md`` in the plugin repository in order to show an introductory paragraph as well as extensive non-standard documentation (like usage examples or other plugin specific information) in the catalog.
+See the `Slurm executor plugin <https://github.com/snakemake/snakemake-executor-plugin-slurm/tree/main/docs>`__ for an example on how that may be specified.
+You can see how its output is rendered in the catalog `here <https://snakemake.github.io/snakemake-plugin-catalog/plugins/executor/slurm.html>`__ .
 
 Scaffolding
 """""""""""


### PR DESCRIPTION
<!--Add a description of your PR here-->

Remove details on how to contribute plugins as this should not be covered in the codebase part of the architecture section. If we have such docs in unexpected places, it is rather likely to go out of date. This has happened here already with the docs still mentioning poetry prior to this PR.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).

This PR is purely a docs change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Slurm executor plugin reference in the plugin catalog with a link and example output rendering.
  * Streamlined scaffolding guidance: replaced Poetry-centric instructions with Snakedeploy and Pixi references.
  * Replaced lengthy scaffold and storage examples with concise pointers to scaffold examples and added a note on continuous testing via GitHub Actions and guidance for deploying additional services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->