### PR TITLE
docs: Use raw string for bwa_map RG parameter example

### DIFF
--- a/docs/tutorial/additional_features.rst
+++ b/docs/tutorial/additional_features.rst
@@ -52,7 +52,7 @@ We activate benchmarking for the rule ``bwa_map``:
         output:
             temp("mapped_reads/{sample}.bam")
         params:
-            rg="@RG\tID:{sample}\tSM:{sample}"
+            rg=r"@RG\tID:{sample}\tSM:{sample}"
         log:
             "logs/bwa_mem/{sample}.log"
         benchmark:


### PR DESCRIPTION
Add the raw string marker

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Fixed tutorial example for read-group parameters to ensure correct syntax representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->