### PR TITLE
fix: ensure that also storage plugins without settings are auto-deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Documentation
 
-* update installation instuctions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
+* update installation instructions ([#4025](https://github.com/snakemake/snakemake/issues/4025)) ([bfb6b59](https://github.com/snakemake/snakemake/commit/bfb6b59f82aa5c86d6c9df3c4006cbe73ac2604a))
 
 ## [9.18.2](https://github.com/snakemake/snakemake/compare/v9.18.1...v9.18.2) (2026-03-26)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ default-environment = "dev"
 description = "Run all tests in the tests directory"
 cmd = [
   "pytest",
-  "tests",
   # TODO for the two excluded tests, see https://github.com/snakemake/snakemake/pull/3369#issuecomment-2718056637
   "-m",
   "not needs_envmodules",

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -217,11 +217,12 @@ class SpawnedJobArgsFactory:
         if executor_common_settings.auto_deploy_default_storage_provider:
             # Collect plugin names to install: the default storage provider (if
             # configured) plus any providers with explicit settings.
-            providers_to_install = set(self.workflow.storage_provider_settings.keys())
+            providers_to_install = set()
             if self.workflow.storage_settings.default_storage_provider is not None:
                 providers_to_install.add(
                     self.workflow.storage_settings.default_storage_provider
                 )
+            providers_to_install.update(self.workflow.storage_provider_settings.keys())
             packages_to_install = set(
                 StoragePluginRegistry().get_plugin_package_name(provider)
                 for provider in providers_to_install

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -215,9 +215,16 @@ class SpawnedJobArgsFactory:
         # or maybe better, always auto-deploy plugins whenever needed in the workflow
         # or explicitly requested via the settings.
         if executor_common_settings.auto_deploy_default_storage_provider:
+            # Collect plugin names to install: the default storage provider (if
+            # configured) plus any providers with explicit settings.
+            providers_to_install = set(self.workflow.storage_provider_settings.keys())
+            if self.workflow.storage_settings.default_storage_provider is not None:
+                providers_to_install.add(
+                    self.workflow.storage_settings.default_storage_provider
+                )
             packages_to_install = set(
-                StoragePluginRegistry().get_plugin_package_name(plugin_name)
-                for plugin_name in StoragePluginRegistry().get_registered_plugins()
+                StoragePluginRegistry().get_plugin_package_name(provider)
+                for provider in providers_to_install
             )
             if packages_to_install:
                 pkgs = " ".join(sorted(packages_to_install))

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -1,4 +1,3 @@
-from snakemake.logging import logger
 from dataclasses import dataclass, fields
 import hashlib
 from itertools import chain

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -215,21 +215,12 @@ class SpawnedJobArgsFactory:
         # or maybe better, always auto-deploy plugins whenever needed in the workflow
         # or explicitly requested via the settings.
         if executor_common_settings.auto_deploy_default_storage_provider:
-            # Collect plugin names to install: the default storage provider (if
-            # configured) plus any providers with explicit settings.
-            providers_to_install = set()
-            if self.workflow.storage_settings.default_storage_provider is not None:
-                providers_to_install.add(
-                    self.workflow.storage_settings.default_storage_provider
-                )
-            providers_to_install.update(self.workflow.storage_provider_settings.keys())
             packages_to_install = set(
-                StoragePluginRegistry().get_plugin_package_name(provider)
-                for provider in providers_to_install
+                StoragePluginRegistry().get_plugin_package_name(plugin_name)
+                for plugin_name in StoragePluginRegistry().get_registered_plugins()
             )
             if packages_to_install:
                 pkgs = " ".join(sorted(packages_to_install))
-
                 precommand.append(
                     f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {pkgs}"
                 )

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -220,7 +220,7 @@ class SpawnedJobArgsFactory:
                 for plugin_name in StoragePluginRegistry().get_registered_plugins()
             )
             if packages_to_install:
-                pkgs = " ".join(packages_to_install)
+                pkgs = " ".join(sorted(packages_to_install))
 
                 precommand.append(
                     f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {pkgs}"

--- a/src/snakemake/spawn_jobs.py
+++ b/src/snakemake/spawn_jobs.py
@@ -1,3 +1,4 @@
+from snakemake.logging import logger
 from dataclasses import dataclass, fields
 import hashlib
 from itertools import chain
@@ -210,17 +211,21 @@ class SpawnedJobArgsFactory:
         precommand = []
         if self.workflow.remote_execution_settings.precommand:
             precommand.append(self.workflow.remote_execution_settings.precommand)
-        if (
-            executor_common_settings.auto_deploy_default_storage_provider
-            and self.workflow.storage_settings.default_storage_provider is not None
-        ):
-            packages_to_install = set(
-                StoragePluginRegistry().get_plugin_package_name(pkg)
-                for pkg in self.workflow.storage_provider_settings.keys()
-            )
-            pkgs = " ".join(packages_to_install)
 
-            precommand.append(f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {pkgs}")
+        # TODO: rename the setting to auto_deploy_plugins and generalize the code below
+        # or maybe better, always auto-deploy plugins whenever needed in the workflow
+        # or explicitly requested via the settings.
+        if executor_common_settings.auto_deploy_default_storage_provider:
+            packages_to_install = set(
+                StoragePluginRegistry().get_plugin_package_name(plugin_name)
+                for plugin_name in StoragePluginRegistry().get_registered_plugins()
+            )
+            if packages_to_install:
+                pkgs = " ".join(packages_to_install)
+
+                precommand.append(
+                    f"pip install --target '{PIP_DEPLOYMENTS_PATH}' {pkgs}"
+                )
 
         if (
             SharedFSUsage.SOURCES not in self.workflow.storage_settings.shared_fs_usage

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,9 @@ def test_precommand_auto_deploy_with_default_provider():
     """precommand includes pip install for the default storage provider."""
     workflow = _make_mock_workflow(default_storage_provider="s3")
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
+    cmd = factory.precommand(
+        _make_common_settings(auto_deploy_default_storage_provider=True)
+    )
     assert "snakemake-storage-plugin-s3" in cmd
     assert "pip install" in cmd
 
@@ -52,7 +54,9 @@ def test_precommand_auto_deploy_disabled():
     """precommand does NOT include pip install when auto_deploy is disabled."""
     workflow = _make_mock_workflow(default_storage_provider="s3")
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=False))
+    cmd = factory.precommand(
+        _make_common_settings(auto_deploy_default_storage_provider=False)
+    )
     assert "pip install" not in cmd
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,27 +48,6 @@ def test_precommand_auto_deploy_with_default_provider():
     assert "pip install" in cmd
 
 
-def test_precommand_auto_deploy_with_explicit_settings_only():
-    """precommand includes pip install for providers with explicit settings (no default provider)."""
-    workflow = _make_mock_workflow(
-        default_storage_provider=None, storage_provider_settings_keys=["gcs"]
-    )
-    factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
-    assert "snakemake-storage-plugin-gcs" in cmd
-    assert "pip install" in cmd
-
-
-def test_precommand_no_auto_deploy_without_providers():
-    """precommand does NOT include pip install when no providers are configured."""
-    workflow = _make_mock_workflow(
-        default_storage_provider=None, storage_provider_settings_keys=[]
-    )
-    factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
-    assert "pip install" not in cmd
-
-
 def test_precommand_auto_deploy_disabled():
     """precommand does NOT include pip install when auto_deploy is disabled."""
     workflow = _make_mock_workflow(default_storage_provider="s3")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import sys, os, subprocess
+from unittest.mock import MagicMock
 
 from snakemake.executors import local
 
@@ -8,7 +9,72 @@ from .common import *
 
 from snakemake import api
 from snakemake.settings import types as settings
+from snakemake.spawn_jobs import SpawnedJobArgsFactory
+from snakemake_interface_executor_plugins.settings import CommonSettings
 import copy
+
+
+def _make_common_settings(auto_deploy: bool) -> CommonSettings:
+    """Create a minimal CommonSettings with auto_deploy_default_storage_provider set."""
+    return CommonSettings(
+        non_local_exec=True,
+        implies_no_shared_fs=False,
+        job_deploy_sources=False,
+        auto_deploy_default_storage_provider=auto_deploy,
+    )
+
+
+def _make_mock_workflow(
+    default_storage_provider=None,
+    storage_provider_settings_keys=(),
+):
+    """Return a minimal mock workflow for SpawnedJobArgsFactory.precommand() testing."""
+    workflow = MagicMock()
+    workflow.remote_execution_settings.precommand = None
+    workflow.storage_settings.default_storage_provider = default_storage_provider
+    # storage_provider_settings.keys() must return the given plugin names
+    workflow.storage_provider_settings.keys.return_value = list(
+        storage_provider_settings_keys
+    )
+    return workflow
+
+
+def test_precommand_auto_deploy_with_default_provider():
+    """precommand includes pip install for the default storage provider."""
+    workflow = _make_mock_workflow(default_storage_provider="s3")
+    factory = SpawnedJobArgsFactory(workflow=workflow)
+    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    assert "snakemake-storage-plugin-s3" in cmd
+    assert "pip install" in cmd
+
+
+def test_precommand_auto_deploy_with_explicit_settings_only():
+    """precommand includes pip install for providers with explicit settings (no default provider)."""
+    workflow = _make_mock_workflow(
+        default_storage_provider=None, storage_provider_settings_keys=["gcs"]
+    )
+    factory = SpawnedJobArgsFactory(workflow=workflow)
+    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    assert "snakemake-storage-plugin-gcs" in cmd
+    assert "pip install" in cmd
+
+
+def test_precommand_no_auto_deploy_without_providers():
+    """precommand does NOT include pip install when no providers are configured."""
+    workflow = _make_mock_workflow(
+        default_storage_provider=None, storage_provider_settings_keys=[]
+    )
+    factory = SpawnedJobArgsFactory(workflow=workflow)
+    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    assert "pip install" not in cmd
+
+
+def test_precommand_auto_deploy_disabled():
+    """precommand does NOT include pip install when auto_deploy is disabled."""
+    workflow = _make_mock_workflow(default_storage_provider="s3")
+    factory = SpawnedJobArgsFactory(workflow=workflow)
+    cmd = factory.precommand(_make_common_settings(auto_deploy=False))
+    assert "pip install" not in cmd
 
 
 def test_deploy_sources(s3_storage):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,13 +14,13 @@ from snakemake_interface_executor_plugins.settings import CommonSettings
 import copy
 
 
-def _make_common_settings(auto_deploy: bool) -> CommonSettings:
+def _make_common_settings(auto_deploy_default_storage_provider: bool) -> CommonSettings:
     """Create a minimal CommonSettings with auto_deploy_default_storage_provider set."""
     return CommonSettings(
         non_local_exec=True,
         implies_no_shared_fs=False,
         job_deploy_sources=False,
-        auto_deploy_default_storage_provider=auto_deploy,
+        auto_deploy_default_storage_provider=auto_deploy_default_storage_provider,
     )
 
 
@@ -43,7 +43,7 @@ def test_precommand_auto_deploy_with_default_provider():
     """precommand includes pip install for the default storage provider."""
     workflow = _make_mock_workflow(default_storage_provider="s3")
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
     assert "snakemake-storage-plugin-s3" in cmd
     assert "pip install" in cmd
 
@@ -54,7 +54,7 @@ def test_precommand_auto_deploy_with_explicit_settings_only():
         default_storage_provider=None, storage_provider_settings_keys=["gcs"]
     )
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
     assert "snakemake-storage-plugin-gcs" in cmd
     assert "pip install" in cmd
 
@@ -65,7 +65,7 @@ def test_precommand_no_auto_deploy_without_providers():
         default_storage_provider=None, storage_provider_settings_keys=[]
     )
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy=True))
+    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=True))
     assert "pip install" not in cmd
 
 
@@ -73,7 +73,7 @@ def test_precommand_auto_deploy_disabled():
     """precommand does NOT include pip install when auto_deploy is disabled."""
     workflow = _make_mock_workflow(default_storage_provider="s3")
     factory = SpawnedJobArgsFactory(workflow=workflow)
-    cmd = factory.precommand(_make_common_settings(auto_deploy=False))
+    cmd = factory.precommand(_make_common_settings(auto_deploy_default_storage_provider=False))
     assert "pip install" not in cmd
 
 

--- a/tests/test_conda/test-env.yaml
+++ b/tests/test_conda/test-env.yaml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - melt ==1.0.3
   - python <3.10
+  - setuptools <81 # ensure that pkg_resources exists

--- a/tests/test_prebuilt_conda_script/env.yaml
+++ b/tests/test_prebuilt_conda_script/env.yaml
@@ -6,4 +6,4 @@ channels:
 dependencies:
   - melt ==1.0.3
   - python <3.10
-  - setuptools <=81 # needed for pkg_resources
+  - setuptools <81 # needed for pkg_resources

--- a/tests/test_prebuilt_conda_script/env.yaml
+++ b/tests/test_prebuilt_conda_script/env.yaml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - melt ==1.0.3
   - python <3.10
+  - setuptools

--- a/tests/test_prebuilt_conda_script/env.yaml
+++ b/tests/test_prebuilt_conda_script/env.yaml
@@ -6,4 +6,4 @@ channels:
 dependencies:
   - melt ==1.0.3
   - python <3.10
-  - setuptools
+  - setuptools <=81 # needed for pkg_resources


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic storage plugin deployment for remote job execution: now evaluates available plugins more broadly and only triggers package installation when at least one plugin requires it, reducing unnecessary installs and failures.
* **Tests**
  * Test environments updated to pin setuptools to ensure required packaging utilities are present and improve test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->