### PR TITLE
fix: compilation error when final line contains an f-string

### DIFF
--- a/src/snakemake/parser.py
+++ b/src/snakemake/parser.py
@@ -146,7 +146,12 @@ class TokenAutomaton:
                 break
         # trim those around the f-string
         s = "".join(lines[i] for i in sorted(lines))
-        t = s[token.start[1] : t1.end[1] - len(t1.line)]
+        if t1.line.endswith("\n"):
+            end = t1.end[1] - len(t1.line)
+        else:
+            # in case the f-string is the last line in a file that doesn't end in a newline
+            end = t1.end[1] - len(t1.line) - 1
+        t = s[token.start[1] : end]
         if hasattr(self, "cmd") and self.cmd[-1][1] == token:
             self.cmd[-1] = t, token
         return t

--- a/src/snakemake/parser.py
+++ b/src/snakemake/parser.py
@@ -6,7 +6,7 @@ __license__ = "MIT"
 import sys
 import textwrap
 import tokenize
-from typing import Any, Callable, Dict, Generator, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional
 
 from snakemake import common
 
@@ -179,9 +179,9 @@ class TokenAutomaton:
 
     def subautomaton(self, automaton, *args, token=None, **kwargs):
         if automaton in self.deprecated:
-            assert (
-                token is not None
-            ), "bug: deprecation encountered but subautomaton not called with a token"
+            assert token is not None, (
+                "bug: deprecation encountered but subautomaton not called with a token"
+            )
             self.error(
                 f"Keyword {automaton} is deprecated. {self.deprecated[automaton]}",
                 token,
@@ -373,10 +373,7 @@ class Storage(GlobalKeywordState):
 
 
 class ResourceScope(GlobalKeywordState):
-    err_msg = (
-        "Invalid scope: {resource}={scope}. Scope must be set to either 'local' or "
-        "'global'"
-    )
+    err_msg = "Invalid scope: {resource}={scope}. Scope must be set to either 'local' or 'global'"
     current_resource = ""
 
     def block_content(self, token):
@@ -401,8 +398,7 @@ class Ruleorder(GlobalKeywordState):
             yield repr(token.string), token
         else:
             self.error(
-                "Expected a descending order of rule names, "
-                "e.g. rule1 > rule2 > rule3 ...",
+                "Expected a descending order of rule names, e.g. rule1 > rule2 > rule3 ...",
                 token,
             )
 
@@ -457,8 +453,7 @@ class Localrules(GlobalKeywordState):
             yield repr(token.string), token
         else:
             self.error(
-                "Expected a comma separated list of rules that shall "
-                "not be executed by the cluster command.",
+                "Expected a comma separated list of rules that shall not be executed by the cluster command.",
                 token,
             )
 
@@ -793,8 +788,7 @@ class Rule(GlobalKeywordState):
 
     def start(self, aux=""):
         yield (
-            f"@workflow.rule(name={self.rulename!r}, lineno={self.lineno}, "
-            f"snakefile={self.snakefile.path!r}{aux})"
+            f"@workflow.rule(name={self.rulename!r}, lineno={self.lineno}, snakefile={self.snakefile.path!r}{aux})"
         )
 
     def end(self):
@@ -864,8 +858,7 @@ class Rule(GlobalKeywordState):
             yield f"@workflow.docstring({token.string})", token
         else:
             self.error(
-                "Expecting rule keyword, comment or docstrings "
-                "inside a rule definition.",
+                "Expecting rule keyword, comment or docstrings inside a rule definition.",
                 token,
             )
 
@@ -1029,8 +1022,7 @@ class Module(GlobalKeywordState):
                     yield t
             except KeyError:
                 self.error(
-                    "Unexpected keyword {} in "
-                    "module definition".format(token.string),
+                    "Unexpected keyword {} in module definition".format(token.string),
                     token,
                 )
             except StopAutomaton as e:
@@ -1045,8 +1037,7 @@ class Module(GlobalKeywordState):
             pass
         else:
             self.error(
-                "Expecting module keyword, comment or docstrings "
-                "inside a module definition.",
+                "Expecting module keyword, comment or docstrings inside a module definition.",
                 token,
             )
 
@@ -1287,8 +1278,7 @@ class UseRule(GlobalKeywordState):
             )
         else:
             self.error(
-                "Expecting rule keyword, comment or docstrings "
-                "inside a 'use rule ... with:' statement.",
+                "Expecting rule keyword, comment or docstrings inside a 'use rule ... with:' statement.",
                 token,
             )
 

--- a/src/snakemake/parser.py
+++ b/src/snakemake/parser.py
@@ -184,9 +184,9 @@ class TokenAutomaton:
 
     def subautomaton(self, automaton, *args, token=None, **kwargs):
         if automaton in self.deprecated:
-            assert token is not None, (
-                "bug: deprecation encountered but subautomaton not called with a token"
-            )
+            assert (
+                token is not None
+            ), "bug: deprecation encountered but subautomaton not called with a token"
             self.error(
                 f"Keyword {automaton} is deprecated. {self.deprecated[automaton]}",
                 token,


### PR DESCRIPTION
<!--Add a description of your PR here-->
fixes #3918 . 

Adds a check for a final newline character to the `parse_fstring` function. Previously, the Snakefile 
```
rule align:
    input: "reads/{sample}.fastq"
    output: "aligned/{sample}.bam"
    threads: 8
    shell:
        f"bwa mem -t {threads} {input} > {output}"
```
(with no final newline) would not pick up the final f-string, resulting in an erroneous compilation:

```
@workflow.shellcmd (

                                )
@workflow.run
def __rule_1(input, output, params, wildcards, threads, resources, log, rule, conda_env, container_img, singularity_args, use_singularity, env_modules, bench_record, jobid, is_shell, bench_iteration, cleanup_scripts, shadow_dir, edit_notebook, conda_base_path, basedir, sourcecache_path, runtime_sourcecache_path, runtime_paths, __is_snakemake_rule_func=True):
                                        shell ( , bench_record=bench_record, bench_iteration=bench_iteration
                                ) 
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge case in f-string parsing for files that don’t end with a trailing newline.

* **Refactor**
  * Improved consistency in typing/import usage and reformatted internal code and generated messages for readability, without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->