### PR TITLE
fix: Snakemake sometimes checks the wrong copy of an output file's info, causing spurious reruns

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1493,8 +1493,10 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                             files.update(
                                 f for f in job.products() if f in self.targetfiles
                             )
+                    canonical = {str(f): f for f in job.output}
+                    canonical_files = [canonical.get(str(f), f) for f in files]
                     reason.missing_output.update(
-                        [f async for f in job.missing_output(files)]
+                        [f async for f in job.missing_output(canonical_files)]
                     )
             if not reason:
                 output_mintime_ = output_mintime.get(job)
@@ -1636,7 +1638,11 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
 
                 for job_, files in dependencies[job].items():
                     if job_ in candidates_set:
-                        missing_output = [f async for f in job_.missing_output(files)]
+                        canonical = {str(f): f for f in job_.output}
+                        canonical_files = [canonical.get(str(f), f) for f in files]
+                        missing_output = [
+                            f async for f in job_.missing_output(canonical_files)
+                        ]
                         reason(job_).missing_output.update(missing_output)
                         if missing_output and job_ not in visited:
                             logger.debug(

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -1493,10 +1493,8 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
                             files.update(
                                 f for f in job.products() if f in self.targetfiles
                             )
-                    canonical = {str(f): f for f in job.output}
-                    canonical_files = [canonical.get(str(f), f) for f in files]
                     reason.missing_output.update(
-                        [f async for f in job.missing_output(canonical_files)]
+                        [f async for f in job.missing_output(files)]
                     )
             if not reason:
                 output_mintime_ = output_mintime.get(job)
@@ -1638,11 +1636,7 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
 
                 for job_, files in dependencies[job].items():
                     if job_ in candidates_set:
-                        canonical = {str(f): f for f in job_.output}
-                        canonical_files = [canonical.get(str(f), f) for f in files]
-                        missing_output = [
-                            f async for f in job_.missing_output(canonical_files)
-                        ]
+                        missing_output = [f async for f in job_.missing_output(files)]
                         reason(job_).missing_output.update(missing_output)
                         if missing_output and job_ not in visited:
                             logger.debug(

--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -723,7 +723,14 @@ class Job(
         return mintime
 
     async def missing_output(self, requested):
+        """Yield requested outputs that are missing."""
+        # requested may hold path-equal copies of our own output that lost
+        # their flags (e.g. storage).
+        output_by_path = {str(f): f for f in self.output}
+
         async def handle_file(f):
+            f = output_by_path.get(str(f), f)
+
             # pipe or service output is always declared as missing
             # (even if it might be present on disk for some reason)
             if (

--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -200,6 +200,7 @@ class Job(
         "_input",
         "dependencies",
         "_output",
+        "_output_by_path",
         "_params",
         "_log",
         "_benchmark",
@@ -350,6 +351,14 @@ class Job(
     @output.setter
     def output(self, value):
         self._output = value
+        if hasattr(self, "_output_by_path"):
+            del self._output_by_path
+
+    @lazy_property
+    def output_by_path(self):
+        # requested may hold path-equal copies of our own output that lost
+        # their flags (e.g. storage). We look them up here by path instead.
+        return {str(f): f for f in self.output}
 
     def logfile_suggestion(self, prefix: str) -> str:
         """Return a suggestion for the log file name given a prefix."""
@@ -724,12 +733,9 @@ class Job(
 
     async def missing_output(self, requested):
         """Yield requested outputs that are missing."""
-        # requested may hold path-equal copies of our own output that lost
-        # their flags (e.g. storage).
-        output_by_path = {str(f): f for f in self.output}
 
         async def handle_file(f):
-            f = output_by_path.get(str(f), f)
+            f = self.output_by_path.get(str(f), f)
 
             # pipe or service output is always declared as missing
             # (even if it might be present on disk for some reason)

--- a/tests/test_storage_dependency_edge_flags/Snakefile
+++ b/tests/test_storage_dependency_edge_flags/Snakefile
@@ -1,0 +1,46 @@
+storage:
+    provider="s3",
+    retries=5
+
+
+REMOTE = f"{config['s3_prefix']}/producer.txt"
+
+
+rule all:
+    input:
+        "downstream.txt"
+
+
+rule producer:
+    output:
+        remote=storage.s3(REMOTE)
+    shell:
+        r"""
+        # Make a spurious second execution fail loudly.
+        test ! -e producer.ran
+        touch producer.ran
+        printf 'producer\n' > {output.remote}
+        """
+
+
+def stale_producer_edge(wildcards):
+    # Build the producer's concrete local staging path correctly, then
+    # intentionally drop the _IOFile flags. This models the stale edge
+    # observed after checkpoint DAG rewriting: same path, flags == {}.
+    canonical = rules.producer.output.remote.apply_wildcards({})
+    assert canonical.is_storage
+    return str(canonical)
+
+
+rule consumer:
+    input:
+        # Ordering is intentional. _IOFile equality/hash is path-based, so
+        # when equal dependency-edge paths are deduplicated, the first object
+        # can survive. The second input is the correct storage-aware view and
+        # also makes the workflow executable after the producer is skipped.
+        stale=stale_producer_edge,
+        good=storage.s3(REMOTE)
+    output:
+        "downstream.txt"
+    shell:
+        "cat {input.good} > {output}"

--- a/tests/test_storage_dependency_edge_flags/Snakefile
+++ b/tests/test_storage_dependency_edge_flags/Snakefile
@@ -23,9 +23,9 @@ rule producer:
         """
 
 
-def stale_producer_edge(wildcards):
+def unflagged_producer_edge(wildcards):
     # Build the producer's concrete local staging path correctly, then
-    # intentionally drop the _IOFile flags. This models the stale edge
+    # intentionally drop the _IOFile flags. This models the unflagged edge
     # observed after checkpoint DAG rewriting: same path, flags == {}.
     canonical = rules.producer.output.remote.apply_wildcards({})
     assert canonical.is_storage
@@ -38,7 +38,7 @@ rule consumer:
         # when equal dependency-edge paths are deduplicated, the first object
         # can survive. The second input is the correct storage-aware view and
         # also makes the workflow executable after the producer is skipped.
-        stale=stale_producer_edge,
+        unflagged=unflagged_producer_edge,
         good=storage.s3(REMOTE)
     output:
         "downstream.txt"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -857,6 +857,51 @@ def test_storage(s3_storage):
 
 @skip_on_windows  # no minio deployment on windows implemented in our CI
 @pytest.mark.needs_s3
+def test_storage_output_not_missing_via_unflagged_dependency_edge(s3_storage):
+    """A stale consumer edge must not override producer storage semantics."""
+    prefix, settings = s3_storage
+    path = dpath("test_storage_dependency_edge_flags")
+
+    # First invocation materializes producer.txt in S3 and records metadata.
+    tmpdir = run(
+        path,
+        cores=1,
+        config={"s3_prefix": prefix},
+        storage_provider_settings=settings,
+        check_results=False,
+        cleanup=False,
+    )
+    assert tmpdir is not None
+
+    try:
+        assert (tmpdir / "producer.ran").exists()
+
+        # Model a fresh machine/invocation: provenance remains, but the local
+        # storage staging cache does not. Force only the consumer to needrun.
+        shutil.rmtree(tmpdir / ".snakemake" / "storage", ignore_errors=True)
+        (tmpdir / "downstream.txt").unlink()
+
+        # Correct behavior: consumer reruns, producer is recognized as already
+        # present in storage. Buggy behavior: update_needrun() checks the stale
+        # unflagged edge locally, schedules producer again, and producer's
+        # sentinel makes this invocation fail.
+        run(
+            path,
+            cores=1,
+            config={"s3_prefix": prefix},
+            storage_provider_settings=settings,
+            check_results=False,
+            cleanup=False,
+            tmpdir=tmpdir,
+        )
+
+        assert (tmpdir / "downstream.txt").read_text() == "producer\n"
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=ON_WINDOWS)
+
+
+@skip_on_windows  # no minio deployment on windows implemented in our CI
+@pytest.mark.needs_s3
 def test_storage_call(s3_storage):
     prefix, settings = s3_storage
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -858,7 +858,7 @@ def test_storage(s3_storage):
 @skip_on_windows  # no minio deployment on windows implemented in our CI
 @pytest.mark.needs_s3
 def test_storage_output_not_missing_via_unflagged_dependency_edge(s3_storage):
-    """A stale consumer edge must not override producer storage semantics."""
+    """An unflagged consumer edge must not override producer storage semantics."""
     prefix, settings = s3_storage
     path = dpath("test_storage_dependency_edge_flags")
 


### PR DESCRIPTION
When deciding whether a job's dependency is already done, snakemake currently sometimes checks a copy of that output's file reference instead of the real one the producing rule declared, and that copy can be missing important information (like "this lives in S3, not on local disk"), causing Snakemake to look in the wrong place and wrongly conclude the file doesn't exist.

The fix looks up the producing rule's real output object by matching its path, and uses that instead.

First pushed the tests that break currently (see red check), then pushed the fix.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflows with storage-backed outputs that could be incorrectly treated as missing after dependency graph updates.
  * Ensured downstream steps reuse existing producer outputs instead of rerunning completed work.
  * Improved reliability when local storage staging files are removed and outputs must be recreated.

* **Tests**
  * Added integration coverage for S3-backed workflows and dependency edge handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->