### PR TITLE
fix: leak of benchmark monitor threads

### DIFF
--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -273,6 +273,11 @@ class ScheduledPeriodicTimer:
 
     def _action(self):
         """Internally, called by timer"""
+        # A cancel() can land between the timer firing and this call. Without this guard
+        # the reschedule below would resurrect a cancelled timer, leaking the monitor
+        # thread for the rest of the process' life.
+        if self._stopped:
+            return
         self.work()
         self._times_called += 1
         if self._times_called > self._interval:
@@ -287,8 +292,11 @@ class ScheduledPeriodicTimer:
 
     def cancel(self):
         """Call to cancel any events"""
-        self._timer.cancel()
+        # Set the flag before cancelling so a concurrent _action() observes it and does
+        # not re-arm. _timer is None if cancel() runs before start().
         self._stopped = True
+        if self._timer is not None:
+            self._timer.cancel()
 
 
 class BenchmarkTimer(ScheduledPeriodicTimer):
@@ -433,9 +441,12 @@ def benchmarked(pid=None, benchmark_record=None, interval=BENCHMARK_INTERVAL):
         start_time = time.time()
         bench_thread = BenchmarkTimer(int(pid or os.getpid()), result, interval)
         bench_thread.start()
-        yield result
-        bench_thread.cancel()
-        result.running_time = time.time() - start_time
+        try:
+            yield result
+        finally:
+            # Cancel in finally so a raising body cannot leak the monitor thread.
+            bench_thread.cancel()
+            result.running_time = time.time() - start_time
 
 
 def print_benchmark_tsv(records, file_, extended_fmt):

--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -259,34 +259,39 @@ class ScheduledPeriodicTimer:
         self._interval = interval
         self._timer = None
         self._stopped = True
+        # Serializes the stop flag with (re)scheduling so cancel() and _action() can't
+        # interleave into a resurrected timer — the thread-leak this class had.
+        self._lock = threading.Lock()
+
+    def _schedule(self):
+        """Arm the next tick. Caller must hold ``self._lock``."""
+        if self._times_called > self._interval:
+            self._timer = DaemonTimer(self._interval, self._action)
+        else:
+            self._timer = DaemonTimer(BENCHMARK_INTERVAL_SHORT, self._action)
+        self._timer.start()
 
     def start(self):
         """Start the intervalic timer"""
         self.work()
         self._times_called += 1
-        self._stopped = False
-        if self._times_called > self._interval:
-            self._timer = DaemonTimer(self._interval, self._action)
-        else:
-            self._timer = DaemonTimer(BENCHMARK_INTERVAL_SHORT, self._action)
-        self._timer.start()
+        with self._lock:
+            self._stopped = False
+            self._schedule()
 
     def _action(self):
         """Internally, called by timer"""
-        # A cancel() can land between the timer firing and this call. Without this guard
-        # the reschedule below would resurrect a cancelled timer, leaking the monitor
-        # thread for the rest of the process' life.
-        if self._stopped:
+        if self._stopped:  # fast path; the authoritative check is under the lock below
             return
         self.work()
         self._times_called += 1
-        if self._stopped:  # work() stops us once the observed process has exited
-            return
-        if self._times_called > self._interval:
-            self._timer = DaemonTimer(self._interval, self._action)
-        else:
-            self._timer = DaemonTimer(BENCHMARK_INTERVAL_SHORT, self._action)
-        self._timer.start()
+        with self._lock:
+            # Re-check under the lock: a cancel() (or work() self-terminating once the
+            # observed process exits) must win the race and stop us from re-arming a timer
+            # that would then live for the rest of the process.
+            if self._stopped:
+                return
+            self._schedule()
 
     def work(self):
         """Override to perform the action"""
@@ -294,11 +299,13 @@ class ScheduledPeriodicTimer:
 
     def cancel(self):
         """Call to cancel any events"""
-        # Set the flag before cancelling so a concurrent _action() observes it and does
-        # not re-arm. _timer is None if cancel() runs before start().
-        self._stopped = True
-        if self._timer is not None:
-            self._timer.cancel()
+        # Under the lock this is mutually exclusive with _action's reschedule: either we set
+        # the flag first and _action sees it, or _action arms the next timer and we cancel it
+        # here. _timer is None if cancel() runs before start().
+        with self._lock:
+            self._stopped = True
+            if self._timer is not None:
+                self._timer.cancel()
 
 
 class BenchmarkTimer(ScheduledPeriodicTimer):

--- a/src/snakemake/benchmark.py
+++ b/src/snakemake/benchmark.py
@@ -280,6 +280,8 @@ class ScheduledPeriodicTimer:
             return
         self.work()
         self._times_called += 1
+        if self._stopped:  # work() stops us once the observed process has exited
+            return
         if self._times_called > self._interval:
             self._timer = DaemonTimer(self._interval, self._action)
         else:
@@ -324,6 +326,11 @@ class BenchmarkTimer(ScheduledPeriodicTimer):
             pass  # skip, process died in flight
         except AttributeError:
             pass  # skip, process died in flight
+        # Stop once the observed process has exited — nothing left to sample, so don't keep
+        # polling a dead PID until the context closes. Checked after the sample above so a
+        # final measurement is still attempted.
+        if not self.main.is_running():
+            self._stopped = True
 
     def _update_record(self):
         """Perform the actual measurement"""

--- a/tests/test_benchmark_leak.py
+++ b/tests/test_benchmark_leak.py
@@ -1,0 +1,60 @@
+"""Regression tests for benchmark monitor thread leaks.
+
+ScheduledPeriodicTimer re-armed a fresh DaemonTimer on every fire without checking the
+stop flag, so a cancel() landing between a fire and _action() was undone and the monitor
+thread lived for the rest of the process. This fires on normal job completion, so at scale
+the leaked threads accumulate until the scheduler starves.
+
+See: https://github.com/snakemake/snakemake/issues/XXXX
+"""
+
+import pytest
+
+from snakemake.benchmark import ScheduledPeriodicTimer, benchmarked
+
+
+class _Counter(ScheduledPeriodicTimer):
+    """A ScheduledPeriodicTimer whose work() just counts, no psutil needed."""
+
+    def __init__(self):
+        super().__init__(interval=1)
+        self.fires = 0
+
+    def work(self):
+        self.fires += 1
+
+
+def _make(stopped, timer):
+    t = _Counter()
+    t._stopped = stopped
+    t._timer = timer
+    t.fires = 0
+    return t
+
+
+def test_action_is_noop_once_stopped():
+    """_action() must not re-arm once _stopped — closes the cancel/reschedule race."""
+    t = _make(stopped=True, timer=None)
+
+    t._action()
+
+    assert t.fires == 0, "work() ran after stop"
+    assert t._timer is None, "_action re-armed a cancelled timer (the leak)"
+
+
+def test_cancel_is_none_safe_and_sets_flag_first():
+    """cancel() before start() must not raise and must record the stop."""
+    t = _make(stopped=False, timer=None)
+
+    t.cancel()  # _timer is None here — must not AttributeError
+
+    assert t._stopped is True
+
+
+def test_benchmarked_cancels_when_body_raises():
+    """A raising body must still cancel the monitor (running_time set in finally)."""
+    with pytest.raises(ValueError), benchmarked() as record:
+        raise ValueError("boom")
+
+    # running_time defaults to None; the finally in benchmarked() sets it after cancel().
+    assert record.running_time is not None, "monitor not stopped on exception path"

--- a/tests/test_benchmark_leak.py
+++ b/tests/test_benchmark_leak.py
@@ -8,9 +8,11 @@ the leaked threads accumulate until the scheduler starves.
 See: https://github.com/snakemake/snakemake/issues/XXXX
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from snakemake.benchmark import ScheduledPeriodicTimer, benchmarked
+from snakemake.benchmark import BenchmarkTimer, ScheduledPeriodicTimer, benchmarked
 
 
 class _Counter(ScheduledPeriodicTimer):
@@ -58,3 +60,33 @@ def test_benchmarked_cancels_when_body_raises():
 
     # running_time defaults to None; the finally in benchmarked() sets it after cancel().
     assert record.running_time is not None, "monitor not stopped on exception path"
+
+
+def test_work_stops_monitor_once_process_exited():
+    """BenchmarkTimer.work() stops the monitor when the observed process is gone, so it
+    doesn't keep polling a dead PID until the context closes."""
+    main = MagicMock()
+    main.is_running.return_value = False
+    timer = BenchmarkTimer.__new__(BenchmarkTimer)
+    timer.main = main
+    timer._stopped = False
+    timer._update_record = lambda: None  # isolate the stop check from actual sampling
+
+    timer.work()
+
+    assert timer._stopped is True
+
+
+def test_action_does_not_rearm_when_work_self_terminates():
+    """If work() stops the monitor (observed process exited), _action must not re-arm."""
+    t = _make(stopped=False, timer=None)
+
+    def stopping_work():
+        t.fires += 1
+        t._stopped = True  # as BenchmarkTimer.work does when the process is gone
+
+    t.work = stopping_work
+    t._action()
+
+    assert t.fires == 1
+    assert t._timer is None, "_action re-armed after work() self-terminated"

--- a/tests/test_benchmark_leak.py
+++ b/tests/test_benchmark_leak.py
@@ -56,9 +56,9 @@ def test_action_does_not_rearm_when_cancelled_mid_action():
     t._action()
 
     assert t.fires == 1
-    assert t._timer is None, (
-        "re-armed despite a cancel during the check→reschedule window"
-    )
+    assert (
+        t._timer is None
+    ), "re-armed despite a cancel during the check→reschedule window"
 
 
 def test_cancel_sets_flag_before_cancelling_timer():

--- a/tests/test_benchmark_leak.py
+++ b/tests/test_benchmark_leak.py
@@ -4,14 +4,13 @@ ScheduledPeriodicTimer re-armed a fresh DaemonTimer on every fire without checki
 stop flag, so a cancel() landing between a fire and _action() was undone and the monitor
 thread lived for the rest of the process. This fires on normal job completion, so at scale
 the leaked threads accumulate until the scheduler starves.
-
-See: https://github.com/snakemake/snakemake/issues/XXXX
 """
 
 from unittest.mock import MagicMock
 
 import pytest
 
+from snakemake import benchmark as bm
 from snakemake.benchmark import BenchmarkTimer, ScheduledPeriodicTimer, benchmarked
 
 
@@ -44,8 +43,40 @@ def test_action_is_noop_once_stopped():
     assert t._timer is None, "_action re-armed a cancelled timer (the leak)"
 
 
-def test_cancel_is_none_safe_and_sets_flag_first():
-    """cancel() before start() must not raise and must record the stop."""
+def test_action_does_not_rearm_when_cancelled_mid_action():
+    """A cancel() that lands after _action's initial check (here: during work(), before
+    the reschedule) must still prevent re-arming — the locked re-check catches it."""
+    t = _make(stopped=False, timer=None)
+
+    def work_then_cancel():
+        t.fires += 1
+        t.cancel()  # concurrent cancel racing the reschedule
+
+    t.work = work_then_cancel
+    t._action()
+
+    assert t.fires == 1
+    assert t._timer is None, (
+        "re-armed despite a cancel during the check→reschedule window"
+    )
+
+
+def test_cancel_sets_flag_before_cancelling_timer():
+    """cancel() must set _stopped before touching the timer, so a racing _action sees it."""
+    t = _make(stopped=False, timer=None)
+    observed = {}
+    fake_timer = MagicMock()
+    fake_timer.cancel.side_effect = lambda: observed.update(stopped=t._stopped)
+    t._timer = fake_timer
+
+    t.cancel()
+
+    assert observed["stopped"] is True, "timer cancelled before the stop flag was set"
+    fake_timer.cancel.assert_called_once()
+
+
+def test_cancel_is_none_safe():
+    """cancel() before start() (no timer yet) must not raise and must record the stop."""
     t = _make(stopped=False, timer=None)
 
     t.cancel()  # _timer is None here — must not AttributeError
@@ -53,13 +84,15 @@ def test_cancel_is_none_safe_and_sets_flag_first():
     assert t._stopped is True
 
 
-def test_benchmarked_cancels_when_body_raises():
-    """A raising body must still cancel the monitor (running_time set in finally)."""
-    with pytest.raises(ValueError), benchmarked() as record:
+def test_benchmarked_cancels_monitor_even_when_body_raises(monkeypatch):
+    """benchmarked() must cancel the monitor on the exception path (cancel in finally)."""
+    fake = MagicMock()
+    monkeypatch.setattr(bm, "BenchmarkTimer", lambda *a, **k: fake)
+
+    with pytest.raises(ValueError), benchmarked():
         raise ValueError("boom")
 
-    # running_time defaults to None; the finally in benchmarked() sets it after cancel().
-    assert record.running_time is not None, "monitor not stopped on exception path"
+    fake.cancel.assert_called_once()
 
 
 def test_work_stops_monitor_once_process_exited():


### PR DESCRIPTION
`ScheduledPeriodicTimer._action` re-arms a fresh `DaemonTimer` on every fire without checking the stop flag, so a cancel() that lands between a timer fire and _action is immediately undone — the monitor thread then lives for the rest of the process. This fires on normal job completion, so at scale the leaked threads accumulate until the scheduler starves: on a ~23k-job run throughput decayed monotonically (from ~11 min per 1% early to ~131 min per 1% near the end) and the run stalled, with repeated "Benchmark: unable to collect ... process no longer exists" messages from timers still polling exited PIDs.

`_action` now honors the stop flag; `cancel()` sets the flag before touching the timer (so a racing `_action` observes it) and is None-safe; and `benchmarked()` cancels in a `finally` so a raising job body cannot leak the monitor.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reworked periodic benchmarking timer handling to prevent cancellation/rescheduling races and avoid unintended re-arming.
  * Improved shutdown behavior so monitoring stops when the process exits and no monitor is left running after failures.
  * Made cancellation more robust by safely handling cases where the underlying timer is not yet available.
* **Tests**
  * Added regression coverage for timer cancellation/re-arming race conditions and for ensuring monitor cleanup even when the benchmark body raises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->