### PR TITLE
fix: fix f-string parsing at file end

### DIFF
--- a/src/snakemake/parser.py
+++ b/src/snakemake/parser.py
@@ -146,11 +146,9 @@ class TokenAutomaton:
                 break
         # trim those around the f-string
         s = "".join(lines[i] for i in sorted(lines))
-        if t1.line.endswith("\n"):
-            end = t1.end[1] - len(t1.line)
-        else:
-            # in case the f-string is the last line in a file that doesn't end in a newline
-            end = t1.end[1] - len(t1.line) - 1
+        # Compute the absolute end index in the reconstructed source snippet.
+        # This works for both files that end with and without a trailing newline.
+        end = len(s) - len(t1.line) + t1.end[1]
         t = s[token.start[1] : end]
         if hasattr(self, "cmd") and self.cmd[-1][1] == token:
             self.cmd[-1] = t, token

--- a/tests/test_function_f_string/Snakefile
+++ b/tests/test_function_f_string/Snakefile
@@ -1,0 +1,4 @@
+def get_something():
+    prefix = "foo"
+    filename = "bar"
+    return f"{prefix}/{filename}"

--- a/tests/test_function_f_string_newline/Snakefile
+++ b/tests/test_function_f_string_newline/Snakefile
@@ -1,0 +1,4 @@
+def get_something():
+    prefix = "foo"
+    filename = "bar"
+    return f"{prefix}/{filename}"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1038,6 +1038,14 @@ def test_issue823_1():
     run(dpath("test_issue823_1"))
 
 
+def test_function_f_string():
+    run(dpath("test_function_f_string"), executor="dryrun", check_results=False)
+
+
+def test_function_f_string_newline():
+    run(dpath("test_function_f_string_newline"), executor="dryrun", check_results=False)
+
+
 @skip_on_windows
 def test_issue823_2():
     run(dpath("test_issue823_2"))


### PR DESCRIPTION
<!--Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of f-string expressions in workflow definitions, including expressions that end with a newline.
  - Prevented parsing issues during dry-run execution of affected workflows.

- **Tests**
  - Added coverage for f-string expressions in function-based workflow definitions, with and without trailing newlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->