### PR TITLE
fix: suppress duplicate SpawnedJobError tracebacks in local executor

### DIFF
--- a/src/snakemake/executors/local.py
+++ b/src/snakemake/executors/local.py
@@ -264,21 +264,19 @@ class Executor(RealExecutor):
         try:
             ex = future.exception()
             if ex is not None:
-                print_exception(ex, self.workflow.linemaps)
-                self.report_job_error(job_info)
-            else:
-                self.report_job_success(job_info)
+                raise ex
+            self.report_job_success(job_info)
         except _ProcessPoolExceptions:
             self.handle_job_error(job_info.job)
             # no error callback, just silently ignore the interrupt as the main scheduler is also killed
-        except SpawnedJobError:
+        except SpawnedJobError as ex:
             # don't print error message, this is done by the spawned subprocess
+            # but log the inner exception at debug level for diagnostics
+            if ex.__context__ is not None:
+                log_verbose_traceback(ex.__context__)
             self.report_job_error(job_info)
         except Exception as ex:
-            if self.workflow.output_settings.verbose or (
-                not job_info.job.is_group() and not job_info.job.is_shell
-            ):
-                print_exception(ex, self.workflow.linemaps)
+            print_exception(ex, self.workflow.linemaps)
             self.report_job_error(job_info)
 
     @property

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -269,7 +269,6 @@ def test_rule_failure(caplog: pytest.LogCaptureFixture):
             LogEvent.SHELLCMD: 3,
             LogEvent.RESOURCES_INFO: 2,
             LogEvent.JOB_STARTED: None,
-            LogEvent.ERROR: 3,
             LogEvent.JOB_ERROR: 6,
         },
     )


### PR DESCRIPTION
## Problem

When a spawned job (e.g. a `run:` block) fails, the parent process printed the `SpawnedJobError` / `concurrent.futures` / `asyncio` call chain — twice. This is pure infrastructure noise with no information useful to the user:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".../concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File ".../concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File ".../local.py", line 236, in cached_or_run
    self.workflow.async_run(self.acached_or_run(job, run_func, *args))
  File ".../workflow.py", line 268, in async_run
    return runner.run(coro)
  File ".../asyncio/runners.py", line 127, in run
    return self._loop.run_until_complete(task)
  File ".../asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
  File ".../local.py", line 253, in acached_or_run
    run_func(*args)
  File ".../local.py", line 233, in spawn_job
    raise SpawnedJobError()
snakemake.exceptions.SpawnedJobError
```

## Root cause

snakemake/snakemake#3309 changed `_callback` in `local.py` from:

```python
ex = future.exception()
if ex is not None:
    raise ex  # flows into except chain, SpawnedJobError caught silently
```

to:

```python
ex = future.exception()
if ex is not None:
    print_exception(ex, ...)  # unconditionally prints SpawnedJobError too
    self.report_job_error(job_info)
```

This made the `except SpawnedJobError` handler (which exists precisely to suppress printing) dead code. 

## Fix

- Restore the original `raise ex` pattern so exceptions flow through the `except` chain, allowing `except SpawnedJobError` to suppress the noisy chain as intended.
- In `except SpawnedJobError`, log the wrapped `CalledProcessError` via `log_verbose_traceback` (i.e. at debug level, visible with `--verbose`) so the failed command is still available for diagnostics.
- Remove the `verbose or not is_group` gate from `except Exception` so pipe/group job errors always print — preserving the fix from snakemake/snakemake#3309 without requiring `--verbose`.

## After

Normal output on job failure now only shows what the subprocess printed:

```
RuleException:
NameError in file "Snakefile", line 13:
name 'a' is not defined
  File "Snakefile", line 13, in __rule_1
```

With `--verbose`, the `CalledProcessError` (which command failed and with what exit code) is additionally shown once:

```
Full Traceback (most recent call last):
  File ".../local.py", line 231, in spawn_job
    subprocess.check_call(cmd, shell=True)
subprocess.CalledProcessError: Command '...' returned non-zero exit status 1.
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable and consistent exception reporting for failed jobs, with improved logging of nested/inner exceptions and unconditional display of exception tracebacks for clearer diagnostics.

* **Tests**
  * Updated logging-related test expectations to reflect the adjusted error reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->