### PR TITLE
test: Add test for issue #2255

### DIFF
--- a/tests/test_github_issue2255/Snakefile
+++ b/tests/test_github_issue2255/Snakefile
@@ -1,0 +1,11 @@
+rule all:
+    input: ["file.txt", "test.txt"],
+
+rule touch:
+    """Touch a file"""
+    output: "file.txt"
+    shell: """ touch {output} """
+
+use rule touch as touche_test with:
+    """The pipeline only runs when this comment is removed"""
+    output: "test.txt"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3159,3 +3159,7 @@ def test_module_onstart_not_in_main_snakefile():
 
 def test_module_onerror():
     run(dpath("test_module_onerror"), shouldfail=True, check_results=True)
+
+
+def test_github_issue2255():
+    run(dpath("test_github_issue2255"), check_results=False)


### PR DESCRIPTION
#2255 describes an error that occures in Snakemake version 8.0.0 in case of a comment in the definition of an inherited rule. In version 9.16.3 this issue doesn't occure anymore. This PR adds a test, that ensures this (credits to @Redmar-van-den-Berg for defining the test in #2255).
Closes #2255.

### QC

As a new test is introduced, the check-boxes are not ticked.

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test case and Snakemake workflow for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->