### PR TITLE
docs: add post-deploy example that ensures `.Renviron` is ignored for R package installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Documentation
 
-* update installation instuctions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
+* update installation instructions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
 
 ## [9.18.2](https://github.com/snakemake/snakemake/compare/v9.18.1...v9.18.2) (2026-03-26)
 

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -376,13 +376,16 @@ If no shebang line like above (``#!env bash``) is provided, the script will be e
 
 Also, make sure that you do not accidentally inherit any environment variables that set installation paths.
 This can for example be the case if you set up ``$R_LIBS_USER`` in a ``.Renviron`` file (usually in your ``$HOME`` directory), which automatically gets `loaded on every startup of <https://rstats.wtf/r-startup.html>`_ ``R`` and ``Rscript``.
-To make sure that any package installations in the ``.post-deploy.sh`` do not go into such a user ``R`` library path, but into the conda environment, run the installation with the ``--no-environ`` flag, for example:
+To make sure that any package installations in the ``.post-deploy.sh`` do not go into such a user ``R`` library path, but into the conda environment, run the installation with the ``--no-environ`` flag.
+And if you use the ``R`` package ``remotes`` to install software into your conda environment, also make sure that it emits an error upon failure (instead of just a warning) `by setting the respective environment variable <https://remotes.r-lib.org/#environment-variables>`_.
+Otherwise ``Rscript`` reports success and the conda environment installation succeeds, even if the package installation in the ``Rscript`` statement failed.
+Altogether, the recommendation for installing ``R`` packages not available via conda into a conda environment, is:
 
 .. code-block:: bash
 
     #!env bash
     set -o pipefail
-    Rscript --no-environ -e 'remotes::install_github("some-org/RPackageNotOnConda", ref = "v1.3.2", upgrade = "never")'
+    Rscript --no-environ -e 'Sys.setenv(R_REMOTES_NO_ERRORS_FROM_WARNINGS="false"); remotes::install_github("some-org/RPackageNotOnConda", ref = "v1.3.2", upgrade = "never")'
 
 .. _conda_named_env:
 

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -374,6 +374,16 @@ Importantly, if the script relies on certain shell specific syntax, (e.g. `set -
 
 If no shebang line like above (``#!env bash``) is provided, the script will be executed with the ``sh`` command.
 
+Also, make sure that you do not accidentally inherit any environment variables that set installation paths.
+This can for example be the case if you set up ``$R_LIBS_USER`` in a ``.Renviron`` file (usually in your ``$HOME`` directory), which automatically gets `loaded on every startup of <https://rstats.wtf/r-startup.html>`_ ``R`` and ``Rscript``.
+To make sure that any package installations you do in the ``.post-deploy.sh`` do not go into such a user ``R`` library path, but into the conda environment, run the installation with the ``--no-environ`` flag, for example:
+
+.. code-block:: bash
+
+    #!env bash
+    set -o pipefail
+    Rscript --no-environ -e 'remotes::install_github("some-org/RPackageNotOnConda", ref = "v1.3.2", upgrade = "never")'
+
 .. _conda_named_env:
 
 -----------------------------------------

--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -376,7 +376,7 @@ If no shebang line like above (``#!env bash``) is provided, the script will be e
 
 Also, make sure that you do not accidentally inherit any environment variables that set installation paths.
 This can for example be the case if you set up ``$R_LIBS_USER`` in a ``.Renviron`` file (usually in your ``$HOME`` directory), which automatically gets `loaded on every startup of <https://rstats.wtf/r-startup.html>`_ ``R`` and ``Rscript``.
-To make sure that any package installations you do in the ``.post-deploy.sh`` do not go into such a user ``R`` library path, but into the conda environment, run the installation with the ``--no-environ`` flag, for example:
+To make sure that any package installations in the ``.post-deploy.sh`` do not go into such a user ``R`` library path, but into the conda environment, run the installation with the ``--no-environ`` flag, for example:
 
 .. code-block:: bash
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deployment guidance warning that post-deployment scripts can inherit user-level R environment settings (e.g., user library paths). Includes best practices and a concrete example using Rscript --no-environ to ensure package installs target the intended environment, and guidance to force failures on install errors to avoid silent install issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->