### PR TITLE
ci: Bump actions/upload-artifact from v5 to v7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
           pixi run --environment docs build-docs
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: docs-html
           path: docs/_build/html/
@@ -53,7 +53,7 @@ jobs:
           pixi run --environment docs build-apidocs
 
       - name: Upload documentation
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: apidocs-html
           path: apidocs/_build/html/


### PR DESCRIPTION
Resolves

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v5.

warning from "docs" and "apidocs" workflows.

https://github.com/snakemake/snakemake/actions/runs/24902709491

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build workflow dependencies to use latest versions.

**Note:** This release contains no user-facing changes. Updates were made to internal development infrastructure only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->