### PR TITLE
feat: add support for quarto in script directive

### DIFF
--- a/src/snakemake/script/__init__.py
+++ b/src/snakemake/script/__init__.py
@@ -1400,6 +1400,190 @@ class HyScript(PythonScript):
         self._execute_cmd("hy {fname:q}", fname=fname)
 
 
+class QuartoScript(ScriptBase):
+    @staticmethod
+    def generate_preamble(
+        path,
+        cache_path: typing.Optional[str],
+        source,
+        basedir,
+        input_,
+        output,
+        params,
+        wildcards,
+        threads,
+        resources,
+        log,
+        config,
+        rulename,
+        conda_env,
+        container_img,
+        singularity_args,
+        env_modules,
+        bench_record,
+        jobid,
+        bench_iteration,
+        cleanup_scripts,
+        shadow_dir,
+        is_local,
+        preamble_addendum="",
+    ) -> str:
+
+        if (match := re.search(r"(?<=```{)[^,\s}]+", source)):
+            engine = match.group()
+        else:
+            logger.warning(
+                f"No code-block found in Quarto script {path}.",
+                "Unable to determine engine for rendering."
+            )
+            engine = None
+
+        match engine:
+            case "python":
+                preamble = PythonScript.generate_preamble(
+                    path,
+                    cache_path,
+                    source,
+                    basedir,
+                    input,
+                    output,
+                    params,
+                    wildcards,
+                    threads,
+                    resources,
+                    log,
+                    config,
+                    rulename,
+                    conda_env,
+                    container_img,
+                    singularity_args,
+                    env_modules,
+                    bench_record,
+                    jobid,
+                    bench_iteration,
+                    cleanup_scripts,
+                    shadow_dir,
+                    is_local,
+                    preamble_addendum,
+                )
+            case "r":
+                preamble = RScript.generate_preamble(
+                    path,
+                    source,
+                    basedir,
+                    input,
+                    output,
+                    params,
+                    wildcards,
+                    threads,
+                    resources,
+                    log,
+                    config,
+                    rulename,
+                    conda_env,
+                    container_img,
+                    singularity_args,
+                    env_modules,
+                    bench_record,
+                    jobid,
+                    bench_iteration,
+                    cleanup_scripts,
+                    shadow_dir,
+                    preamble_addendum,
+                )
+            case "julia":
+                preamble = JuliaScript.generate_preamble(
+                    path,
+                    cache_path,
+                    source,
+                    basedir,
+                    input,
+                    output,
+                    params,
+                    wildcards,
+                    threads,
+                    resources,
+                    log,
+                    config,
+                    rulename,
+                    conda_env,
+                    container_img,
+                    singularity_args,
+                    env_modules,
+                    bench_record,
+                    jobid,
+                    bench_iteration,
+                    cleanup_scripts,
+                    shadow_dir,
+                    is_local,
+                    preamble_addendum,
+                )
+            case _:
+                preamble = None
+
+        if engine and preamble:
+            return textwrap.dedent(
+                """
+                ```{{{}}}
+                #| echo: false
+                #| warning: false
+
+                {}
+                ```
+                """.format(
+                    engine,
+                    preamble
+                )
+            )
+        return ""
+
+
+    def get_preamble(self) -> str:
+        return QuartoScript.generate_preamble(
+            self.path,
+            self.cache_path,
+            self.source,
+            self.basedir,
+            self.input,
+            self.output,
+            self.params,
+            self.wildcards,
+            self.threads,
+            self.resources,
+            self.log,
+            self.config,
+            self.rulename,
+            self.conda_env,
+            self.container_img,
+            self.singularity_args,
+            self.env_modules,
+            self.bench_record,
+            self.jobid,
+            self.bench_iteration,
+            self.cleanup_scripts,
+            self.shadow_dir,
+            self.is_local,
+        )
+
+    def write_script(self, preamble, fd):
+        # Insert Snakemake object after the Quarto header
+        pos = next(itertools.islice(re.finditer(r"---\n", self.source), 1, 2)).start() + 3
+        fd.write(str.encode(self.source[:pos]))
+        fd.write(preamble.encode())
+        fd.write(self.source[pos:].encode())
+
+    def execute_script(self, fname, edit=False):
+        if len(self.output) != 1:
+            raise WorkflowError(
+                "Quarto scripts (.qmd) may only have a single output file."
+            )
+        self._execute_cmd(
+            "quarto render {fname:q} --quiet --metadata embed-resources:true --execute-param qmd:{fname} --output - 1> {out}"
+            fname=fname,
+            out=self.output[0],
+        )
+
+
 def strip_re(regex: Pattern, s: str) -> Tuple[str, str]:
     """Strip a substring matching a regex from a string and return the stripped part
     and the remainder of the original string.
@@ -1466,6 +1650,8 @@ def get_language(source_file, source):
         language = "xonsh"
     elif filename.endswith(".hy"):
         language = "hy"
+    elif filename.endswith(".qmd"):
+        language = "quarto"
 
     # detect kernel language for Jupyter Notebooks
     if language == "jupyter":
@@ -1532,10 +1718,11 @@ def script(
         "bash": BashScript,
         "xonsh": XonshScript,
         "hy": HyScript,
+        "quarto": QuartoScript,
     }.get(language, None)
     if exec_class is None:
         raise ValueError(
-            "Script must be one of the following filetypes: [.py .R .Rmd .jl .rs .sh .xsh .hy]"
+            "Script must be one of the following filetypes: [.py .R .Rmd .jl .rs .sh .xsh .hy .qmd]"
         )
 
     executor = exec_class(

--- a/src/snakemake/script/__init__.py
+++ b/src/snakemake/script/__init__.py
@@ -1429,12 +1429,12 @@ class QuartoScript(ScriptBase):
         preamble_addendum="",
     ) -> str:
 
-        if (match := re.search(r"(?<=```{)[^,\s}]+", source)):
+        if match := re.search(r"(?<=```{)[^,\s}]+", source):
             engine = match.group()
         else:
             logger.warning(
                 f"No code-block found in Quarto script {path}.",
-                "Unable to determine engine for rendering."
+                "Unable to determine engine for rendering.",
             )
             engine = None
 
@@ -1522,21 +1522,15 @@ class QuartoScript(ScriptBase):
                 preamble = None
 
         if engine and preamble:
-            return textwrap.dedent(
-                """
+            return textwrap.dedent("""
                 ```{{{}}}
                 #| echo: false
                 #| warning: false
 
                 {}
                 ```
-                """.format(
-                    engine,
-                    preamble
-                )
-            )
+                """.format(engine, preamble))
         return ""
-
 
     def get_preamble(self) -> str:
         return QuartoScript.generate_preamble(
@@ -1567,7 +1561,9 @@ class QuartoScript(ScriptBase):
 
     def write_script(self, preamble, fd):
         # Insert Snakemake object after the Quarto header
-        pos = next(itertools.islice(re.finditer(r"---\n", self.source), 1, 2)).start() + 3
+        pos = (
+            next(itertools.islice(re.finditer(r"---\n", self.source), 1, 2)).start() + 3
+        )
         fd.write(str.encode(self.source[:pos]))
         fd.write(preamble.encode())
         fd.write(self.source[pos:].encode())
@@ -1578,7 +1574,7 @@ class QuartoScript(ScriptBase):
                 "Quarto scripts (.qmd) may only have a single output file."
             )
         self._execute_cmd(
-            "quarto render {fname:q} --quiet --metadata embed-resources:true --execute-param qmd:{fname} --output - 1> {out}"
+            "quarto render {fname:q} --quiet --metadata embed-resources:true --execute-param qmd:{fname} --output - 1> {out}",
             fname=fname,
             out=self.output[0],
         )

--- a/src/snakemake/script/__init__.py
+++ b/src/snakemake/script/__init__.py
@@ -852,60 +852,114 @@ class RMarkdown(ScriptBase):
 
 
 class JuliaScript(ScriptBase):
+    @staticmethod
+    def generate_preamble(
+        path,
+        cache_path: typing.Optional[str],
+        source,
+        basedir,
+        input_,
+        output,
+        params,
+        wildcards,
+        threads,
+        resources,
+        log,
+        config,
+        rulename,
+        conda_env,
+        container_img,
+        singularity_args,
+        env_modules,
+        bench_record,
+        jobid,
+        bench_iteration,
+        cleanup_scripts,
+        shadow_dir,
+        is_local,
+        preamble_addendum="",
+    ) -> str:
+        return textwrap.dedent("""
+        ######## snakemake preamble start (automatically inserted, do not edit) ########
+        struct Snakemake
+            input::Dict
+            output::Dict
+            params::Dict
+            wildcards::Dict
+            threads::Int64
+            log::Dict
+            resources::Dict
+            config::Dict
+            rule::String
+            bench_iteration
+            scriptdir::String
+            #source::Any
+        end
+        snakemake = Snakemake(
+            {}, #input::Dict
+            {}, #output::Dict
+            {}, #params::Dict
+            {}, #wildcards::Dict
+            {}, #threads::Int64
+            {}, #log::Dict
+            {}, #resources::Dict
+            {}, #config::Dict
+            {}, #rule::String
+            {}, #bench_iteration::Int64
+            {}, #scriptdir::String
+            #, #source::Any
+        )
+        {preamble_addendum}
+
+        ######## snakemake preamble end #########
+        """).format(
+            JuliaEncoder.encode_namedlist(input_),
+            JuliaEncoder.encode_namedlist(output),
+            JuliaEncoder.encode_namedlist(params),
+            JuliaEncoder.encode_namedlist(wildcards),
+            threads,
+            JuliaEncoder.encode_namedlist(log),
+            JuliaEncoder.encode_namedlist(
+                {
+                    name: value
+                    for name, value in resources.items()
+                    if name != "_cores" and name != "_nodes"
+                }
+            ),
+            JuliaEncoder.encode_dict(config),
+            JuliaEncoder.encode_value(rulename),
+            JuliaEncoder.encode_value(bench_iteration),
+            JuliaEncoder.encode_value(
+                path.get_basedir().get_path_or_uri(secret_free=True)
+            ),
+            preamble_addendum=preamble_addendum,
+        )
+
     def get_preamble(self):
-        return textwrap.dedent(
-            """
-                ######## snakemake preamble start (automatically inserted, do not edit) ########
-                struct Snakemake
-                    input::Dict
-                    output::Dict
-                    params::Dict
-                    wildcards::Dict
-                    threads::Int64
-                    log::Dict
-                    resources::Dict
-                    config::Dict
-                    rule::String
-                    bench_iteration
-                    scriptdir::String
-                    #source::Any
-                end
-                snakemake = Snakemake(
-                    {}, #input::Dict
-                    {}, #output::Dict
-                    {}, #params::Dict
-                    {}, #wildcards::Dict
-                    {}, #threads::Int64
-                    {}, #log::Dict
-                    {}, #resources::Dict
-                    {}, #config::Dict
-                    {}, #rule::String
-                    {}, #bench_iteration::Int64
-                    {}, #scriptdir::String
-                    #, #source::Any
-                )
-                ######## snakemake preamble end #########
-                """.format(
-                JuliaEncoder.encode_namedlist(self.input),
-                JuliaEncoder.encode_namedlist(self.output),
-                JuliaEncoder.encode_namedlist(self.params),
-                JuliaEncoder.encode_namedlist(self.wildcards),
-                JuliaEncoder.encode_value(self.threads),
-                JuliaEncoder.encode_namedlist(self.log),
-                JuliaEncoder.encode_namedlist(
-                    {
-                        name: value
-                        for name, value in self.resources.items()
-                        if name != "_cores" and name != "_nodes"
-                    }
-                ),
-                JuliaEncoder.encode_dict(self.config),
-                JuliaEncoder.encode_value(self.rulename),
-                JuliaEncoder.encode_value(self.bench_iteration),
-                JuliaEncoder.encode_value(
-                    self.path.get_basedir().get_path_or_uri(secret_free=True)
-                ),
-            )
+        return JuliaScript.generate_preamble(
+            self.path,
+            self.cache_path,
+            self.source,
+            self.basedir,
+            self.input,
+            self.output,
+            self.params,
+            self.wildcards,
+            self.threads,
+            self.resources,
+            self.log,
+            self.config,
+            self.rulename,
+            self.conda_env,
+            self.container_img,
+            self.singularity_args,
+            self.env_modules,
+            self.bench_record,
+            self.jobid,
+            self.bench_iteration,
+            self.cleanup_scripts,
+            self.shadow_dir,
+            self.is_local,
         )
 
     def write_script(self, preamble, fd):


### PR DESCRIPTION
Resolves #3988 

Add support for [Quarto](quarto.org) in the script directive. This enables seamless integration of Quarto-based reports and analyses within Snakemake workflows.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding
