### PR TITLE
feat: allow first positional parameter of lookup function to be used as both query and dpath

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -450,7 +450,7 @@ The ``lookup`` function has the signature
 
 The required ``within`` parameter takes either a python mapping, a pandas dataframe, or a pandas series.
 For the former case, it expects the ``dpath`` argument, for the latter two cases, it expects the ``query`` argument to be given.
-From Snakemake 9.25 on, alternatively, you can simply provide any of the two as the first positonal argument.
+From Snakemake 9.25 on, alternatively, you can simply provide any of the two as the first positional argument.
 The matching argument will be chosen via the type of the ``within`` parameter.
 
 In case of a pandas dataframe,

--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -440,8 +440,8 @@ The ``lookup`` function has the signature
 .. code-block:: python
 
     lookup(
-        dpath: Optional[str | Callable] = None,
         query: Optional[str | Callable] = None,
+        dpath: Optional[str | Callable] = None,
         cols: Optional[List[str]] = None,
         is_nrows: Optional[int],
         within=None,
@@ -450,6 +450,8 @@ The ``lookup`` function has the signature
 
 The required ``within`` parameter takes either a python mapping, a pandas dataframe, or a pandas series.
 For the former case, it expects the ``dpath`` argument, for the latter two cases, it expects the ``query`` argument to be given.
+From Snakemake 9.25 on, alternatively, you can simply provide any of the two as the first positonal argument.
+The matching argument will be chosen via the type of the ``within`` parameter.
 
 In case of a pandas dataframe,
 the query parameter is passed to `DataFrame.query() <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html>`_.
@@ -467,7 +469,7 @@ e.g.
 
 .. code-block:: python
 
-    collect("results/{item.sample}.txt", item=lookup(query="someval > 2", within=samples))
+    collect("results/{item.sample}.txt", item=lookup("someval > 2", within=samples))
 
 Here, we take the file ``"results/{item.sample}.txt"`` with ``{item.sample}`` being replaced by the
 sample names that occur in all rows of the dataframe ``samples`` where the value of the ``someval`` column is greater than 2.
@@ -478,26 +480,26 @@ for the :ref:`branch function <snakefiles-branch-function>`, e.g.
 
 .. code-block:: python
 
-    branch(lookup(query="sample == '{sample}' & someval > 2", within=samples), then="foo", otherwise="bar")
+    branch(lookup("sample == '{sample}' & someval > 2", within=samples), then="foo", otherwise="bar")
 
 In case your dataframe has an index, you can also access the index within the
 query, e.g. for faster, constant time lookups:
 
 .. code-block:: python
 
-    lookup(query="index.loc[{sample}]", within=samples)
+    lookup("index.loc[{sample}]", within=samples)
 
 Further, it is possible to constrain the output to a list of columns, e.g.
 
 .. code-block:: python
 
-    lookup(query="sample == '{sample}'", within=samples, cols=["somecolumn"])
+    lookup("sample == '{sample}'", within=samples, cols=["somecolumn"])
 
 or to a single column, e.g.
 
 .. code-block:: python
 
-    lookup(query="sample == '{sample}'", within=samples, cols="somecolumn")
+    lookup("sample == '{sample}'", within=samples, cols="somecolumn")
 
 In the latter case, just a list of items in that column is returned (e.g. ``["a", "b", "c"]``).
 
@@ -506,7 +508,7 @@ If it is used, lookup just returns a boolean value indicating whether the number
 
 .. code-block:: python
 
-    lookup(query="sample == '{sample}'", within=samples, is_nrows=5)
+    lookup("sample == '{sample}'", within=samples, is_nrows=5)
 
 In case of a **pandas series**, the series is converted into a dataframe via
 Series.to_frame() and the same logic as for a dataframe is applied.
@@ -525,7 +527,7 @@ to auxiliary namespace arguments given to the lookup function, e.g.
 .. code-block:: python
 
     lookup(
-        query="cell_type == '{sample.cell_type}'",
+        "cell_type == '{sample.cell_type}'",
         within=samples,
         sample=lookup("sample == '{sample}'", within=samples)
     )
@@ -569,7 +571,7 @@ An example of using ``branch`` in combination with ``lookup`` from a ``config`` 
 .. code-block:: python
 
     branch(
-        lookup(dpath="tools/sometool", within=config),
+        lookup("tools/sometool", within=config),
         then="results/sometool/{dataset}.txt",
         otherwise="results/someresult/{dataset}.txt"
     )
@@ -602,7 +604,7 @@ An example for using the cases argument could look as follows:
 .. code-block:: python
 
     branch(
-        lookup(dpath="tool/to/use", within=config),
+        lookup("tool/to/use", within=config),
         cases={
             "sometool": "results/sometool/{dataset}.txt",
             "someothertool": "results/someothertool/{dataset}.txt"
@@ -615,7 +617,7 @@ To avoid that, one can provide ``otherwise`` as a fallback value, e.g.
 .. code-block:: python
 
     branch(
-        lookup(dpath="tool/to/use", within=config),
+        lookup("tool/to/use", within=config),
         cases={
             "sometool": "results/sometool/{dataset}.txt",
             "someothertool": "results/someothertool/{dataset}.txt"

--- a/src/snakemake/ioutils/lookup.py
+++ b/src/snakemake/ioutils/lookup.py
@@ -103,8 +103,8 @@ NODEFAULT = object()
 
 
 def lookup(
-    dpath: Optional[str] = None,
     query: Optional[str] = None,
+    dpath: Optional[str] = None,
     cols: Optional[Union[List[str], str]] = None,
     is_nrows: Optional[int] = None,
     within=None,
@@ -168,6 +168,14 @@ def lookup(
         raise error(msg="The cols argument has to be either a str or a list of str.")
     if is_nrows is not None and not isinstance(is_nrows, int):
         raise error(msg="The is_nrows argument has to be an int.")
+
+    if query is not None and dpath is not None:
+        raise error(msg="Cannot provide both query and dpath arguments.")
+
+    if query is not None and isinstance(within, Mapping):
+        # The query is actually meant to be a dpath, maybe provided unnamed.
+        dpath = query
+        query = None
 
     if query is not None:
         if isinstance(within, Mapping):


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a more flexible `lookup` calling convention, with `query` shown before `dpath` and improved support for concise positional usage (including mapping-based lookups).
  - Expanded compatibility for `lookup` in `collect`/`branch` conditions (dataframe filtering, column-restricted selections, row-count checks, config-driven lookups, and `cases`/`otherwise` fallbacks).

- **Bug Fixes**
  - Prevented ambiguous calls by rejecting cases where both `query` and `dpath` are provided together.

- **Documentation**
  - Updated `lookup`/`collect`/`branch` examples and corrected wording to match the new calling convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->