### PR TITLE
build: replace appdirs with platformdirs

### DIFF
--- a/apidocs/requirements.txt
+++ b/apidocs/requirements.txt
@@ -5,7 +5,7 @@ sphinx-autodoc-typehints
 docutils
 myst-parser
 configargparse
-appdirs
+platformdirs
 sphinxawesome-theme
 snakemake-interface-common
 snakemake-interface-executor-plugins

--- a/doc-environment.yml
+++ b/doc-environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - wrapt
   - pyyaml
   - requests
-  - appdirs
+  - platformdirs
   - docutils
   - throttler
   - configargparse

--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -15,7 +15,7 @@ Important environment variables
 -------------------------------
 
 Snakemake caches source files for performance and reproducibility.
-The location of this cache is determined by the `appdirs <https://github.com/ActiveState/appdirs>`_ package.
+The location of this cache is determined by the `platformdirs <https://platformdirs.readthedocs.io/>`_ package.
 If you want to change the location on a unix/linux system, you can define an override path via the environment variable ``XDG_CACHE_HOME``.
 
 .. user_manual-snakemake_options:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ sphinx-tabs
 docutils
 myst-parser
 configargparse
-appdirs
+platformdirs
 immutables
 sphinxawesome-theme
 snakemake-interface-common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "appdirs",
+  "platformdirs",
   "immutables",
   "configargparse",
   "connection_pool>=0.0.3",

--- a/src/snakemake/common/__init__.py
+++ b/src/snakemake/common/__init__.py
@@ -187,7 +187,7 @@ RULEFUNC_CONTEXT_MARKER = "__is_snakemake_rule_func"
 def get_appdirs():
     global APPDIRS
     if APPDIRS is None:
-        from appdirs import AppDirs
+        from platformdirs import AppDirs
 
         APPDIRS = AppDirs("snakemake", "snakemake")
     return APPDIRS


### PR DESCRIPTION
appdirs is no longer maintained upstream and has been removed from Debian and other distributions


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Replaced the `appdirs` package with `platformdirs` across documentation requirements, environment configuration, and source dependencies.
  * Updated documentation references to reflect the dependency change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->