### PR TITLE
fix: temp files not deleted when using remote storage plugins

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1133,7 +1133,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
             async for f in unneeded_files():
                 if await f.exists_local():
                     logger.info(f"Removing local copy of storage file: {fmt_iofile(f)}")
-                    await f.remove()
+                    await f.remove(only_local=True)
 
     def jobid(self, job):
         """Return job id of given job."""

--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -1211,7 +1211,7 @@ def contains_wildcard_constraints(pattern):
 
 
 async def remove(file, remove_non_empty_dir=False, only_local=False):
-    if not only_local and file.is_storage and file.should_not_be_retrieved_from_storage:
+    if not only_local and file.is_storage:
         if await file.exists_in_storage():
             await file.storage_object.managed_remove()
     elif os.path.isdir(file) and not os.path.islink(file):

--- a/tests/test_delete_temp_fs/Snakefile
+++ b/tests/test_delete_temp_fs/Snakefile
@@ -1,0 +1,21 @@
+# This test is run with the fs storage plugin. It tests whether the temp file is properly deleted
+# not only in the fs path but also in the global path.
+
+
+rule all:
+    input:
+        "b"
+
+rule first:
+    output:
+        temp("a"),
+    shell:
+        "echo 'first' > {output}"
+
+rule second:
+    input:
+        "a",
+    output:
+        "b",
+    shell:
+        "(cat {input}; echo 'second') > {output}"

--- a/tests/test_delete_temp_fs/expected-results/b
+++ b/tests/test_delete_temp_fs/expected-results/b
@@ -1,0 +1,2 @@
+first
+second

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3493,4 +3493,7 @@ def test_delete_temp_fs():
         cleanup=False,
     )
     temp_file = os.path.join(outdir, "a")
-    assert not os.path.exists(temp_file), "temp file was not removed in main working directory"
+    assert not os.path.exists(
+        temp_file
+    ), "temp file was not removed in main working directory"
+    shutil.rmtree(tmpdir)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3484,3 +3484,13 @@ def test_github_issue_4039_runtime_no_override():
         cleanup=False,
     )
     shutil.rmtree(tmpdir)
+
+
+def test_delete_temp_fs():
+    outdir = run(
+        dpath("test_delete_temp_fs"),
+        shellcmd="snakemake -c1 --default-storage-provider fs",
+        cleanup=False,
+    )
+    temp_file = os.path.join(outdir, "a")
+    assert not os.path.exists(temp_file), "temp file was not removed in main working directory"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3486,6 +3486,7 @@ def test_github_issue_4039_runtime_no_override():
     shutil.rmtree(tmpdir)
 
 
+@skip_on_windows
 def test_delete_temp_fs():
     outdir = run(
         dpath("test_delete_temp_fs"),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3496,4 +3496,4 @@ def test_delete_temp_fs():
     assert not os.path.exists(
         temp_file
     ), "temp file was not removed in main working directory"
-    shutil.rmtree(tmpdir)
+    shutil.rmtree(outdir)


### PR DESCRIPTION
When using the fs storage plugin, snakemake did not remove temporary files in the "main" storage after they were not needed anymore. The place, where this is supposed to happen, is the `remove` method in the `_IOFile` class. However, the cleanup via the storage object is only invoked for files, which are not supposed to be retrieved from the storage. This causes said temp files to be removed twice on the local storage (once because they are temp, once because the storage plugin cleans up local fiels behind itself) but not on the main storage. The expectation would be that temp files never permanently remain in the main storage, regardless of how transfers are handled by any storage plugin.

This PR removes the condition that currently prevents the cleanup. In addition, the `only_local` flag is now only set to `True` for callers of the `remove` method, when it actually wants to remove the global file and not just the local one. This might have been another bug that was masked by the excess condition that is now gone. Finally, a new test case ensures that temp files are properly removed now using the fs storage plugin.  

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior for temporary, storage-backed inputs so deletions correctly target the intended local copy when the files are no longer needed.
* **Tests**
  * Added an integration test workflow to verify `temp()` outputs are deleted as expected with the filesystem storage provider.
  * Updated the expected results fixture and extended the test harness to check cleanup outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->