### PR TITLE
fix: ensure that the snakemake-wrappers repo is properly cached when --wrapper-prefix is not specified

### DIFF
--- a/src/snakemake/cli.py
+++ b/src/snakemake/cli.py
@@ -1447,7 +1447,6 @@ def get_argument_parser(profiles=None):
     )
     group_behavior.add_argument(
         "--wrapper-prefix",
-        default="https://github.com/snakemake/snakemake-wrappers/raw/",
         help="URL prefix for wrapper directive. Set this to use your fork or a local clone of the repository, "
         "e.g., use a git URL like `git+file://path/to/your/local/clone@`.",
     )


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified the default behavior of the `--wrapper-prefix` command-line argument. Users who previously relied on implicit defaults may need to explicitly specify this option or check downstream configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->