### PR TITLE
fix(docs): remove misleading "touch"  example and explain checksum behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Documentation
 
-* update installation instuctions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
+* update installation instructions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
 
 ## [9.18.2](https://github.com/snakemake/snakemake/compare/v9.18.1...v9.18.2) (2026-03-26)
 

--- a/docs/project_info/faq.rst
+++ b/docs/project_info/faq.rst
@@ -686,6 +686,12 @@ Snakemake wants to rerun a rule that has been already executed, what can I do?
 Snakemake tries to ensure consistency between input and output files.
 This is based on file modification dates (input files may not be newer than output files of the same job), as well as execution metadata like the used software stack (e.g. conda env or container image), the non-file parameters, the set of input files, and the code of the rule.
 If Snakemake wants to rerun a rule that has been already executed, it is because one of these criteria has changed and detailed information about the reasoning is given in the job description of Snakemake's output as well as in the final summary at the end of a dry-run.
+However, there is one exception:
+For files that are smaller than a certain size,
+by default 1 MB, as controlled by ``--max-checksum-file-size``,
+Snakemake calculates a checksum of the file content and only reruns the rule if that checksum has changed,
+even if the timestamp of the input file is newer than the output file(s).
+To rely on file modification dates exclusively, set ``--max-checksum-file-size=0``.
 
 If your job is triggered by newer input files, but you are sure that the input files did not change on a semantic level (i.e. won't yield different results), you can mark those input files as ancient via the command line, or (usually better) via a :ref:`workflow specific profile <profiles>`.
 Let us assume you have the following rule from which such an unwanted job is triggered:

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -2110,7 +2110,10 @@ Ignoring timestamps
 -------------------
 
 For determining whether output files have to be re-created, Snakemake checks whether the file modification date (i.e. the timestamp) of any input file of the same job is newer than the timestamp of the output file.
-This behavior can be overridden by marking an input file as ``ancient``.
+Please note, however, that for small input files (of by default up to 1 MB, controlled by ``--max-checksum-file-size``),
+Snakemake instead records and compares file checksums and only reruns the rule if the input file checksum has changed,
+even if the timestamp of the input file is newer than the output file(s).
+This overall behavior can be overridden by marking an input file as ``ancient``.
 The timestamp of such files is ignored and always assumed to be older than any of the output files:
 
 .. code-block:: python

--- a/docs/tutorial/basics.rst
+++ b/docs/tutorial/basics.rst
@@ -140,8 +140,8 @@ Later, you will see how parallelization works.
 
 
 Note that, if you try to run that command a second time, Snakemake will not try to create ``mapped_reads/A.bam`` again.
-That is because it is already present in the file system.
-Snakemake will **only** re-run jobs if one of the input files is newer than one of the output files, if one of the input files will be updated by another job, or if the code and parameters of the job have changed.
+That is because the output is already present and Snakemake can determine that it is still consistent with the input files and the rule definition.
+If an input file changes, an output file is missing, or relevant parts of the workflow definition change, Snakemake will schedule the affected jobs again.
 
 
 .. tip::
@@ -204,19 +204,7 @@ This is not special Snakemake syntax.
 Bash_ is just applying its `brace expansion <https://tldp.org/LDP/Bash-Beginners-Guide/html/sect_03_04.html>`_ to the set ``{A,B}``, creating the given path for each element and separating the resulting paths by a whitespace.
 
 In both cases, you will see that Snakemake only proposes to create the output file ``mapped_reads/B.bam``.
-This is because you already executed the workflow for ``mapped_reads/A.bam`` before, and the input has not changed.
-You can update the file modification date of the input file
-``data/samples/A.fastq`` via
-
-.. code:: console
-
-    $ touch data/samples/A.fastq
-
-and see how Snakemake wants to re-run the job to create the file ``mapped_reads/A.bam`` by executing
-
-.. code:: console
-
-    $ snakemake -np mapped_reads/A.bam mapped_reads/B.bam
+This is because you already executed the workflow for ``mapped_reads/A.bam`` before, and the corresponding output is still up to date.
 
 :oldanchor:`step-3-sorting-read-alignmnents`
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

Given that running `touch` on an input file does not necessarily mean that a workflow rule will be rerun because of the checksum feature (controlled by ``--max-checksum-file-size``) that's been introduced for Snakemake v7, I've tried to explain this in the corresponding places in the docs and removed the `touch` example in the basic tutorial.

Fixes #4172 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified FAQ entry explaining how Snakemake uses content checksums for small input files (default up to 1 MB) instead of relying solely on timestamps, and documented the `--max-checksum-file-size` option for controlling this behavior.
  * Updated freshness checking documentation to reflect checksum comparison logic for small files.
  * Revised tutorial re-execution explanations to emphasize consistency checking between outputs, inputs, and rule definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->