### PR TITLE
fix: skip pss collection on platforms without pss support

### DIFF
--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -322,6 +322,7 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
 
         # Memory measurements
         rss, vms, uss, pss = 0, 0, 0, 0
+        check_pss = True
         # I/O measurements
         io_in, io_out = 0, 0
         check_io = True
@@ -354,7 +355,11 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
                     rss += meminfo.rss
                     vms += meminfo.vms
                     uss += meminfo.uss
-                    pss += meminfo.pss
+                    if check_pss:
+                        if hasattr(meminfo, "pss"):
+                            pss += meminfo.pss
+                        else:
+                            check_pss = False
 
                     if check_io:
                         try:
@@ -379,7 +384,10 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
             rss /= 1024 * 1024
             vms /= 1024 * 1024
             uss /= 1024 * 1024
-            pss /= 1024 * 1024
+            if check_pss:
+                pss /= 1024 * 1024
+            else:
+                pss = None
 
             if check_io:
                 io_in /= 1024 * 1024
@@ -399,7 +407,8 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
             self.bench_record.max_rss = max(self.bench_record.max_rss or 0, rss)
             self.bench_record.max_vms = max(self.bench_record.max_vms or 0, vms)
             self.bench_record.max_uss = max(self.bench_record.max_uss or 0, uss)
-            self.bench_record.max_pss = max(self.bench_record.max_pss or 0, pss)
+            if pss is not None:
+                self.bench_record.max_pss = max(self.bench_record.max_pss or 0, pss)
 
             self.bench_record.io_in = io_in
             self.bench_record.io_out = io_out


### PR DESCRIPTION
Fixes #3665.

**Root cause:** `psutil.Process.memory_full_info()` only includes the `pss` field on Linux. On Windows the named tuple lacks this attribute, so `meminfo.pss` raises `AttributeError`. The outer `except AttributeError` at line 317 catches it, but this discards *all* benchmark data (RSS, VMS, USS, CPU, IO) for the entire run — not just PSS.

**Fix:** Guard `pss` access with `hasattr(meminfo, "pss")`, mirroring the existing `check_io` pattern. When `pss` is unavailable, the field stays `None` so the benchmark output reports `NA` instead of a misleading `0`.

## Changes
- `src/snakemake/benchmark.py`: guard `pss` access, report `None` when unavailable

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure

I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced benchmark resource measurement to properly detect and handle systems where PSS (Proportional Set Size) is unavailable, ensuring accurate reporting and preventing measurement errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->