### PR TITLE
feat: provide a new helper alias to join parameters into a single string (join_params)

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -741,12 +741,33 @@ set the ``space`` keyword argument to ``False``:
 
 .. code-block:: python
 
-    params:
-        data=prepend_param("-i", input.data, space=False)
-    input:
-        data=["a.txt", "b.txt", "c.txt"],
-    shell:
-        "somecommand {params.data}"  # Runs somecommand -ia.txt -ib.txt -ic.txt
+    rule a:
+        input:
+            data=["a.txt", "b.txt", "c.txt"],
+        params:
+            data=prepend_param("-i", input.data, space=False)
+        shell:
+            "somecommand {params.data}"  # Runs somecommand -ia.txt -ib.txt -ic.txt
+
+
+The join_params function
+""""""""""""""""""""""""
+
+The ``join_params`` function takes one or more parameters (str, Path, :ref:`parameter functions <snakefiles-params>`) and joins them into a single string (by default separated with a whitespace).
+It is most useful in case of e.g. `wrappers <https://snakemake-wrappers.readthedocs.io>`__ that are for simplicity limited to a single string parameter for extra arguments.
+The helper function thereby automatically and recursively resolves any parameter functions:
+
+.. code-block:: python
+
+    rule a:
+        input:
+            graph="test.gbz",
+            paths="test.paths",
+        params:
+            extra=join_params(prepend_param("--ref-paths", input.data), "--parameter-preset hifi")
+        wrapper:
+            "v9.9.0/bio/vg/giraffe"
+
 
 
 .. _snakefiles-rule-item-access:

--- a/src/snakemake/ioutils/prepend_param.py
+++ b/src/snakemake/ioutils/prepend_param.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Union
 
 from snakemake.common import get_function_params, overwrite_function_params
 from snakemake.io import is_callable
@@ -10,6 +10,7 @@ def prepend_param(
     prefix: str,
     paths_or_func: Union[Callable, str, Path, List[Union[str, Path]]],
     space: bool = True,
+    _func_name: str = "prepend_param"
 ):
     """
     Prepend each filename in `paths_or_func` with `prefix`,
@@ -24,7 +25,7 @@ def prepend_param(
             path = str(path)
         if not isinstance(path, str):
             raise ValueError(
-                "Values passed to prepend "
+                f"Values passed to {_func_name} "
                 "must be a single string or pathlib.Path (or a function returning those). "
                 f"Obtained value: {repr(path)}"
             )
@@ -54,3 +55,13 @@ def prepend_param(
         return inner
     else:
         return do(paths_or_func)
+
+
+def join_params(
+    *params: Union[Callable, str, Path, List[Union[str, Path]]],
+    space: bool = True,
+) -> Union[str, Callable]:
+    """
+    Join given parameters into a single string, with a space (if `space` is `True`).
+    """
+    return prepend_param("", params, space=space, _func_name="join_params")


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `join_params` semantic helper to combine multiple parameter values into a single space-separated argument (supports strings, paths, lists, and dynamic providers).
  * Extended `prepend_param` usage via improved composition with `join_params`.

* **Bug Fixes**
  * Improved type-mismatch error messages to report the correct parameter operation more accurately.

* **Documentation**
  * Updated the `prepend_param` example for correct rule context/order and added documentation and examples for `join_params`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->