### PR TITLE
fix: ensure that storage is not actually retrieved with --touch

### DIFF
--- a/src/snakemake/scheduling/job_scheduler.py
+++ b/src/snakemake/scheduling/job_scheduler.py
@@ -354,7 +354,10 @@ class JobScheduler(JobSchedulerExecutorInterface):
                                 f"{', '.join(j.name for j in local_runjobs)}."
                             )
                         else:
-                            if not self.dryrun and not self.workflow.subprocess_exec:
+                            if (
+                                not (self.dryrun or self.touch)
+                                and not self.workflow.subprocess_exec
+                            ):
                                 # retrieve storage inputs for local jobs
                                 self.workflow.async_run(
                                     self.workflow.dag.retrieve_storage_inputs(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1877,9 +1877,11 @@ def test_output_file_cache_storage(s3_storage):
     )
 
 
-@patch("snakemake.io._IOFile.retrieve_from_storage", AsyncMock(side_effect=Exception))
-def test_storage_noretrieve_dryrun():
-    run(dpath("test_storage_noretrieve_dryrun"), executor="dryrun")
+@pytest.mark.parametrize("executor", ["dryrun", "touch"])
+@patch("snakemake.dag.DAG.retrieve_storage_inputs", new_callable=AsyncMock)
+def test_storage_noretrieve_dryrun_or_touch(mock_retrieve_storage_inputs, executor):
+    run(dpath("test_storage_noretrieve_dryrun"), executor=executor)
+    mock_retrieve_storage_inputs.assert_not_called()
 
 
 def test_multiext():


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Touch-mode now skips unnecessary storage input retrieval, matching dry-run behavior and improving performance when touching files without executing jobs.

* **Tests**
  * Expanded tests to verify that both dry-run and touch executors do not trigger storage retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->