### PR TITLE
fix: correctly register module pathvars of the module of each rule

### DIFF
--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -146,7 +146,7 @@ class Rule(RuleInterface):
 
     @property
     def pathvars(self) -> Pathvars:
-        return self._pathvars or self.workflow.pathvars
+        return self._pathvars
 
     @pathvars.setter
     def pathvars(self, pathvars: Pathvars) -> None:

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1857,6 +1857,8 @@ class Workflow(WorkflowExecutorInterface):
             if ruleinfo.pathvars:
                 rule.pathvars = Pathvars.from_rule(ruleinfo.pathvars)
                 rule.pathvars.update(self.pathvars)
+            else:
+                rule.pathvars = self.pathvars
 
             if ruleinfo.wildcard_constraints:
                 rule.set_wildcard_constraints(

--- a/tests/test_pathvars_modules/module/Snakefile
+++ b/tests/test_pathvars_modules/module/Snakefile
@@ -1,7 +1,21 @@
 pathvars:
     results="results/custom",
 
+
+def infunc(wildcards):
+    return "<results>/testin.txt"
+
+
 rule a:
+    output:
+        "<results>/testin.txt"
+    shell:
+        "touch {output}"
+
+
+rule b:
+    input:
+        infunc
     output:
         "<results>/text.txt"
     shell:


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path variable resolution by centralizing fallback logic; rules now consistently inherit path variables from the workflow when not explicitly specified.

* **Tests**
  * Added tests for path variable handling in module workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->