### PR TITLE
docs: Add note on profile and module usage

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -139,7 +139,9 @@ The default profile to use when no ``--profile`` argument is specified can also 
 e.g. by specifying ``export SNAKEMAKE_PROFILE=myprofile`` in your ``~/.bashrc`` or the system wide shell defaults means that the ``--profile`` flag can be omitted.
 In order unset the profile defined by this environment variable for individual runs without specifying and alternative profile you can provide the special value ``none``, i.e. ``--profile none``.
 
-.. note:: Note when using modules, the profile will not be propagated to the main workflow, which means that a profile has to be specified for the main workflow as well, if needed.
+.. note::
+
+  When using modules, the profile will not be propagated to the main workflow, which means that a profile has to be specified for the main workflow as well, if needed.
 
 The profile folder is expected to contain a configuration file that file that defines default values for the Snakemake command line arguments.
 The file has to be named ``config.vX+.yaml`` with ``X`` denoting the minimum supported Snakemake major version (e.g. ``config.v8+.yaml``).


### PR DESCRIPTION
This PR adds a note to the documentation with the information that profiles of modules are not propagated to the main workflow. Related to #3470.

### QC

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure

I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that when running workflows that use modules, the profile set for a module is not propagated to the main workflow; the main workflow’s profile must be specified explicitly.
  * Added this note in relevant execution and profiles sections for clearer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->