### PR TITLE
feat: add temp to default pathvars

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -362,7 +362,7 @@ The values of pathvars can thereby even contain wildcards themselves.
 Pathvar defaults
 """"""""""""""""
 
-By default, Snakemake offers the pathvars ``results``, ``resources``, ``logs``, ``benchmarks``.
+By default, Snakemake offers the pathvars ``results``, ``resources``, ``temp``, ``logs``, ``benchmarks``.
 Each of them is set to its respective name (i.e. the output file ``"<results>/processed/{sample}.txt"`` will be interpreted as ``"results/processed/{sample}.txt"``).
 
 Pathvar definition

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -362,7 +362,7 @@ The values of pathvars can thereby even contain wildcards themselves.
 Pathvar defaults
 """"""""""""""""
 
-By default, Snakemake offers the pathvars ``results``, ``stats``, ``temp``, ``resources``, ``logs``, ``benchmarks``.
+By default, Snakemake offers the pathvars ``results``, ``stats``, ``reports``, ``temp``, ``resources``, ``logs``, ``benchmarks``.
 Each of them is set to its respective name (i.e. the output file ``"<results>/processed/{sample}.txt"`` will be interpreted as ``"results/processed/{sample}.txt"``).
 
 Pathvar definition

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -362,7 +362,7 @@ The values of pathvars can thereby even contain wildcards themselves.
 Pathvar defaults
 """"""""""""""""
 
-By default, Snakemake offers the pathvars ``results``, ``resources``, ``temp``, ``logs``, ``benchmarks``.
+By default, Snakemake offers the pathvars ``results``, ``stats``, ``temp``, ``resources``, ``logs``, ``benchmarks``.
 Each of them is set to its respective name (i.e. the output file ``"<results>/processed/{sample}.txt"`` will be interpreted as ``"results/processed/{sample}.txt"``).
 
 Pathvar definition

--- a/src/snakemake/pathvars.py
+++ b/src/snakemake/pathvars.py
@@ -64,10 +64,11 @@ class Pathvars:
     def with_defaults(cls) -> "Pathvars":
         items = {
             "results": "results",
+            "stats": "stats",
+            "temp": "temp",
             "resources": "resources",
             "logs": "logs",
             "benchmarks": "benchmarks",
-            "temp": "temp",
         }
         return cls._from_raw(
             items=items,

--- a/src/snakemake/pathvars.py
+++ b/src/snakemake/pathvars.py
@@ -67,6 +67,7 @@ class Pathvars:
             "resources": "resources",
             "logs": "logs",
             "benchmarks": "benchmarks",
+            "temp", "temp",
         }
         return cls._from_raw(
             items=items,

--- a/src/snakemake/pathvars.py
+++ b/src/snakemake/pathvars.py
@@ -65,6 +65,7 @@ class Pathvars:
         items = {
             "results": "results",
             "stats": "stats",
+            "reports": "reports",
             "temp": "temp",
             "resources": "resources",
             "logs": "logs",

--- a/src/snakemake/pathvars.py
+++ b/src/snakemake/pathvars.py
@@ -67,7 +67,7 @@ class Pathvars:
             "resources": "resources",
             "logs": "logs",
             "benchmarks": "benchmarks",
-            "temp", "temp",
+            "temp": "temp",
         }
         return cls._from_raw(
             items=items,


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "stats", "reports", and "temp" as new default path variables alongside results, resources, logs, and benchmarks for use in Snakemake workflows.

* **Documentation**
  * Updated docs to list the expanded set of default path variables and their mapping to output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->