### PR TITLE
docs: note about quoting dynamic resource statements with python code, quotes in example

### DIFF
--- a/docs/executing/cli.rst
+++ b/docs/executing/cli.rst
@@ -181,13 +181,17 @@ These enable ``profile.yaml`` entries like:
 .. code-block:: yaml
 
     default-resources:
-      mem_mb: max(1.5 * input.size_mb, 100)
+      mem_mb: "max(1.5 * input.size_mb, 100)"
     set-threads:
-      myrule: max(input.size_mb / 5, 2)
+      myrule: "max(input.size_mb / 5, 2)"
     set-resources:
       myrule:
-        mem_mb: attempt * 200
+        mem_mb: "attempt * 200"
 
+.. note::
+
+    For profile entries with :ref:`dynamic resource <snakefiles-dynamic-resources>` definitions, it helps to always quote the python code used.
+    Otherwise, those statements can render the YAML syntax invalid, leading to respective errors during linting or at runtime.
 
 Also, values in profiles can make use of globally available environment variables, for example the ``$USER`` variable.
 For example, the following entry would set the default prefix for storing local copies of remote storage files to a user specific directory


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated YAML examples for dynamic resource definitions to show proper quoting of Python expressions.
  * Added guidance on required quoting for dynamic resource statements in Profile YAML files to prevent syntax errors during linting and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->