### PR TITLE
refactor: Remove Python < 3.11 compat

### DIFF
--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -16,10 +16,7 @@ from functools import partial
 
 from snakemake.pathvars import Pathvars
 
-try:
-    import re._constants as sre_constants
-except ImportError:  # python < 3.11
-    import sre_constants
+import re._constants as sre_constants
 
 from snakemake_interface_executor_plugins.settings import ExecMode
 


### PR DESCRIPTION
The project doesn't support Python < 3.11 and this if-else block is no longer necessary.

### QC
* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of regex-related error references to streamline compatibility logic.
  * No user-facing changes; behavior and public interfaces remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snakemake/snakemake/pull/4167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->