### PR TITLE
feat: add --share-benchmark flag to send benchmark telemetry to a remote collector

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1571,6 +1571,21 @@ def get_argument_parser(profiles=None):
         action="store_true",
         help="Write extended benchmarking metrics.",
     )
+    group_behavior.add_argument(
+        "--share-benchmark",
+        default=False,
+        action="store_true",
+        help="Opt-in: collect benchmark telemetry for all shell rules and submit "
+        "to a PSB (Planetary Scale Benchmark) collector at workflow end. "
+        "Requires --share-benchmark-collector.",
+    )
+    group_behavior.add_argument(
+        "--share-benchmark-collector",
+        metavar="URL",
+        default=None,
+        help="URL of the PSB telemetry collector endpoint "
+        "(e.g. http://psb.example.com). Used with --share-benchmark.",
+    )
 
     group_cluster = parser.add_argument_group("REMOTE EXECUTION")
 
@@ -1939,6 +1954,8 @@ def create_output_settings(args, log_handler_settings) -> OutputSettings:
         log_handler_settings=log_handler_settings,
         stdout=args.dryrun,
         benchmark_extended=args.benchmark_extended,
+        share_benchmark=args.share_benchmark,
+        share_benchmark_collector=args.share_benchmark_collector,
     )
 
     # Set logging behavior based on execution mode

--- a/src/snakemake/executors/local.py
+++ b/src/snakemake/executors/local.py
@@ -35,6 +35,7 @@ from snakemake.exceptions import (
     SpawnedJobError,
     CacheMissException,
 )
+from snakemake.telemetry import capture_system_snapshot, submit_benchmark_records
 
 common_settings = CommonSettings(
     non_local_exec=False,
@@ -169,6 +170,7 @@ class Executor(RealExecutor):
             self.workflow.sourcecache.cache_path,
             self.workflow.sourcecache.runtime_cache_path,
             self.workflow.runtime_paths,
+            self.workflow.output_settings.share_benchmark,
         )
 
     def run_single_job(self, job: SingleJobExecutorInterface):
@@ -310,6 +312,7 @@ def run_wrapper(
     sourcecache_path,
     runtime_sourcecache_path,
     runtime_paths,
+    share_benchmark=False,
 ):
     """
     Wrapper around the run method that handles exceptions and benchmarking.
@@ -331,7 +334,9 @@ def run_wrapper(
     if os.name == "posix" and debug:
         sys.stdin = open("/dev/stdin")
 
-    if benchmark is not None:
+    should_benchmark = (benchmark is not None) or share_benchmark
+
+    if should_benchmark:
         from snakemake.benchmark import (
             BenchmarkRecord,
             benchmarked,
@@ -347,7 +352,15 @@ def run_wrapper(
 
     try:
         with change_working_directory(shadow_dir):
-            if benchmark:
+            # Capture system state before benchmarking for PSB distress metrics
+            _psb_snapshot = None
+            if share_benchmark:
+                try:
+                    _psb_snapshot = capture_system_snapshot()
+                except Exception:
+                    pass
+
+            if should_benchmark:
                 bench_records = []
                 for bench_iteration in range(benchmark_repeats):
                     # Determine whether to benchmark this process or do not
@@ -473,7 +486,7 @@ def run_wrapper(
             # some internal bug, just reraise
             raise ex
 
-    if benchmark is not None:
+    if should_benchmark:
         try:
             # Add job info to (all repeats of) benchmark file
             for bench_record in bench_records:
@@ -484,6 +497,22 @@ def run_wrapper(
                 bench_record.resources = resources
                 bench_record.input = input
                 bench_record.threads = threads
-            write_benchmark_records(bench_records, benchmark, benchmark_extended)
+
+            # Write benchmark file if benchmark: directive was present
+            if benchmark is not None:
+                write_benchmark_records(bench_records, benchmark, benchmark_extended)
+
+            # Submit to telemetry collector if enabled (shell rules only)
+            if share_benchmark and is_shell and job_rule.shellcmd:
+                submit_benchmark_records(
+                    bench_records=bench_records,
+                    job_rule=job_rule,
+                    params=params,
+                    wildcards=wildcards,
+                    threads=threads,
+                    input_files=input,
+                    output_files=output,
+                    psb_snapshot=_psb_snapshot,
+                )
         except Exception as ex:
             raise WorkflowError(ex)

--- a/src/snakemake/settings/types.py
+++ b/src/snakemake/settings/types.py
@@ -461,6 +461,8 @@ class OutputSettings(SettingsBase, OutputSettingsLoggerInterface):
     log_handler_settings: Mapping[str, LogHandlerSettingsBase] = immutables.Map()
     stdout: bool = False
     benchmark_extended: bool = False
+    share_benchmark: bool = False
+    share_benchmark_collector: Optional[str] = None
     log_level_override: Optional[int] = None
     skip_plugin_handlers: bool = False
     enable_file_logging: bool = True

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -334,6 +334,8 @@ class SpawnedJobArgsFactory:
             w2a("config_settings.config_args", flag="--config"),
             w2a("output_settings.printshellcmds"),
             w2a("output_settings.benchmark_extended"),
+            w2a("output_settings.share_benchmark"),
+            w2a("output_settings.share_benchmark_collector"),
             w2a("execution_settings.latency_wait"),
             w2a("scheduling_settings.scheduler", flag="--scheduler"),
             w2a("workflow_settings.cache"),

--- a/src/snakemake/telemetry/__init__.py
+++ b/src/snakemake/telemetry/__init__.py
@@ -1,0 +1,51 @@
+"""PSB (Planetary Scale Benchmark) telemetry for Snakemake.
+
+Public API for telemetry collection, initialization, and data submission.
+
+Protocol specification:
+https://github.com/btraven00/psb/blob/main/docs/spec.md
+"""
+
+from ._client import (
+    DEFAULT_TOKEN,
+    BenchmarkTelemetryClient,
+    add_psb_record,
+    flush_psb,
+    get_psb_client,
+    get_session_url,
+    init_psb,
+    submit_benchmark_records,
+)
+from ._environment import collect_environment
+from ._metrics import (
+    capture_system_snapshot,
+    compute_iowait_pct,
+    read_iowait_ticks,
+    read_loadavg,
+    read_mem_swap,
+)
+from ._parsing import GENERIC_INTERPRETERS, get_file_type, parse_shell_tool
+
+__all__ = [
+    # Client
+    "BenchmarkTelemetryClient",
+    "init_psb",
+    "get_psb_client",
+    "add_psb_record",
+    "flush_psb",
+    "get_session_url",
+    "submit_benchmark_records",
+    "DEFAULT_TOKEN",
+    # Environment
+    "collect_environment",
+    # Metrics
+    "capture_system_snapshot",
+    "read_loadavg",
+    "read_mem_swap",
+    "read_iowait_ticks",
+    "compute_iowait_pct",
+    # Parsing
+    "parse_shell_tool",
+    "get_file_type",
+    "GENERIC_INTERPRETERS",
+]

--- a/src/snakemake/telemetry/_client.py
+++ b/src/snakemake/telemetry/_client.py
@@ -1,0 +1,359 @@
+"""Telemetry client for Snakemake.
+
+Thread-safe singleton that accumulates benchmark records during a workflow run
+and flushes them as a single JSONL POST to the PSB collector on shutdown.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import threading
+import urllib.error
+import urllib.request
+import uuid
+from typing import Any
+
+from snakemake.logging import logger
+
+DEFAULT_TOKEN = "dev-secret"
+
+
+class BenchmarkTelemetryClient:
+    """Accumulates benchmark records and flushes as a single JSONL POST."""
+
+    def __init__(self, endpoint: str, token: str, session_id: str | None = None):
+        self.endpoint = endpoint.rstrip("/")
+        self.token = token
+        self.session_id = session_id or str(uuid.uuid4())
+        self.session_start = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        self._cookie = str(uuid.uuid4())
+        self._env: dict[str, str] = {}
+        self._session_meta: dict[str, str] = {}
+        self._buffer: list[dict[str, Any]] = []
+
+    def make_record_id(self, rule_name: str, wildcards: dict | None = None) -> str:
+        """Deterministic record ID from session start + rule name + wildcards."""
+        key = f"{self.session_start}:{rule_name}"
+        if wildcards:
+            wc_str = ",".join(f"{k}={v}" for k, v in sorted(wildcards.items()))
+            key = f"{key}:{wc_str}"
+        h = hashlib.sha256(key.encode()).hexdigest()
+        return h[:16]
+
+    def set_session_meta(
+        self, workflow_url: str = "", workflow_version: str = ""
+    ) -> None:
+        """Set session-level metadata (workflow URL and version)."""
+        self._session_meta = {}
+        if workflow_url:
+            self._session_meta["workflow_url"] = workflow_url
+        if workflow_version:
+            self._session_meta["workflow_version"] = workflow_version
+
+    def set_environment(self, **kwargs: str) -> None:
+        self._env = dict(kwargs)
+
+    def add_record(
+        self,
+        *,
+        record_id: str,
+        tool: str,
+        runtime_sec: float,
+        max_rss_mb: float,
+        cpu_percent: float,
+        **optional: Any,
+    ) -> None:
+        if not tool or runtime_sec <= 0 or not record_id:
+            return  # silently skip invalid
+        record: dict[str, Any] = {
+            "record_id": record_id,
+            "tool": tool,
+            "runtime_sec": runtime_sec,
+            "max_rss_mb": max_rss_mb,
+            "cpu_percent": cpu_percent,
+        }
+        for key in (
+            "command",
+            "params",
+            "inputs",
+            "outputs",
+            "threads",
+            "exit_code",
+            "load_avg",
+            "mem_avail_mb",
+            "swap_used_mb",
+            "io_wait_pct",
+            "shell_block",
+            "max_vms_mb",
+            "max_uss_mb",
+            "max_pss_mb",
+            "io_in_mb",
+            "io_out_mb",
+            "cpu_time_sec",
+            "resources",
+            "tool_version",
+            "category",
+        ):
+            if key in optional:
+                record[key] = optional[key]
+        self._buffer.append(record)
+
+    def flush(self, timeout: float = 10.0) -> dict | None:
+        if not self._buffer or not self._env:
+            return None
+
+        lines = []
+        for record in self._buffer:
+            line = {
+                "session_id": self.session_id,
+                **self._session_meta,
+                **self._env,
+                **record,
+            }
+            lines.append(json.dumps(line, separators=(",", ":")))
+
+        body = "\n".join(lines).encode("utf-8")
+        url = f"{self.endpoint}/v1/telemetry"
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", "text/jsonl")
+        req.add_header("User-Agent", "snakemake-psb/1.0")
+        req.add_header("X-PSB-Token", self.token)
+        req.add_header("X-PSB-Nonce", str(uuid.uuid4()))
+        req.add_header("Cookie", f"_psb_session={self._cookie}")
+
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                resp_body = resp.read().decode("utf-8")
+                if resp.status == 201:
+                    result = json.loads(resp_body)
+                    self._buffer.clear()
+                    return result
+        except Exception:
+            pass  # buffer preserved for retry
+        return None
+
+
+# Global client singleton
+_client: BenchmarkTelemetryClient | None = None
+_lock = threading.Lock()
+
+
+def init_psb(
+    endpoint: str,
+    sm_version: str,
+    token: str = DEFAULT_TOKEN,
+    deploy_mode: str = "host",
+    workflow_url: str = "",
+    workflow_version: str = "",
+) -> None:
+    """Initialize the global PSB client. Call once at workflow start."""
+    from ._environment import collect_environment
+
+    global _client
+    with _lock:
+        _client = BenchmarkTelemetryClient(endpoint, token)
+        _client.set_environment(**collect_environment(sm_version, deploy_mode))
+        _client.set_session_meta(
+            workflow_url=workflow_url, workflow_version=workflow_version
+        )
+    logger.info(f"Telemetry enabled (session {_client.session_id})")
+
+
+def get_psb_client() -> BenchmarkTelemetryClient | None:
+    """Return the global PSB client, or None if not initialized."""
+    with _lock:
+        return _client
+
+
+def add_psb_record(**kwargs: Any) -> None:
+    """Thread-safe append of a benchmark record. No-op if not initialized."""
+    with _lock:
+        if _client is not None:
+            try:
+                _client.add_record(**kwargs)
+            except Exception as e:
+                logger.debug(f"Telemetry: failed to add record: {e}")
+
+
+def flush_psb() -> None:
+    """Flush all buffered records. Fire-and-forget, never raises."""
+    with _lock:
+        client = _client
+    if client is None:
+        return
+    try:
+        result = client.flush(timeout=10.0)
+        if result:
+            logger.info(
+                f"Telemetry: {result.get('accepted', 0)} accepted, "
+                f"{result.get('duplicates', 0)} duplicates, "
+                f"{result.get('rejected', 0)} rejected"
+            )
+        else:
+            n = len(client._buffer)
+            if n:
+                logger.warning(f"Telemetry: flush failed, {n} records lost")
+    except Exception as e:
+        logger.warning(f"Telemetry flush error: {e}")
+
+
+def get_session_url() -> str | None:
+    """Return the full URL to view the current session, or None."""
+    with _lock:
+        if _client is not None:
+            return f"{_client.endpoint}/session/{_client.session_id}"
+    return None
+
+
+def submit_benchmark_records(
+    bench_records,
+    job_rule,
+    params,
+    wildcards,
+    threads,
+    input_files,
+    output_files,
+    psb_snapshot,
+):
+    """Submit benchmark records to Telemetry.
+
+    Handles annotation resolution, file metadata collection, and record submission.
+
+    Args:
+        bench_records: List of BenchmarkRecord objects
+        job_rule: The rule being executed
+        params: Rule parameters (may contain _psb_* annotations)
+        wildcards: Wildcards dict
+        threads: Number of threads
+        input_files: List of input file paths
+        output_files: List of output file paths
+        psb_snapshot: System snapshot captured before execution
+    """
+    import json
+    import os
+
+    from ._parsing import GENERIC_INTERPRETERS, parse_shell_tool, get_file_type
+    from ._metrics import read_iowait_ticks, compute_iowait_pct
+
+    # Resolve _psb_* annotations
+    # Precedence: rule-level param > workflow config > auto-detect
+    psb_cfg = {}
+    try:
+        psb_cfg = job_rule.workflow.config.get("psb", {}) or {}
+    except Exception:
+        pass
+
+    def _annot(name):
+        """Get annotation: rule param > config default."""
+        val = getattr(params, f"_psb_{name}", None)
+        if val is not None:
+            return val
+        return psb_cfg.get(name)
+
+    # Auto-detect tool/params from shell template
+    auto_tool, auto_params = parse_shell_tool(job_rule.shellcmd)
+
+    # _psb_tool replaces tool field
+    psb_tool = _annot("tool")
+    tool = psb_tool if psb_tool else auto_tool
+
+    # _psb_primary_cmd replaces command field
+    psb_cmd = _annot("primary_cmd")
+    command = psb_cmd if psb_cmd else tool
+
+    # _psb_params replaces params field
+    psb_params = _annot("params")
+    if psb_params is not None:
+        params_str = psb_params
+    elif psb_cmd and not psb_params:
+        # When _psb_primary_cmd is set without _psb_params, clear params
+        params_str = ""
+    else:
+        params_str = auto_params
+
+    # tool_version and category from annotations
+    tool_version = _annot("tool_version") or ""
+    category = _annot("category") or ""
+
+    # GENERIC_INTERPRETERS drop rule always applies
+    psb_client = get_psb_client()
+    if not tool or tool in GENERIC_INTERPRETERS or not psb_client:
+        return
+
+    # Compute iowait delta
+    io_wait_pct = 0.0
+    if psb_snapshot:
+        iowait_end = read_iowait_ticks()
+        io_wait_pct = compute_iowait_pct(psb_snapshot["iowait_start"], iowait_end)
+
+    for br in bench_records:
+        if br.running_time is None or br.running_time <= 0:
+            continue
+        wc_dict = dict(wildcards) if wildcards else None
+        record_id = psb_client.make_record_id(job_rule.name, wc_dict)
+
+        # Build per-file input entries
+        inputs_list: list[dict[str, object]] = []
+        # Ensure input_files is iterable as a list, not a string
+        # Namedlist works correctly, but plain strings would iterate by character
+        if isinstance(input_files, str):
+            input_files = [input_files] if input_files.strip() else []
+        if input_files:
+            for inp in input_files:
+                try:
+                    size = os.path.getsize(inp)
+                except OSError:
+                    size = 0
+                t = get_file_type(inp) or ""
+                inputs_list.append({"type": t, "size": size})
+
+        # Build per-file output entries
+        outputs_list: list[dict[str, object]] = []
+        # Ensure output_files is iterable as a list, not a string
+        if isinstance(output_files, str):
+            output_files = [output_files] if output_files.strip() else []
+        if output_files:
+            for out in output_files:
+                try:
+                    size = os.path.getsize(out)
+                except OSError:
+                    size = 0
+                t = get_file_type(out) or ""
+                outputs_list.append({"type": t, "size": size})
+
+        # Resources as JSON string
+        res_str = ""
+        try:
+            res_str = json.dumps(br.parse_resources())
+        except Exception:
+            pass
+
+        add_psb_record(
+            record_id=record_id,
+            tool=tool,
+            command=command,
+            params=params_str,
+            shell_block=job_rule.shellcmd,
+            runtime_sec=br.running_time,
+            threads=threads or 0,
+            max_rss_mb=br.max_rss or 0.0,
+            cpu_percent=br.cpu_usage or 0.0,
+            max_vms_mb=br.max_vms or 0.0,
+            max_uss_mb=br.max_uss or 0.0,
+            max_pss_mb=br.max_pss or 0.0,
+            io_in_mb=br.io_in or 0.0,
+            io_out_mb=br.io_out or 0.0,
+            cpu_time_sec=br.cpu_time or 0.0,
+            resources=res_str,
+            tool_version=tool_version,
+            category=category,
+            inputs=inputs_list,
+            outputs=outputs_list,
+            exit_code=0,
+            load_avg=psb_snapshot["load_avg"] if psb_snapshot else 0.0,
+            mem_avail_mb=psb_snapshot["mem_avail_mb"] if psb_snapshot else 0,
+            swap_used_mb=psb_snapshot["swap_used_mb"] if psb_snapshot else 0,
+            io_wait_pct=io_wait_pct,
+        )

--- a/src/snakemake/telemetry/_environment.py
+++ b/src/snakemake/telemetry/_environment.py
@@ -1,0 +1,247 @@
+"""System environment introspection for telemetry.
+
+Collects hardware and OS information: CPU model, features, cores, caches,
+frequency, OS version, etc.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import socket
+import subprocess
+import sys
+
+
+def host_hash() -> str:
+    """Return a deterministic hash of the hostname."""
+    return hashlib.sha256(socket.gethostname().encode()).hexdigest()
+
+
+def cpu_model() -> str:
+    """Return CPU model name."""
+    if sys.platform == "linux":
+        try:
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("model name"):
+                        return line.split(":", 1)[1].strip()
+        except OSError:
+            pass
+    elif sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["sysctl", "-n", "machdep.cpu.brand_string"], text=True, timeout=2
+            )
+            return out.strip()
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+    return platform.processor() or "unknown"
+
+
+# Curated CPU feature bitmask. bit positions MUST match the Go server
+# (internal/cpufeatures/cpufeatures.go).
+_CPU_FEATURE_REGISTRY: list[tuple[str, int]] = [
+    # x86 SIMD
+    ("sse2", 1 << 0),
+    ("pni", 1 << 1),  # Linux name for SSE3
+    ("sse3", 1 << 1),
+    ("ssse3", 1 << 2),
+    ("sse4_1", 1 << 3),
+    ("sse4_2", 1 << 4),
+    ("avx", 1 << 5),
+    ("avx2", 1 << 6),
+    ("fma", 1 << 7),
+    ("avx512f", 1 << 8),
+    ("avx512bw", 1 << 9),
+    ("avx512vl", 1 << 10),
+    ("avx512dq", 1 << 11),
+    ("avx512_vnni", 1 << 12),
+    ("avx512vnni", 1 << 12),
+    ("f16c", 1 << 13),
+    # Bit manipulation
+    ("popcnt", 1 << 14),
+    ("bmi1", 1 << 15),
+    ("bmi2", 1 << 16),
+    ("abm", 1 << 17),
+    ("lzcnt", 1 << 17),
+    # Crypto / hashing
+    ("aes", 1 << 18),
+    ("aesni", 1 << 18),
+    ("sha_ni", 1 << 19),
+    ("sha1", 1 << 19),
+    ("sha2", 1 << 19),
+    ("pclmulqdq", 1 << 20),
+    ("pclmul", 1 << 20),
+    # Misc x86
+    ("rdrand", 1 << 21),
+    ("rtm", 1 << 22),
+    ("hle", 1 << 22),
+    # ARM
+    ("neon", 1 << 23),
+    ("asimd", 1 << 23),
+    ("sve", 1 << 24),
+    ("sve2", 1 << 25),
+    ("crc32", 1 << 26),
+    # AMD
+    ("xop", 1 << 27),
+]
+
+
+def raw_cpu_flags() -> list[str]:
+    """Return raw CPU flag names from the OS."""
+    if sys.platform == "linux":
+        try:
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("flags"):
+                        return line.split(":", 1)[1].strip().split()
+        except OSError:
+            pass
+    elif sys.platform == "darwin":
+        try:
+            out = subprocess.check_output(
+                ["sysctl", "-n", "machdep.cpu.features"], text=True, timeout=2
+            )
+            return [f.lower() for f in out.strip().split()]
+        except (subprocess.SubprocessError, FileNotFoundError):
+            pass
+    return []
+
+
+def encode_cpu_features(flags: list[str]) -> int:
+    """Encode a list of CPU flag names into a bitmask."""
+    lookup: dict[str, int] = {}
+    for name, bit in _CPU_FEATURE_REGISTRY:
+        lookup[name] = bit
+    mask = 0
+    for f in flags:
+        f = f.lower().strip()
+        if f in lookup:
+            mask |= lookup[f]
+    return mask
+
+
+def cpu_cores() -> int:
+    """Return the number of physical CPU cores (0 if unknown)."""
+    try:
+        if sys.platform == "linux":
+            # Count unique physical core IDs
+            cores: set[tuple[str, str]] = set()
+            phys_id = core_id = ""
+            with open("/proc/cpuinfo") as f:
+                for line in f:
+                    if line.startswith("physical id"):
+                        phys_id = line.split(":", 1)[1].strip()
+                    elif line.startswith("core id"):
+                        core_id = line.split(":", 1)[1].strip()
+                        cores.add((phys_id, core_id))
+            return len(cores) if cores else os.cpu_count() or 0
+        elif sys.platform == "darwin":
+            out = subprocess.check_output(
+                ["sysctl", "-n", "hw.physicalcpu"], text=True, timeout=2
+            )
+            return int(out.strip())
+    except (OSError, subprocess.SubprocessError, ValueError):
+        pass
+    return os.cpu_count() or 0
+
+
+def cache_sizes() -> tuple[int, int]:
+    """Return (l2_cache_kb, l3_cache_kb). Returns 0 for unknown values."""
+    l2 = l3 = 0
+    try:
+        if sys.platform == "linux":
+            import glob as _glob
+
+            for idx_dir in sorted(
+                _glob.glob("/sys/devices/system/cpu/cpu0/cache/index*")
+            ):
+                try:
+                    with open(os.path.join(idx_dir, "level")) as f:
+                        level = int(f.read().strip())
+                    with open(os.path.join(idx_dir, "size")) as f:
+                        size_str = f.read().strip()  # e.g. "256K" or "8192K"
+                        size_kb = int(size_str.rstrip("K"))
+                    if level == 2:
+                        l2 = size_kb
+                    elif level == 3:
+                        l3 = size_kb
+                except (OSError, ValueError):
+                    continue
+        elif sys.platform == "darwin":
+            for key, setter in [
+                ("hw.l2cachesize", "l2"),
+                ("hw.l3cachesize", "l3"),
+            ]:
+                try:
+                    out = subprocess.check_output(
+                        ["sysctl", "-n", key], text=True, timeout=2
+                    )
+                    val = int(out.strip()) // 1024  # bytes -> KB
+                    if setter == "l2":
+                        l2 = val
+                    else:
+                        l3 = val
+                except (subprocess.SubprocessError, ValueError, FileNotFoundError):
+                    pass
+    except Exception:
+        pass
+    return l2, l3
+
+
+def cpu_freq_mhz() -> int:
+    """Return max CPU frequency in MHz (0 if unknown)."""
+    try:
+        if sys.platform == "linux":
+            with open("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq") as f:
+                return int(f.read().strip()) // 1000  # kHz -> MHz
+        elif sys.platform == "darwin":
+            out = subprocess.check_output(
+                ["sysctl", "-n", "hw.cpufrequency_max"], text=True, timeout=2
+            )
+            return int(out.strip()) // 1_000_000  # Hz -> MHz
+    except (OSError, subprocess.SubprocessError, ValueError, FileNotFoundError):
+        pass
+    return 0
+
+
+def platform_os() -> str:
+    """Return normalized OS name."""
+    mapping = {
+        "linux": "linux",
+        "darwin": "darwin",
+        "freebsd": "freebsd",
+        "win32": "windows",
+        "cygwin": "windows",
+    }
+    return mapping.get(sys.platform, sys.platform)
+
+
+def collect_environment(sm_version: str, deploy_mode: str = "host") -> dict:
+    """Collect all environment metadata for telemetry session.
+
+    Args:
+        sm_version: Snakemake version string
+        deploy_mode: Deployment method (e.g., "host", "conda", "conda+apptainer")
+
+    Returns:
+        Dictionary with CPU, OS, and version metadata
+    """
+    raw_flags = raw_cpu_flags()
+    l2, l3 = cache_sizes()
+    return {
+        "host_hash": host_hash(),
+        "cpu_model": cpu_model(),
+        "cpu_features": encode_cpu_features(raw_flags),
+        "cpu_cores": cpu_cores(),
+        "l2_cache_kb": l2,
+        "l3_cache_kb": l3,
+        "cpu_freq_mhz": cpu_freq_mhz(),
+        "os": platform_os(),
+        "kernel_version": platform.release(),
+        "kernel_string": platform.platform(),
+        "sm_version": sm_version,
+        "deploy_mode": deploy_mode,
+    }

--- a/src/snakemake/telemetry/_metrics.py
+++ b/src/snakemake/telemetry/_metrics.py
@@ -1,0 +1,118 @@
+"""Per-job system state metrics for telemetry.
+
+Captures system "distress" metrics like load average, memory availability,
+swap usage, and I/O wait percentage at job execution time.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def read_loadavg() -> float:
+    """Return 1-minute load average."""
+    try:
+        return os.getloadavg()[0]
+    except OSError:
+        return 0.0
+
+
+def read_mem_swap() -> tuple[int, int]:
+    """Return (mem_avail_mb, swap_used_mb)."""
+    mem_avail = 0
+    swap_used = 0
+    try:
+        if sys.platform == "linux":
+            swap_total = swap_free = 0
+            with open("/proc/meminfo") as f:
+                for line in f:
+                    if line.startswith("MemAvailable:"):
+                        mem_avail = int(line.split()[1]) // 1024  # kB -> MB
+                    elif line.startswith("SwapTotal:"):
+                        swap_total = int(line.split()[1]) // 1024
+                    elif line.startswith("SwapFree:"):
+                        swap_free = int(line.split()[1]) // 1024
+            swap_used = swap_total - swap_free
+        elif sys.platform == "darwin":
+            # Memory available: use vm_stat (pages × page_size)
+            try:
+                out = subprocess.check_output(["vm_stat"], text=True, timeout=2)
+                page_size = 4096  # default macOS page size
+                free_pages = inactive_pages = 0
+                for line in out.splitlines():
+                    if "page size of" in line:
+                        page_size = int(line.split()[-2])
+                    elif "Pages free:" in line:
+                        free_pages = int(line.split()[-1].rstrip("."))
+                    elif "Pages inactive:" in line:
+                        inactive_pages = int(line.split()[-1].rstrip("."))
+                mem_avail = (free_pages + inactive_pages) * page_size // (1024 * 1024)
+            except (subprocess.SubprocessError, FileNotFoundError):
+                pass
+            # Swap used: sysctl vm.swapusage
+            try:
+                out = subprocess.check_output(
+                    ["sysctl", "-n", "vm.swapusage"], text=True, timeout=2
+                )
+                # Format: "total = 2048.00M  used = 123.45M  free = 1924.55M"
+                parts = out.split()
+                for i, p in enumerate(parts):
+                    if p == "used":
+                        val = parts[i + 2].rstrip("M")
+                        swap_used = int(float(val))
+                        break
+            except (
+                subprocess.SubprocessError,
+                ValueError,
+                FileNotFoundError,
+                IndexError,
+            ):
+                pass
+    except Exception:
+        pass
+    return mem_avail, swap_used
+
+
+def read_iowait_ticks() -> tuple[int, int]:
+    """Return (iowait_ticks, total_ticks) from /proc/stat. Linux only."""
+    if sys.platform != "linux":
+        return 0, 0
+    try:
+        with open("/proc/stat") as f:
+            for line in f:
+                if line.startswith("cpu "):
+                    fields = line.split()
+                    # user, nice, system, idle, iowait, irq, softirq, steal
+                    vals = [int(x) for x in fields[1:9]]
+                    iowait = vals[4] if len(vals) > 4 else 0
+                    total = sum(vals)
+                    return iowait, total
+    except (OSError, ValueError):
+        pass
+    return 0, 0
+
+
+def compute_iowait_pct(start: tuple[int, int], end: tuple[int, int]) -> float:
+    """Compute iowait percentage from before/after tick snapshots."""
+    d_iowait = end[0] - start[0]
+    d_total = end[1] - start[1]
+    if d_total <= 0:
+        return 0.0
+    return round(100.0 * d_iowait / d_total, 2)
+
+
+def capture_system_snapshot() -> dict:
+    """Capture system state metrics at a point in time.
+
+    Returns a dict with load_avg, mem_avail_mb, swap_used_mb, and
+    iowait_start (raw ticks for later delta computation).
+    """
+    mem_avail, swap_used = read_mem_swap()
+    return {
+        "load_avg": round(read_loadavg(), 2),
+        "mem_avail_mb": mem_avail,
+        "swap_used_mb": swap_used,
+        "iowait_start": read_iowait_ticks(),
+    }

--- a/src/snakemake/telemetry/_parsing.py
+++ b/src/snakemake/telemetry/_parsing.py
@@ -1,0 +1,103 @@
+"""Parsing utilities for telemetry.
+
+Extracts tool names and parameters from shell commands, and determines
+file types from file paths.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Generic interpreters that should be skipped when detecting tool names
+GENERIC_INTERPRETERS = frozenset(
+    {"python", "python3", "bash", "sh", "Rscript", "perl", "java", "ruby"}
+)
+
+
+def parse_shell_tool(shellcmd: str) -> tuple[str | None, str]:
+    """Extract the tool and params from a shell command template.
+
+    Skips comment lines, blank lines, and leading generic interpreter tokens.
+    Returns (tool, params) where tool is the first non-interpreter token
+    and params is everything after it.
+
+    Args:
+        shellcmd: Shell command string, potentially multi-line
+
+    Returns:
+        Tuple of (tool_name, params_string). Returns (None, "") if no tool found.
+
+    Examples:
+        "samtools sort -@ 4 {input}"       -> ("samtools", "sort -@ 4 {input}")
+        "python scripts/foo.py --arg"      -> ("scripts/foo.py", "--arg")
+        "# comment\\ngzip -9 {input}"       -> ("gzip", "-9 {input}")
+        "python3"                           -> (None, "")
+        ""                                  -> (None, "")
+    """
+    for line in shellcmd.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        tokens = stripped.split()
+        # Skip leading interpreter tokens
+        idx = 0
+        while idx < len(tokens) and tokens[idx] in GENERIC_INTERPRETERS:
+            idx += 1
+        if idx >= len(tokens):
+            return None, ""
+        tool = tokens[idx]
+        params = " ".join(tokens[idx + 1 :]) if idx + 1 < len(tokens) else ""
+        return tool, params
+    return None, ""
+
+
+def get_file_type(filepath: str) -> str | None:
+    """Extract file extension, handling compound extensions like .fastq.gz.
+
+    Args:
+        filepath: Path to file (can be relative or absolute). Must be a single
+            file path. If a space-separated list of paths is passed, only the
+            first path will be processed.
+
+    Returns:
+        File extension including the dot, or None if no extension found.
+        Compound extensions (e.g., .fastq.gz) are preserved.
+
+    Examples:
+        "data.txt" -> ".txt"
+        "reads.fastq.gz" -> ".fastq.gz"
+        "archive.tar.bz2" -> ".tar.bz2"
+        "Makefile" -> None
+        "" -> None
+    """
+    if not filepath:
+        return None
+
+    # Handle the case where a space-separated list of files is passed
+    # (e.g., from accidentally converting a list to string).
+    # We take the first file only as a best-effort approach.
+    stripped = filepath.strip()
+    if " " in stripped and "." in stripped.split()[0]:
+        # Looks like space-separated files (e.g., "file1.txt file2.txt")
+        # Take the first file only
+        stripped = stripped.split()[0]
+        filepath = stripped
+
+    name = os.path.basename(filepath)
+    parts = name.split(".")
+
+    # Handle compound extensions (e.g., .fastq.gz, .tar.bz2, .tar.gz)
+    # Recognized compression suffixes
+    COMPRESSION_SUFFIXES = frozenset({"gz", "bz2", "xz", "zst", "zip", "rar", "7z"})
+
+    if len(parts) >= 3 and parts[-1] in COMPRESSION_SUFFIXES:
+        # It's a compound extension like file.tar.gz or reads.fastq.gz
+        ext = "." + ".".join(parts[-2:])
+    elif len(parts) >= 2:
+        # Simple extension like .txt, .fa, .bam
+        ext = "." + parts[-1]
+    else:
+        # No extension found (e.g., "Makefile", "README")
+        return None
+
+    return ext

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1267,6 +1267,32 @@ class Workflow(WorkflowExecutorInterface):
         assert self.dag_settings is not None
         assert self.remote_execution_settings is not None
         assert self.output_settings is not None
+
+        # Initialize telemetry if opted in
+        if self.output_settings.share_benchmark:
+            if not self.output_settings.share_benchmark_collector:
+                raise WorkflowError(
+                    "--share-benchmark requires --share-benchmark-collector=URL"
+                )
+            from snakemake import __version__ as sm_version
+            from snakemake.telemetry import init_psb
+
+            # Derive deploy_mode from deployment settings
+            deploy_methods = self.deployment_settings.deployment_method
+            if deploy_methods:
+                deploy_mode = "+".join(sorted(m.name.lower() for m in deploy_methods))
+            else:
+                deploy_mode = "host"
+
+            psb_cfg = self.config.get("psb", {}) or {}
+            init_psb(
+                self.output_settings.share_benchmark_collector,
+                sm_version=sm_version,
+                deploy_mode=deploy_mode,
+                workflow_url=psb_cfg.get("workflow_url", ""),
+                workflow_version=psb_cfg.get("workflow_version", ""),
+            )
+
         shell.conda_block_conflicting_envvars = (
             not self.deployment_settings.conda_not_block_search_path_envvars
         )
@@ -1505,13 +1531,25 @@ class Workflow(WorkflowExecutorInterface):
                         )
                 else:
                     self.logger_manager.logfile_hint()
+                    self._psb_session_hint()
                 if not self.dryrun and not self.execution_settings.no_hooks:
                     self._onsuccess(self.logger_manager.get_logfile())
             else:
                 if not self.dryrun and not self.execution_settings.no_hooks:
                     self._onerror(self.logger_manager.get_logfile())
                 self.logger_manager.logfile_hint()
+                self._psb_session_hint()
                 raise WorkflowError("At least one job did not complete successfully.")
+
+    def _psb_session_hint(self):
+        """Flush telemetry and log the session URL."""
+        if self.output_settings.share_benchmark:
+            from snakemake.telemetry import flush_psb, get_session_url
+
+            flush_psb()
+            url = get_session_url()
+            if url:
+                logger.info(f"Shared benchmark results: {url}")
 
     def log_metadata_info(self, metadata_attr, description):
         jobs = [

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,287 @@
+"""Simple behavior tests for PSB telemetry."""
+
+import subprocess as sp
+import sys
+import pytest
+from pathlib import Path
+
+from .common import run, dpath
+
+
+class TestTelemetryCLI:
+    """Test CLI parameter handling for --share-benchmark."""
+
+    def test_share_benchmark_requires_collector(self, tmp_path):
+        """Test that --share-benchmark without --share-benchmark-collector fails."""
+        # Create minimal Snakefile
+        snakefile = tmp_path / "Snakefile"
+        snakefile.write_text("""
+rule all:
+    output: "test.txt"
+    shell: "echo hi > {output}"
+""")
+
+        result = sp.run(
+            [sys.executable, "-m", "snakemake", "--share-benchmark", "-c1"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+
+        # Should fail with error message
+        assert result.returncode != 0
+        assert (
+            "share-benchmark-collector" in result.stderr.lower()
+            or "share-benchmark-collector" in result.stdout.lower()
+        )
+
+    def test_share_benchmark_with_collector_accepted(self, tmp_path):
+        """Test that both flags together are accepted."""
+        snakefile = tmp_path / "Snakefile"
+        snakefile.write_text("""
+rule all:
+    output: "test.txt"
+    shell: "echo hi > {output}"
+""")
+
+        # Use fake collector URL - workflow should start (may fail on flush, but that's ok)
+        result = sp.run(
+            [
+                sys.executable,
+                "-m",
+                "snakemake",
+                "--share-benchmark",
+                "--share-benchmark-collector",
+                "http://localhost:9999",
+                "-c1",
+                "-n",
+            ],  # -n for dry-run
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+
+        # Should not fail due to missing collector URL
+        assert "--share-benchmark-collector" not in result.stderr
+
+
+class TestAnnotationResolution:
+    """Test PSB annotation resolution: per-rule > config > auto-detect."""
+
+    def test_auto_detect_extracts_tool_from_shell(self):
+        """Test that tool name is auto-detected from shell command."""
+        from snakemake.telemetry import parse_shell_tool
+
+        tool, params = parse_shell_tool("samtools sort -@ 4 input.bam")
+        assert tool == "samtools"
+        assert "sort" in params
+
+    def test_auto_detect_skips_generic_interpreters(self):
+        """Test that python/bash are skipped, revealing actual tool."""
+        from snakemake.telemetry import parse_shell_tool
+
+        tool, params = parse_shell_tool("python scripts/process.py --input data")
+        assert tool == "scripts/process.py"
+        assert tool != "python"
+
+
+class TestClientInit:
+    """Test basic PSB client initialization."""
+
+    def test_client_can_be_initialized(self):
+        """Test that PSB client initializes without errors."""
+        from snakemake.telemetry import BenchmarkTelemetryClient
+
+        client = BenchmarkTelemetryClient(
+            endpoint="http://test:8080", token="test-token"
+        )
+
+        assert client.endpoint == "http://test:8080"
+        assert client.token == "test-token"
+        assert client.session_id is not None
+
+    def test_global_init_creates_client(self):
+        """Test that init_psb creates a global client."""
+        from snakemake.telemetry import init_psb, get_psb_client
+
+        init_psb(endpoint="http://test:8080", sm_version="8.0.0")
+
+        client = get_psb_client()
+        assert client is not None
+        assert client.endpoint == "http://test:8080"
+
+    def test_client_accumulates_records(self):
+        """Test that client can accumulate multiple records."""
+        from snakemake.telemetry import BenchmarkTelemetryClient
+
+        client = BenchmarkTelemetryClient("http://test", "token")
+        client.set_environment(sm_version="8.0.0", deploy_mode="host")
+
+        client.add_record(
+            record_id="r1",
+            tool="tool1",
+            runtime_sec=10.0,
+            max_rss_mb=100.0,
+            cpu_percent=50.0,
+        )
+
+        client.add_record(
+            record_id="r2",
+            tool="tool2",
+            runtime_sec=5.0,
+            max_rss_mb=50.0,
+            cpu_percent=30.0,
+        )
+
+        # Buffer should contain both records
+        assert len(client._buffer) == 2
+
+
+class TestPSBCollectorIntegration:
+    """Integration test with a real (fake) HTTP server."""
+
+    def test_client_sends_valid_jsonl_to_collector(self, tmp_path):
+        """Behavior: client should send valid JSONL conforming to PSB spec."""
+        import threading
+        import http.server
+        import socketserver
+        from urllib.parse import urlparse
+
+        from snakemake.telemetry import init_psb, add_psb_record, flush_psb
+
+        import json
+
+        # Storage for received data
+        received_records = []
+
+        class FakePSBHandler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                if self.path == "/v1/telemetry":
+                    content_length = int(self.headers["Content-Length"])
+                    body = self.rfile.read(content_length).decode("utf-8")
+
+                    # Verify it's valid JSONL
+                    lines = body.strip().split("\n")
+                    for line in lines:
+                        record = json.loads(line)  # Will raise if invalid JSON
+                        received_records.append(record)
+
+                    # Send success response
+                    response = json.dumps(
+                        {"accepted": len(lines), "duplicates": 0, "rejected": 0}
+                    ).encode("utf-8")
+
+                    self.send_response(201)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(response)))
+                    self.end_headers()
+                    self.wfile.write(response)
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def log_message(self, format, *args):
+                pass  # Suppress logs
+
+        # Start fake server on random port
+        with socketserver.TCPServer(("127.0.0.1", 0), FakePSBHandler) as httpd:
+            port = httpd.server_address[1]
+            server_thread = threading.Thread(target=httpd.serve_forever)
+            server_thread.daemon = True
+            server_thread.start()
+
+            try:
+                # Initialize PSB client pointing to fake server
+                init_psb(
+                    endpoint=f"http://127.0.0.1:{port}",
+                    sm_version="9.0.0",
+                    deploy_mode="host",
+                    workflow_url="https://github.com/test/repo",
+                    workflow_version="v1.2.3",
+                )
+
+                # Add some records
+                add_psb_record(
+                    record_id="test-rec-1",
+                    tool="samtools",
+                    command="samtools",
+                    params="sort -@ 4",
+                    runtime_sec=10.5,
+                    max_rss_mb=256.0,
+                    cpu_percent=85.0,
+                    threads=4,
+                    inputs=[{"type": ".bam", "size": 1024000}],
+                    outputs=[{"type": ".sorted.bam", "size": 1024000}],
+                )
+
+                add_psb_record(
+                    record_id="test-rec-2",
+                    tool="bwa-mem2",
+                    command="bwa-mem2",
+                    params="mem -t 8",
+                    runtime_sec=45.2,
+                    max_rss_mb=2048.0,
+                    cpu_percent=750.0,
+                    threads=8,
+                )
+
+                # Flush and verify
+                flush_psb()
+
+                # Give server a moment to process
+                import time
+
+                time.sleep(0.1)
+
+                # Verify received records
+                assert len(received_records) == 2
+
+                # Verify required fields in spec
+                for record in received_records:
+                    # Session metadata
+                    assert "session_id" in record
+                    assert "sm_version" in record
+                    assert record["sm_version"] == "9.0.0"
+                    assert "deploy_mode" in record
+                    assert "workflow_url" in record
+                    assert record["workflow_url"] == "https://github.com/test/repo"
+                    assert "workflow_version" in record
+                    assert record["workflow_version"] == "v1.2.3"
+
+                    # Environment metadata
+                    assert "host_hash" in record
+                    assert "cpu_model" in record
+                    assert "cpu_cores" in record
+                    assert "os" in record
+
+                    # Record-level required fields
+                    assert "record_id" in record
+                    assert "tool" in record
+                    assert "runtime_sec" in record
+                    assert "max_rss_mb" in record
+                    assert "cpu_percent" in record
+
+                    # Verify types
+                    assert isinstance(record["runtime_sec"], (int, float))
+                    assert isinstance(record["max_rss_mb"], (int, float))
+                    assert isinstance(record["cpu_percent"], (int, float))
+
+                # Verify specific tool names made it through
+                tools = [r["tool"] for r in received_records]
+                assert "samtools" in tools
+                assert "bwa-mem2" in tools
+
+                # Verify inputs/outputs format
+                rec1 = [r for r in received_records if r["tool"] == "samtools"][0]
+                assert "inputs" in rec1
+                assert isinstance(rec1["inputs"], list)
+                assert len(rec1["inputs"]) == 1
+                assert rec1["inputs"][0]["type"] == ".bam"
+                assert rec1["inputs"][0]["size"] == 1024000
+
+            finally:
+                httpd.shutdown()
+                # Cleanup
+                import snakemake.telemetry._client as client_module
+
+                client_module._client = None

--- a/tests/test_telemetry_parsing.py
+++ b/tests/test_telemetry_parsing.py
@@ -1,0 +1,192 @@
+"""Unit tests for telemetry parsing utilities."""
+
+import pytest
+from snakemake.telemetry._parsing import get_file_type, parse_shell_tool
+
+
+class TestGetFileType:
+    """Test file type extraction from file paths."""
+
+    # Standard cases
+    def test_simple_extension(self):
+        """Test basic file extension extraction."""
+        assert get_file_type("data.txt") == ".txt"
+        assert get_file_type("/path/to/file.csv") == ".csv"
+
+    def test_compound_gz_extension(self):
+        """Test compound .fastq.gz style extensions."""
+        assert get_file_type("reads.fastq.gz") == ".fastq.gz"
+        assert get_file_type("/data/sample.fastq.gz") == ".fastq.gz"
+
+    def test_compound_bz2_extension(self):
+        """Test compound .tar.bz2 style extensions."""
+        assert get_file_type("archive.tar.bz2") == ".tar.bz2"
+
+    def test_compound_xz_extension(self):
+        """Test compound .tar.xz style extensions."""
+        assert get_file_type("archive.tar.xz") == ".tar.xz"
+
+    def test_compound_zst_extension(self):
+        """Test compound .tar.zst style extensions."""
+        assert get_file_type("archive.tar.zst") == ".tar.zst"
+
+    def test_compound_zip_extension(self):
+        """Test compound .zip extensions."""
+        assert get_file_type("archive.zip") == ".zip"
+        assert get_file_type("data.tar.zip") == ".tar.zip"
+
+    def test_compound_other_compression(self):
+        """Test other compression suffixes."""
+        assert get_file_type("archive.tar.rar") == ".tar.rar"
+        assert get_file_type("archive.tar.7z") == ".tar.7z"
+
+    def test_no_extension(self):
+        """Test files without extensions."""
+        assert get_file_type("Makefile") is None
+        assert get_file_type("README") is None
+        assert get_file_type("/path/to/bin/noext") is None
+
+    def test_empty_path(self):
+        """Test empty string handling."""
+        assert get_file_type("") is None
+
+    def test_dotfile(self):
+        """Test dotfiles (hidden files starting with .)."""
+        # Dotfiles like .bashrc - the function treats the part after the first dot
+        # as the extension. This is a design choice - could be debated either way.
+        result = get_file_type(".bashrc")
+        # Currently returns ".bashrc" (everything after the first dot)
+        # Alternative interpretation: None (dotfiles have no extension)
+        assert result in [".bashrc", None]
+
+        # .gitignore is similar
+        result = get_file_type(".gitignore")
+        assert result in [".gitignore", None]
+
+    def test_multiple_dots(self):
+        """Test files with multiple dots but not compound extensions."""
+        # file.name.with.dots.txt -> should return .txt
+        assert get_file_type("file.name.with.dots.txt") == ".txt"
+
+    # Edge cases and brittleness issues
+
+    def test_space_separated_paths_returns_first_file_ext(self):
+        """Test handling of space-separated paths (best-effort fallback).
+
+        When multiple file paths are joined with spaces (as happens when
+        Namedlist is accidentally converted to string), the function now
+        extracts the extension from the first file only as a best-effort
+        fallback, rather than returning garbage.
+        """
+        # Simulating what happens when Namedlist.__str__() is called:
+        # InputFiles(["genome.fa", "genome.amb", ...]) becomes:
+        # "genome.fa genome.amb genome.ann genome.pac genome.0123 genome.64"
+        space_separated = (
+            "genome.fa genome.amb genome.ann genome.pac genome.0123 genome.64"
+        )
+        result = get_file_type(space_separated)
+        # Should extract extension from first file only
+        assert result == ".fa"
+
+    def test_space_separated_with_fastq_gz(self):
+        """Test space-separated paths with compound extension."""
+        space_sep = "reads.fastq.gz reads2.fastq.gz"
+        result = get_file_type(space_sep)
+        # Should extract .fastq.gz from the first file
+        assert result == ".fastq.gz"
+
+    def test_single_file_with_numeric_extension(self):
+        """Test numeric file extensions like .0123, .64."""
+        # These are legitimate extensions used by bioinformatics tools (e.g., BWA index files)
+        assert get_file_type("genome.0123") == ".0123"
+        assert get_file_type("genome.64") == ".64"
+
+    def test_path_with_spaces(self):
+        """Test paths containing spaces in directory names."""
+        # This is different from space-separated file lists
+        # A single file with spaces in the path
+        assert get_file_type("/path with spaces/file.txt") == ".txt"
+        assert get_file_type("/my data/results.csv") == ".csv"
+
+    def test_weird_extensions(self):
+        """Test unusual but valid extensions."""
+        assert get_file_type("file.a") == ".a"  # single char extension
+        assert get_file_type("file.AB") == ".AB"  # uppercase extension
+        assert get_file_type("file.ext1.ext2") == ".ext2"  # not a compound extension
+
+    def test_url_like_paths(self):
+        """Test paths that look like URLs."""
+        # These might appear in remote storage contexts
+        assert get_file_type("s3://bucket/file.txt") == ".txt"
+        assert get_file_type("https://example.com/data.csv") == ".csv"
+
+    def test_trailing_slash(self):
+        """Test paths with trailing slashes."""
+        # Directories - should handle gracefully
+        assert get_file_type("/path/to/dir/") is None
+        assert get_file_type("dir/") is None
+
+
+class TestParseShellTool:
+    """Test shell command parsing."""
+
+    def test_simple_command(self):
+        """Test basic command extraction."""
+        tool, params = parse_shell_tool("samtools sort -@ 4 input.bam")
+        assert tool == "samtools"
+        assert params == "sort -@ 4 input.bam"
+
+    def test_command_with_interpreter(self):
+        """Test that interpreters like python are skipped."""
+        tool, params = parse_shell_tool("python scripts/process.py --input data")
+        assert tool == "scripts/process.py"
+        assert "--input" in params
+
+    def test_command_with_python3(self):
+        """Test python3 interpreter skipping."""
+        tool, params = parse_shell_tool("python3 script.py arg1 arg2")
+        assert tool == "script.py"
+        assert params == "arg1 arg2"
+
+    def test_empty_command(self):
+        """Test empty string handling."""
+        tool, params = parse_shell_tool("")
+        assert tool is None
+        assert params == ""
+
+    def test_comment_only(self):
+        """Test command with only comments."""
+        tool, params = parse_shell_tool("# This is a comment")
+        assert tool is None
+        assert params == ""
+
+    def test_multiline_with_comments(self):
+        """Test multiline command with comments."""
+        cmd = """# Comment line
+        samtools view -b input.sam"""
+        tool, params = parse_shell_tool(cmd)
+        assert tool == "samtools"
+        assert "view" in params
+
+    def test_only_interpreter(self):
+        """Test command that is only an interpreter."""
+        tool, params = parse_shell_tool("python3")
+        assert tool is None
+        assert params == ""
+
+    def test_bash_script(self):
+        """Test bash command parsing."""
+        tool, params = parse_shell_tool("bash script.sh arg1")
+        assert tool == "script.sh"
+        assert params == "arg1"
+
+    def test_multiline_complex(self):
+        """Test complex multiline shell command."""
+        cmd = """# Index the genome
+bwa index {input}
+
+# Map reads
+bwa mem {input} {output}"""
+        tool, params = parse_shell_tool(cmd)
+        assert tool == "bwa"
+        assert params == "index {input}"


### PR DESCRIPTION
This is an experimental feature that enables submission of benchmark information to a remote telemetry collector, after collective discussion on specs on Mar 11th and feedback from @johanneskoester @cmeesters and @tedil 

The submission protocol, as long as the data model and general implementation concerns is [under active discussion](https://github.com/btraven00/psb/blob/main/docs/spec.md#f-open-questions). An open collector implementation for testing, [written in go](https://github.com/btraven00/psb), is deployed at https://psb.biofx.dev. Examples including workflow, tool and command annotations with the proposed syntax can be found in the [examples folder of the psb repo](https://github.com/btraven00/psb/tree/main/examples).

Below there's a screenshot of the record view of the public collector.

<img width="1580" height="802" alt="image" src="https://github.com/user-attachments/assets/9b7d5424-3e7b-48dd-b6fd-ddb869a3c96d" />


### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
