### PR TITLE
fix: somewhat shorter announce message 

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -32,8 +32,8 @@ jobs:
             
             Give us some time, and you will automatically find it on #Bioconda and #Pypi.
             
-            If you want to discuss the release, you will find the maintainer here on Mastodon!
-            @johanneskoester@fosstodon.org
+            The maintainer is here on Mastodon -
+            @johanneskoester@fosstodon.org .
             
             If you discover any issues, please report them on {{ issue_url }}.
 


### PR DESCRIPTION
Harmonized with the slurm executor plugin. This is a first step to harmonize post message for the Mastodon announcement robot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release announcement messaging text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->