### PR TITLE
fix: in scripts/wrappers using shell(), auto-infer thread count from …

### DIFF
--- a/src/snakemake/shell.py
+++ b/src/snakemake/shell.py
@@ -185,8 +185,14 @@ class shell:
             # implicitly via the rule func context, which is added here.
             context = func_context
         else:
-            # Otherwise, context is just filled via kwargs.
-            context = dict()
+            if "snakemake" in func_context:
+                # We are called from a script/wrapper.
+                # Infer threads from snakemake object, so that env variables like
+                # OMP_NUM_THREADS have reasonable defaults instead of 1
+                context = {"threads": func_context["snakemake"].threads}
+            else:
+                # Otherwise, context is just filled via kwargs.
+                context = dict()
         # add kwargs to context (overwriting the locals of the caller)
         context.update(kwargs)
 

--- a/src/snakemake/shell.py
+++ b/src/snakemake/shell.py
@@ -185,7 +185,9 @@ class shell:
             # implicitly via the rule func context, which is added here.
             context = func_context
         else:
-            if "snakemake" in func_context:
+            if "snakemake" in func_context and hasattr(
+                func_context["snakemake"], "threads"
+            ):
                 # We are called from a script/wrapper.
                 # Infer threads from snakemake object, so that env variables like
                 # OMP_NUM_THREADS have reasonable defaults instead of 1


### PR DESCRIPTION
On behalf of @johanneskoester , I submit his fix for correctly propagating a rule's thread resource when using `shell()` inside a wrapper or script in case the called tool queries certain environment variables for available computation resources. The issue occurred in the wrapper for `vg giraffe` because it ended up using only one CPU thread, even when the surrounding rule defined a higher thread count. With the provided fix, the wrapper correctly uses all given CPU threads.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell commands invoked through scripts or wrappers now correctly inherit the configured thread count when available.
  * Existing behavior is preserved when no workflow context is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->