### PR TITLE
chore: fix to using a static, release-please managed version string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snakemake"
-dynamic = ["version"]
+version = "9.17.3"
 description = "Workflow management system to create reproducible and scalable data analyses"
 readme = { content-type = "text/markdown", text = """
   Snakemake is a workflow management system that aims to reduce the

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ Assets.deploy()
 
 setup(
     name="snakemake",
-    use_scm_version=True,
     package_data={
         "snakemake": [
             "assets/data/**/*",

--- a/src/snakemake/__init__.py
+++ b/src/snakemake/__init__.py
@@ -5,7 +5,7 @@ __license__ = "MIT"
 
 import sys
 
-from snakemake._version import version as __version__
+__version__ = "9.17.2"
 
 PIP_DEPLOYMENTS_PATH = ".snakemake/pip-deployments"
 

--- a/src/snakemake/common/__init__.py
+++ b/src/snakemake/common/__init__.py
@@ -247,7 +247,7 @@ def num_if_possible(s):
 
 
 def get_last_stable_version():
-    return __version__.split("+")[0]
+    return __version__
 
 
 def get_container_image():

--- a/src/snakemake/report/html_reporter/data/packages.py
+++ b/src/snakemake/report/html_reporter/data/packages.py
@@ -18,7 +18,7 @@ def get_packages():
     return Packages(
         {
             "snakemake": Package(
-                version=snakemake.__version__.split("+")[0],
+                version=snakemake.__version__,
                 license_path="snakemake/LICENSE.md",
             ),
             "pygments": Package(


### PR DESCRIPTION
Rationale: simpler, less implicitly and more robust (github recently managed to break the version retrieval in github actions).

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version management configuration to use fixed version string instead of dynamic version detection.
  * Modified version reporting in generated reports to display the complete version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->