### PR TITLE
chore: add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pixi-format
+        name: Run formatter
+        entry: pixi run format
+        language: system
+        types: [python]
+        pass_filenames: false
+


### PR DESCRIPTION
This PR adds a .pre-commit-config.yaml that just calls `pixi format` for now to automatically run pixi format upon commit when any python files have been touched (and pre-commit is installed and enabled, of course).

TODO:
- [ ] document this in contribution guidelines

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration for code formatting automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->