### PR TITLE
feat: enable caching for named multi-output rules

### DIFF
--- a/docs/executing/caching.rst
+++ b/docs/executing/caching.rst
@@ -48,8 +48,7 @@ For workflows defining cache rules like this, it is enough to invoke Snakemake w
 
 without explicit rulenames listed.
 
-Note that only rules with just a single output file (or directory) or with :ref:`multiext output files <snakefiles-multiext>` are eligible for caching.
-The reason is that for other rules it would be impossible to unambiguously assign the output files to cache entries while being agnostic of the actual file names.
+Note that rules with multiple output files are only eligible for caching if they use :ref:`multiext output files <snakefiles-multiext>` or if all output files are named.
 Also note that the rules need to retrieve all their parameters via the ``params`` directive (except input files).
 It is not allowed to directly use ``wildcards``, ``config`` or any global variable in the shell command or script, because these are not captured in the hash (otherwise, reuse would be unnecessarily limited).
 

--- a/src/snakemake/caching/__init__.py
+++ b/src/snakemake/caching/__init__.py
@@ -53,24 +53,24 @@ class AbstractOutputFileCache:
                 apply_wildcards(job.rule.output[0].multiext_prefix, job.wildcards)
             )
             yield from ((f, f[prefix_len:]) for f in job.output)
-        else:
-            assert (
-                len(job.output) == 1
-            ), "bug: multiple output files in cacheable job but multiext not used for declaring them"
+        elif len(job.output) == 1:
             # It is crucial to distinguish cacheable objects by the file extension.
             # Otherwise, for rules that generate different output based on the provided
             # extension a wrong cache entry can be returned.
             # Another nice side effect is that the cached files become more accessible
             # because their extension is presented in the cache dir.
-            ext = Path(job.output[0]).suffix
-            yield (job.output[0], ext)
+            yield (job.output[0], Path(job.output[0]).suffix)
+        else:
+            for name, outputfile in job.output._allitems():
+                assert name is not None, "bug: multiple unnamed output files in cacheable job"
+                yield (outputfile, f"_{name}{Path(outputfile).suffix}")
 
     def raise_write_error(self, entry, exception=None):
         raise WorkflowError(
             "Given output cache entry {} ($SNAKEMAKE_OUTPUT_CACHE={}) is not writeable.".format(
                 entry, self.cache_location
             ),
-            *[exception],
+            exception,
         )
 
     def raise_read_error(self, entry, exception=None):
@@ -78,7 +78,7 @@ class AbstractOutputFileCache:
             "Given output cache entry {} ($SNAKEMAKE_OUTPUT_CACHE={}) is not readable.".format(
                 entry, self.cache_location
             ),
-            *[exception],
+            exception,
         )
 
     def raise_cache_miss_exception(self, job: Job):

--- a/src/snakemake/caching/__init__.py
+++ b/src/snakemake/caching/__init__.py
@@ -62,7 +62,9 @@ class AbstractOutputFileCache:
             yield (job.output[0], Path(job.output[0]).suffix)
         else:
             for name, outputfile in job.output._allitems():
-                assert name is not None, "bug: multiple unnamed output files in cacheable job"
+                assert (
+                    name is not None
+                ), "bug: multiple unnamed output files in cacheable job"
                 yield (outputfile, f"_{name}{Path(outputfile).suffix}")
 
     def raise_write_error(self, entry, exception=None):

--- a/src/snakemake/caching/rule.py
+++ b/src/snakemake/caching/rule.py
@@ -90,11 +90,13 @@ class RuleCache:
                 "Rules without output files cannot be cached.", rule=rule
             )
         if len(rule.output) > 1:
-            if not all(out.is_multiext for out in rule.output):
+            if not all(out.is_multiext for out in rule.output) and not all(
+                name is not None for name, _ in rule.output._allitems()
+            ):
                 raise WorkflowError(
                     "Rule is marked for between workflow caching but has multiple output files. "
-                    "This is only allowed if multiext() is used to declare them (see docs on between "
-                    "workflow caching).",
+                    "This is only allowed if multiext() is used to declare them, or if all "
+                    "output files are named (see docs on between workflow caching).",
                     rule=rule,
                 )
         if rule.workflow.workflow_settings.cache is None:

--- a/tests/test_cache_multioutput/Snakefile
+++ b/tests/test_cache_multioutput/Snakefile
@@ -1,7 +1,7 @@
 rule a:
     output:
-        "1.txt",
-        "2.txt",
+        first="1.txt",
+        second="2.txt",
     cache: True
     shell:
         "touch {output}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2273,7 +2273,8 @@ def test_default_target():
 
 
 def test_cache_multioutput():
-    run(dpath("test_cache_multioutput"), shouldfail=True)
+    os.environ["SNAKEMAKE_OUTPUT_CACHE"] = "cache"
+    run(dpath("test_cache_multioutput"), cache=["a"])
 
 
 @skip_on_windows


### PR DESCRIPTION
Between-workflow caching was previously restricted to rules with a single output file or
with `multiext()` outputs, using cache filenames like:
```
{cache_dir}/{hash}.{ext}          # single output or multiext.
```

This PR extends caching to also support rules where all output files are explicitly named,
using the output key to disambiguate cache entries:
```
{cache_dir}/{hash}_{key}.{ext}
```

For example, given:
```python
rule a:
    output:
        first="1.txt",
        second="2.txt",
    cache: True
    shell: "touch {output}"
```

the cache directory is populated as:
```
cache/
├── d5281ea3...b1_first.txt
└── d5281ea3...b1_second.txt
```

### Design

Three cases are now handled in `get_outputfiles()`:

1. **Single output** — unchanged, uses `.{ext}` suffix
2. **`multiext()` output** — unchanged, uses the suffix from the multiext prefix
3. **Named multi-output** — new, uses `_{key}.{ext}`

Unlike the previous attempt (#3948), this approach is **backward compatible**: existing
cache entries for single-output and multiext rules are unaffected since their filename
format does not change. Only the new named multi-output case uses a different scheme.

Rules with multiple unnamed outputs still fail validation with a clear error message.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Rules with multiple outputs are now eligible for between-workflow caching if all outputs are explicitly named, in addition to multiext-style outputs.

* **Documentation**
  * Updated caching eligibility docs to reflect the expanded multi-output cache support.

* **Tests**
  * Updated tests to exercise successful multi-output caching with named outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->