### PR TITLE
fix: cache path existence

### DIFF
--- a/src/snakemake/caching/__init__.py
+++ b/src/snakemake/caching/__init__.py
@@ -33,6 +33,12 @@ class AbstractOutputFileCache:
             self.cache_location = os.environ[LOCATION_ENVVAR]
         except KeyError:
             raise MissingOutputFileCachePathException()
+
+        try:
+            Path(self.cache_location).mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            self.raise_write_error(self.cache_location, e)
+
         self.provenance_hash_map = ProvenanceHashMap()
 
     @abstractmethod

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1898,6 +1898,18 @@ def test_output_file_cache_storage(s3_storage):
     )
 
 
+def test_output_file_cache_creates_cache_directory(tmp_path, monkeypatch):
+    from snakemake.caching.local import OutputFileCache
+
+    cache_dir = tmp_path / "nested" / "cache"
+    assert not cache_dir.exists()
+
+    monkeypatch.setenv("SNAKEMAKE_OUTPUT_CACHE", str(cache_dir))
+    OutputFileCache()
+
+    assert cache_dir.is_dir()
+
+
 @pytest.mark.parametrize("executor", ["dryrun", "touch"])
 @patch("snakemake.dag.DAG.retrieve_storage_inputs", new_callable=AsyncMock)
 def test_storage_noretrieve_dryrun_or_touch(mock_retrieve_storage_inputs, executor):


### PR DESCRIPTION
The other day, I was launching a new workflow and defined `SNAKEMAKE_OUTPUT_CACHE`. The workflow crashed and crashed. In the office it was > 30 C, so I failed to notice the error message. What if we ensure the cache directory is created, in case it does not exist?

### QC

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Output caching now automatically creates missing cache directories, including nested parent directories.
  * Directory-creation failures are reported using the existing cache write error behavior.

* **Tests**
  * Added coverage confirming cache directories are created correctly when configured through `SNAKEMAKE_OUTPUT_CACHE`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->