### PR TITLE
fix: consider checkpoint jobs during update_needrun

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1439,7 +1439,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
 
             if is_forced(job):
                 reason.forced = True
-            elif job in self.targetjobs:
+            elif job in self.targetjobs or job.is_checkpoint:
                 if not job.has_products(include_logfiles=False):
                     if job.input:
                         if job.rule.norun:

--- a/tests/test_checkpoint_missing_output/Snakefile
+++ b/tests/test_checkpoint_missing_output/Snakefile
@@ -1,0 +1,34 @@
+checkpoint checkpoint_test:
+    output:
+        "output/test_{n}.txt"
+    shell:
+        '''
+        echo {wildcards.n} > {output[0]}
+        '''
+
+def aggregate_input(wildcards):
+    max_value = None
+    selected_file = None
+    for i in range(10):
+        check = checkpoints.checkpoint_test.get(n=i)
+        curr_file = check.output[0]
+        with open(curr_file) as f:
+            n = int(f.read().strip())
+        if max_value is None or n > max_value:
+            max_value = n
+            selected_file = curr_file
+    return selected_file
+
+rule aggregate:
+    input:
+        aggregate_input
+    output:
+        "output/selection.txt"
+    shell:
+        '''
+        cp {input[0]} {output[0]}
+        '''
+
+rule all:
+    default_target: True
+    input: "output/selection.txt"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1629,6 +1629,24 @@ def test_checkpoint_rerun():
         assert f.read().strip() == "1"
 
 
+def test_checkpoint_missing_output():
+    """test for issue 3879"""
+    test_dir = dpath("test_checkpoint_missing_output")
+    tmpdir = run(test_dir, cleanup=False, check_results=False)
+
+    try:
+        missing_file = Path(tmpdir) / "output" / "test_4.txt"
+        os.remove(missing_file)
+
+        run(test_dir, tmpdir=tmpdir, cleanup=False, check_results=False)
+
+        assert (
+            missing_file.exists()
+        ), "The missing checkpoint output was not regenerated."
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
+
+
 def test_issue1092():
     run(dpath("test_issue1092"))
 


### PR DESCRIPTION
Resolves #3879

Not sure this is the correct solution, though (might have unforeseeable side consequences, though I believe this should be fine, may just cause some more I/O overhead for checking the checkpoint's dependencies).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint job handling to ensure they are properly considered alongside target jobs during workflow execution evaluation, affecting how missing outputs and updated inputs are handled.

* **Tests**
  * Added test to verify that missing checkpoint outputs are correctly regenerated when workflows are re-run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->