### PR TITLE
chore: switch to miniforge container since the miniconda container is broken in the last release

### DIFF
--- a/docs/snakefiles/deployment.rst
+++ b/docs/snakefiles/deployment.rst
@@ -574,7 +574,7 @@ For example, you can write
 
 .. code-block:: python
 
-    container: "docker://continuumio/miniconda3:4.4.10"
+    container: "docker://condaforge/miniforge3:26.3.2-3"
 
     rule NAME:
         input:

--- a/docs/snakefiles/reporting.rst
+++ b/docs/snakefiles/reporting.rst
@@ -34,7 +34,7 @@ Consider the following example:
       output:
           "test.{i}.out"
       container:
-          "docker://continuumio/miniconda3:4.4.10"
+          "docker://condaforge/miniforge3:26.3.2-3"
       conda:
           "envs/test.yaml"
       shell:

--- a/tests/test_singularity_conda/Snakefile
+++ b/tests/test_singularity_conda/Snakefile
@@ -1,6 +1,6 @@
 
 
-singularity: "docker://continuumio/miniconda3"
+singularity: "docker://condaforge/miniforge3:26.3.2-3"
 
 
 rule a:


### PR DESCRIPTION
The miniconda container hangs when calling e.g. `conda info --json` in it.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
