### PR TITLE
fix: Flush global log handlers in LoggerManager.stop()

### DIFF
--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -738,13 +738,27 @@ class LoggerManager:
 
     def stop(self) -> None:
         """Shut down logging, removing and closing all log handlers."""
+
         # Stop the queue listener (if it exists) - this finishes processing the remaining records
         # and waits for the thread to exit.
         if self.queue_listener is not None and self.queue_listener._thread is not None:
             self.queue_listener.stop()
 
-        # Remove and close all handlers - this should mostly clean up the global logger instance.
+        # Flush and close plugin handlers (not attached directly to global logger instance)
+        for handler in self.plugin_handlers:
+            try:
+                handler.flush()
+            except Exception:
+                pass
+            handler.close()
+
+        # Flush, remove and close all handlers on the global logger instance (this should mostly
+        # reset it).
         for handler in list(self.logger.handlers):
+            try:
+                handler.flush()
+            except Exception:
+                pass
             self.logger.removeHandler(handler)
             handler.close()
 


### PR DESCRIPTION
- Call the `flush()` and `close()` methods of all plugin handlers in `LoggerManager.stop()` so they process any remaining records and properly release any resources. This does not otherwise happen because they are attached to the queue listener instead of directly to the global `Logger` instance. Do it after the queue listener is flushed so that it sends any remaining records to them.
- Also adds calls to `flush()` before shutting down handlers directly attached to the logger (which would be the default file and stream handlers).
- Also wraps all calls to `flush()` in `try/except` and ignores errors. This is how the standard library `logging.shudown()` does it, not 100% sure if it's completely necessary but doesn't seem like it can hurt much. Possibly a warning should be generated from any errors to assist in plugin debugging.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging shutdown so all attached log handlers are flushed and then removed/closed during shutdown, leading to more reliable cleanup of logging output and resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakemake/pull/4143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->