### PR TITLE
fix: failure when module-specific <pathvar> in input func of a `rules.final.input` statement in main Snakefile

### DIFF
--- a/tests/test_pathvars_modules/Snakefile
+++ b/tests/test_pathvars_modules/Snakefile
@@ -27,12 +27,6 @@ module foo3:
 
 use rule * from foo3 as foo3_*
 
-module module_2:
-    snakefile:
-        "module_2/Snakefile"
-
-use rule * from module_2
-
 rule all:
     default_target: True
     input:
@@ -40,8 +34,6 @@ rule all:
         "<results>/foo/text.txt",
         "<results>/foo2/text.txt",
         "<results>/custom/text.txt",
-        rules.final.input,
-
 
 rule a:
     output:

--- a/tests/test_pathvars_modules/Snakefile
+++ b/tests/test_pathvars_modules/Snakefile
@@ -27,6 +27,11 @@ module foo3:
 
 use rule * from foo3 as foo3_*
 
+module module_2:
+    snakefile:
+        "module_2/Snakefile"
+
+use rule * from module_2
 
 rule all:
     default_target: True
@@ -35,6 +40,7 @@ rule all:
         "<results>/foo/text.txt",
         "<results>/foo2/text.txt",
         "<results>/custom/text.txt",
+        rules.final.input,
 
 
 rule a:

--- a/tests/test_pathvars_modules/module_2/Snakefile
+++ b/tests/test_pathvars_modules/module_2/Snakefile
@@ -1,0 +1,17 @@
+pathvars:
+    in_func="pathvar_input_func_within_module",
+
+def final_output(wildcards):
+    return [
+        "some/<in_func>/text.txt",
+    ]
+
+rule c:
+    output:
+        "some/<in_func>/text.txt",
+    shell:
+        "touch {output}"
+
+rule final:
+    input:
+        final_output,

--- a/tests/test_pathvars_modules_rules_input/Snakefile
+++ b/tests/test_pathvars_modules_rules_input/Snakefile
@@ -1,0 +1,10 @@
+module mod:
+    snakefile:
+        "module/Snakefile"
+
+use rule * from mod
+
+rule all:
+    default_target: True
+    input:
+        rules.final.input,

--- a/tests/test_pathvars_modules_rules_input/module/Snakefile
+++ b/tests/test_pathvars_modules_rules_input/module/Snakefile
@@ -15,3 +15,4 @@ rule c:
 rule final:
     input:
         final_output,
+    default_target: True

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2807,6 +2807,10 @@ def test_pathvars_modules():
     run(dpath("test_pathvars_modules"))
 
 
+def test_pathvars_modules_rules_input():
+    run(dpath("test_pathvars_modules_rules_input"))
+
+
 def test_pathvars_cycle():
     run(dpath("test_pathvars_cycle"), shouldfail=True)
 


### PR DESCRIPTION
As a first step, this PR just adds a test that triggers the issue: When a `<pathvar>` in an input function of a rule from a module is used via rules.<rule_name>.input in the main Snakefile. This errors with:

```
snakemake.exceptions.UndefinedPathvarException: Undefined pathvar 'in_func' when expanding pathvars in some/<in_func>/text.txt.
```

<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new integration tests for Snakemake modules with pathvars configuration and rule input handling.

* **New Features**
  * Extended module system to support complex rule input scenarios with improved configuration inheritance capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->