### PR TITLE
fix: avoid config hash crash for non-serializable values

### DIFF
--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -284,7 +284,7 @@ class Workflow(WorkflowExecutorInterface):
             config_md5 = hashlib.md5(
                 json.dumps(self.config, sort_keys=True).encode("utf-8")
             ).hexdigest()
-        except TypeError:
+        except (TypeError, ValueError):
             config_md5 = "unavailable"
 
         return {

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -280,6 +280,12 @@ class Workflow(WorkflowExecutorInterface):
         import hashlib
 
         conda_bin = shutil.which("conda")
+        try:
+            config_md5 = hashlib.md5(
+                json.dumps(config, sort_keys=True).encode("utf-8")
+            ).hexdigest()
+        except TypeError:
+            config_md5 = "unavailable"
 
         return {
             "datetime": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
@@ -296,9 +302,7 @@ class Workflow(WorkflowExecutorInterface):
             "snakefile_main": self.main_snakefile,
             "snakefile": self.snakefile,
             "workflow_id": uuid.uuid4(),
-            "config_md5": hashlib.md5(
-                json.dumps(config, sort_keys=True).encode("utf-8")
-            ).hexdigest(),
+            "config_md5": config_md5,
         }
 
     @property

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -282,7 +282,7 @@ class Workflow(WorkflowExecutorInterface):
         conda_bin = shutil.which("conda")
         try:
             config_md5 = hashlib.md5(
-                json.dumps(config, sort_keys=True).encode("utf-8")
+                json.dumps(self.config, sort_keys=True).encode("utf-8")
             ).hexdigest()
         except TypeError:
             config_md5 = "unavailable"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -504,6 +504,10 @@ def test_config():
     run(dpath("test_config"))
 
 
+def test_config_non_json_serializable():
+    run(dpath("test_config"), config={"path_value": Path("data")})
+
+
 def test_update_config():
     run(dpath("test_update_config"))
 


### PR DESCRIPTION
Fixes #4215.

Workflow startup logging calculates `config_md5` with `json.dumps(..., sort_keys=True)`. This can fail before workflow execution when runtime config contains values that JSON cannot serialize, such as `pathlib.Path`, or values that produce JSON serialization value errors, such as circular references.

This change preserves the existing deterministic MD5 calculation for JSON-serializable configs. If serialization raises `TypeError` or `ValueError`, the startup header reports `Config MD5: unavailable` instead of crashing. The config object is not mutated, and arbitrary values are not stringified with `default=str`.

Validation:
- `env XDG_CACHE_HOME="$PWD/.cache" PYTHONPATH=src .venv/bin/python3.12 -m pytest tests/tests.py::test_config tests/tests.py::test_config_non_json_serializable -q`
- `env XDG_CACHE_HOME="$PWD/.cache" PYTHONPATH=src .venv/bin/python3.12 -m pytest tests/tests.py -k "config" -q`
- `.venv/bin/black --check src/snakemake/workflow.py tests/tests.py`
- `git diff --check`
- manual reproduction with `pathlib.Path` config
- manual reproduction with circular config
- deterministic MD5 verification for ordinary JSON config

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow information no longer fails when configuration contains non–JSON-serializable values.
  * Shows an “unavailable” configuration checksum instead of erroring.
* **Tests**
  * Added a new test to cover workflows using non–JSON-serializable configuration inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->