### PR TITLE
fix: touch and wildcard_constraints

### DIFF
--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -285,7 +285,6 @@ class Job(
         self._queue_input = set()
         for f in self.output:
             f_ = output_mapping[f]
-
             if is_flagged(f_, "temp"):
                 self.temp_output.add(f)
             if is_flagged(f_, "protected"):

--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -285,11 +285,12 @@ class Job(
         self._queue_input = set()
         for f in self.output:
             f_ = output_mapping[f]
-            if f_ in self.rule.temp_output:
+
+            if is_flagged(f_, "temp"):
                 self.temp_output.add(f)
-            if f_ in self.rule.protected_output:
+            if is_flagged(f_, "protected"):
                 self.protected_output.add(f)
-            if f_ in self.rule.touch_output:
+            if is_flagged(f_, "touch"):
                 self.touch_output.add(f)
             if is_flagged(f_, "pipe") or is_flagged(f_, "service"):
                 self.pipe_or_service_output.add(f)

--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -105,9 +105,6 @@ class Rule(RuleInterface):
         self._params = Params()
         self._wildcard_constraints = dict()
         self.dependencies = dict()
-        self.temp_output = set()
-        self.protected_output = set()
-        self.touch_output = set()
         self.shadow_depth = None
         self.resources: Resources | None = None
         self.priority = 0
@@ -541,15 +538,6 @@ class Rule(RuleInterface):
             _item = IOFile(item, rule=self)
             _item.check()
 
-            if is_flagged(item, "temp"):
-                if output:
-                    self.temp_output.add(_item)
-            if is_flagged(item, "protected"):
-                if output:
-                    self.protected_output.add(_item)
-            if is_flagged(item, "touch"):
-                if output:
-                    self.touch_output.add(_item)
             if is_flagged(item, "report"):
                 report_obj = item.flags["report"]
                 if report_obj.caption is not None:

--- a/tests/test_touch/Snakefile
+++ b/tests/test_touch/Snakefile
@@ -1,5 +1,13 @@
-rule:
+rule all:
+    input:
+        "test.out",
+
+
+rule name:
     output:
-        touch("test.out")
+        touch("{name}.out"),
     shell:
         "exit 0"
+
+wildcard_constraints:
+    name="test",


### PR DESCRIPTION
<!--Add a description of your PR here-->
Fixes #3645

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of output file flags after wildcard expansion.
  * Ensured temporary, protected, and touch outputs are classified correctly for each generated file.

* **Tests**
  * Updated touch-based workflow tests to explicitly verify generation of the expected `test.out` file.
  * Added validation for supported output naming and improved coverage of generated output classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->