### PR TITLE
feat: allow to combine cases with otherwise in branch function

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -609,6 +609,20 @@ An example for using the cases argument could look as follows:
         }
     )
 
+Above, if the value given as condition is not found in the cases mapping, a KeyError is raised.
+To avoid that, one can provide ``otherwise`` as a fallback value, e.g.
+
+.. code-block:: python
+
+    branch(
+        lookup(dpath="tool/to/use", within=config),
+        cases={
+            "sometool": "results/sometool/{dataset}.txt",
+            "someothertool": "results/someothertool/{dataset}.txt"
+        },
+        otherwise="results/someresult/{dataset}.txt"
+    )
+
 The evaluate function
 """""""""""""""""""""
 

--- a/src/snakemake/ioutils/branch.py
+++ b/src/snakemake/ioutils/branch.py
@@ -46,13 +46,17 @@ def branch(
         try:
             selected_case = cases[res]
         except KeyError:
+            if otherwise is not None:
+                return handle_callable(otherwise, wildcards)
             raise KeyError(f"Key {res} not found in given cases of branch function")
         return handle_callable(selected_case, wildcards)
 
     do_branch = do_branch_then_otherwise
     if cases is not None:
-        if otherwise is not None or then is not None:
-            raise ValueError("Cannot use cases together with then or otherwise.")
+        if then is not None:
+            raise ValueError(
+                "Cannot use 'cases' together with 'then' in 'branch' function."
+            )
         do_branch = do_branch_cases
 
     if any(isinstance(value, Callable) for value in (condition, then, otherwise)):


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [x] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for using an `otherwise` fallback when a `branch()` condition does not match any key in `cases`.

- **Bug Fixes**
  - Improved error handling for unmatched branch conditions, including clearer `KeyError` messages.
  - Updated validation to allow `cases` and `otherwise` to be used together.

- **Documentation**
  - Added guidance and examples for configuring fallback behavior with `otherwise`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->