### PR TITLE
fix: preserve flags when formatting _IOFile

### DIFF
--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -896,6 +896,25 @@ class _IOFile(str, AnnotatedStringInterface):
             with open(file, "w") as f:
                 pass
 
+    def format(self, *args, **kwargs):
+        """Override str.format() to guard against silently dropping flags."""
+        from snakemake.path_modifier import PATH_MODIFIER_FLAG
+
+        significant_flags = {
+            key: value
+            for key, value in self.flags.items()
+            if key != PATH_MODIFIER_FLAG
+        }
+        if significant_flags:
+            raise WorkflowError(
+                f"Flags ({significant_flags}) on file '{self}' would be silently lost by "
+                "calling .format() on it (str.format() has no notion of flags such as "
+                "storage.s3(), temp(), or directory(), and does not preserve them). Use "
+                ".apply_wildcards(wildcards_dict) instead, which is the flag-preserving "
+                "equivalent for substituting wildcards into a single file pattern."
+            )
+        return super().format(*args, **kwargs)
+
     def apply_wildcards(self, wildcards):
         f = self._file
 

--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -901,9 +901,7 @@ class _IOFile(str, AnnotatedStringInterface):
         from snakemake.path_modifier import PATH_MODIFIER_FLAG
 
         significant_flags = {
-            key: value
-            for key, value in self.flags.items()
-            if key != PATH_MODIFIER_FLAG
+            key: value for key, value in self.flags.items() if key != PATH_MODIFIER_FLAG
         }
         if significant_flags:
             raise WorkflowError(

--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -897,21 +897,27 @@ class _IOFile(str, AnnotatedStringInterface):
                 pass
 
     def format(self, *args, **kwargs):
-        """Override str.format() to guard against silently dropping flags."""
-        from snakemake.path_modifier import PATH_MODIFIER_FLAG
+        """Override str.format() to carry flags (e.g. temp(), directory()) over to the
+        formatted result, instead of silently dropping them as plain str.format() would.
 
-        significant_flags = {
-            key: value for key, value in self.flags.items() if key != PATH_MODIFIER_FLAG
-        }
-        if significant_flags:
+        storage_object is excluded: it embeds its own query string, which apply_wildcards()
+        rebuilds consistently with the substituted wildcards. str.format() has no notion of
+        that, so a storage-flagged file cannot be formatted this way and must go through
+        apply_wildcards() instead.
+        """
+        if self.is_storage:
             raise WorkflowError(
-                f"Flags ({significant_flags}) on file '{self}' would be silently lost by "
-                "calling .format() on it (str.format() has no notion of flags such as "
-                "storage.s3(), temp(), or directory(), and does not preserve them). Use "
-                ".apply_wildcards(wildcards_dict) instead, which is the flag-preserving "
-                "equivalent for substituting wildcards into a single file pattern."
+                f"Cannot call .format() on storage file '{self}': str.format() has no "
+                "notion of storage.s3() and similar flags, and would leave the storage "
+                "query out of sync with the substituted wildcards. Use "
+                ".apply_wildcards(wildcards_dict) instead, which rebuilds the storage "
+                "query correctly."
             )
-        return super().format(*args, **kwargs)
+        formatted = super().format(*args, **kwargs)
+        if self.flags:
+            formatted = AnnotatedString(formatted)
+            formatted.flags = self.flags.copy()
+        return formatted
 
     def apply_wildcards(self, wildcards):
         f = self._file

--- a/src/snakemake/io/__init__.py
+++ b/src/snakemake/io/__init__.py
@@ -275,7 +275,35 @@ def iocache(
     return wrapper
 
 
-class _IOFile(str, AnnotatedStringInterface):
+class AnnotatedStringFormatMixin(AnnotatedStringInterface):
+    """Mixin for str subclasses that carry flags (e.g. temp(), directory()) via
+    AnnotatedStringInterface. Overrides str.format() to carry those flags over to the
+    formatted result, instead of silently dropping them as plain str.format() would.
+
+    Must precede str in the MRO of the concrete class (i.e. `class Foo(Mixin, str)`,
+    not `class Foo(str, Mixin)`), otherwise str.format() would shadow this override.
+    """
+
+    def _storage_format_error_msg(self) -> str:
+        return (
+            f"Cannot call .format() on storage-flagged value '{self}': str.format() "
+            "has no notion of storage.s3() and similar flags, and would leave the "
+            "storage query out of sync with the substituted wildcards."
+        )
+
+    def format(self, *args, **kwargs):
+        if self.is_flagged("storage_object"):
+            raise WorkflowError(self._storage_format_error_msg())
+        # narrows self for the type checker: this mixin is only valid on str subclasses
+        assert isinstance(self, str)
+        formatted = str.format(self, *args, **kwargs)
+        if self.flags:
+            formatted = AnnotatedString(formatted)
+            formatted.flags = self.flags.copy()
+        return formatted
+
+
+class _IOFile(AnnotatedStringFormatMixin, str):
     """
     A file that is either input or output of a rule.
     """
@@ -896,28 +924,16 @@ class _IOFile(str, AnnotatedStringInterface):
             with open(file, "w") as f:
                 pass
 
-    def format(self, *args, **kwargs):
-        """Override str.format() to carry flags (e.g. temp(), directory()) over to the
-        formatted result, instead of silently dropping them as plain str.format() would.
-
-        storage_object is excluded: it embeds its own query string, which apply_wildcards()
-        rebuilds consistently with the substituted wildcards. str.format() has no notion of
-        that, so a storage-flagged file cannot be formatted this way and must go through
-        apply_wildcards() instead.
-        """
-        if self.is_storage:
-            raise WorkflowError(
-                f"Cannot call .format() on storage file '{self}': str.format() has no "
-                "notion of storage.s3() and similar flags, and would leave the storage "
-                "query out of sync with the substituted wildcards. Use "
-                ".apply_wildcards(wildcards_dict) instead, which rebuilds the storage "
-                "query correctly."
-            )
-        formatted = super().format(*args, **kwargs)
-        if self.flags:
-            formatted = AnnotatedString(formatted)
-            formatted.flags = self.flags.copy()
-        return formatted
+    def _storage_format_error_msg(self) -> str:
+        # storage_object is excluded from format(): it embeds its own query string,
+        # which apply_wildcards() rebuilds consistently with the substituted wildcards.
+        # str.format() has no notion of that, so a storage-flagged file cannot be
+        # formatted this way and must go through apply_wildcards() instead.
+        return (
+            super()._storage_format_error_msg()
+            + " Use .apply_wildcards(wildcards_dict) instead, which rebuilds the "
+            "storage query correctly."
+        )
 
     def apply_wildcards(self, wildcards):
         f = self._file
@@ -1030,7 +1046,7 @@ class _IOFile(str, AnnotatedStringInterface):
         return self._file.__hash__()
 
 
-class AnnotatedString(str, AnnotatedStringInterface):
+class AnnotatedString(AnnotatedStringFormatMixin, str):
     def __init__(self, value):
         self._flags = {}
         self.callable = value if is_callable(value) else None

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -156,6 +156,7 @@ def test_iofile_format_preserves_path_modifier_flag():
 def test_iofile_format_raises_on_storage_file():
     """Storage flags cannot be copied after formatting because their
     query must remain consistent with the formatted local path."""
+
     class FakeStorageObject:
         def __init__(self, query):
             self.query = query

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,16 @@
 from pathlib import PosixPath
 
-from snakemake.io import WILDCARD_REGEX, IOFile, expand, temp
+from snakemake.io import (
+    WILDCARD_REGEX,
+    IOFile,
+    directory,
+    expand,
+    flag,
+    is_flagged,
+    temp,
+)
 from snakemake.exceptions import WildcardError, WorkflowError
+from snakemake.path_modifier import PATH_MODIFIER_FLAG
 
 
 def test_wildcard_regex():
@@ -107,31 +116,69 @@ def test_expand():
     assert expand(PosixPath() / "{x}" / "{y}", x="Hello", y="world") == ["Hello/world"]
 
 
-def test_iofile_format_raises_on_flagged_file():
-    """.format() on a flagged _IOFile (e.g. temp(), storage.s3()) must not silently drop the
-    flag. It's an inherited plain str.format() call, which has no notion of flags at all and
-    returns a bare str -- unlike apply_wildcards(), which snakemake's own expand() uses
-    internally and which correctly preserves flags across wildcard substitution. Mirrors the
-    existing guard in expand() itself (see test_expand's lack of coverage for this -- expand()
-    raises WorkflowError for an already-flagged pattern rather than silently mishandling it;
-    .format() previously had no equivalent protection)."""
+def test_iofile_format_preserves_flags():
+    """.format() on a flagged _IOFile (e.g. temp(), directory()) is an inherited plain
+    str.format() call, which has no notion of flags and used to silently return a bare str
+    with the flag gone entirely. It must instead carry the flags over to the formatted
+    result, mirroring what apply_wildcards() already does for wildcard substitution."""
     flagged = IOFile(temp("results/{sample}.txt"), rule=None)
 
-    # apply_wildcards() is the correct, flag-preserving way to do this -- confirm it actually
-    # works as the baseline this test is protecting.
-    substituted = flagged.apply_wildcards({"sample": "foo"})
-    assert substituted == "results/foo.txt"
-    assert substituted.is_temp
+    formatted = flagged.format(sample="foo")
+    assert formatted == "results/foo.txt"
+    assert is_flagged(formatted, "temp")
 
-    # .format() must refuse rather than silently return an unflagged (and not even _IOFile)
-    # result.
-    try:
-        flagged.format(sample="foo")
-        assert False, ".format() on a flagged _IOFile should raise WorkflowError"
-    except WorkflowError:
-        pass
-
-    # a plain, unflagged file has nothing to lose, so .format() keeps working as ordinary
+    # a plain, unflagged file has nothing to preserve, so .format() keeps working as ordinary
     # str.format() -- this override must not affect the common, harmless case.
     unflagged = IOFile("results/{sample}.txt", rule=None)
     assert unflagged.format(sample="foo") == "results/foo.txt"
+    assert not is_flagged(unflagged.format(sample="foo"), "temp")
+
+
+def test_iofile_format_preserves_multiple_flags():
+    flagged = IOFile(directory(temp("results/{sample}")), rule=None)
+
+    formatted = flagged.format(sample="foo")
+    assert formatted == "results/foo"
+    assert is_flagged(formatted, "temp")
+    assert is_flagged(formatted, "directory")
+
+
+def test_iofile_format_preserves_path_modifier_flag():
+    """CodeRabbit flagged that a file carrying only PATH_MODIFIER_FLAG would previously lose
+    that marker on .format(), because a plain str result has no flags at all -- risking the
+    path modifier being (re-)applied a second time downstream."""
+    flagged = IOFile(flag("results/{sample}.txt", PATH_MODIFIER_FLAG), rule=None)
+
+    formatted = flagged.format(sample="foo")
+    assert formatted == "results/foo.txt"
+    assert is_flagged(formatted, PATH_MODIFIER_FLAG)
+
+
+def test_iofile_format_raises_on_storage_file():
+    """storage_object embeds its own query string, which apply_wildcards() rebuilds
+    consistently with the substituted wildcards. .format() has no notion of that, so naively
+    copying the (unmodified) storage_object flag over to the formatted result would leave the
+    formatted local path paired with a stale, unformatted storage query. Until .format()
+    learns to rebuild that query itself, it must refuse rather than silently produce an
+    inconsistent storage file."""
+
+    class FakeStorageObject:
+        def __init__(self, query):
+            self.query = query
+
+    flagged_storage = IOFile(
+        flag(
+            "results/{sample}.txt",
+            "storage_object",
+            FakeStorageObject("s3://bucket/{sample}.txt"),
+        ),
+        rule=None,
+    )
+
+    try:
+        flagged_storage.format(sample="foo")
+        raise AssertionError(
+            ".format() on a storage-flagged _IOFile should raise WorkflowError"
+        )
+    except WorkflowError:
+        pass

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -144,9 +144,8 @@ def test_iofile_format_preserves_multiple_flags():
 
 
 def test_iofile_format_preserves_path_modifier_flag():
-    """CodeRabbit flagged that a file carrying only PATH_MODIFIER_FLAG would previously lose
-    that marker on .format(), because a plain str result has no flags at all -- risking the
-    path modifier being (re-)applied a second time downstream."""
+    """Formatting must preserve PATH_MODIFIER_FLAG to avoid applying
+    path modifiers twice."""
     flagged = IOFile(flag("results/{sample}.txt", PATH_MODIFIER_FLAG), rule=None)
 
     formatted = flagged.format(sample="foo")
@@ -155,13 +154,8 @@ def test_iofile_format_preserves_path_modifier_flag():
 
 
 def test_iofile_format_raises_on_storage_file():
-    """storage_object embeds its own query string, which apply_wildcards() rebuilds
-    consistently with the substituted wildcards. .format() has no notion of that, so naively
-    copying the (unmodified) storage_object flag over to the formatted result would leave the
-    formatted local path paired with a stale, unformatted storage query. Until .format()
-    learns to rebuild that query itself, it must refuse rather than silently produce an
-    inconsistent storage file."""
-
+    """Storage flags cannot be copied after formatting because their
+    query must remain consistent with the formatted local path."""
     class FakeStorageObject:
         def __init__(self, query):
             self.query = query

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ from pathlib import PosixPath
 
 from snakemake.io import (
     WILDCARD_REGEX,
+    AnnotatedString,
     IOFile,
     directory,
     expand,
@@ -175,5 +176,60 @@ def test_iofile_format_raises_on_storage_file():
         raise AssertionError(
             ".format() on a storage-flagged _IOFile should raise WorkflowError"
         )
-    except WorkflowError:
-        pass
+    except WorkflowError as e:
+        # _IOFile has an apply_wildcards() alternative that AnnotatedString lacks, so
+        # it must get the more specific message pointing users to it.
+        assert "apply_wildcards" in str(e)
+
+
+def test_annotated_string_format_preserves_flags():
+    """temp(), directory(), etc. attach flags to a plain AnnotatedString before it is
+    ever wrapped as an _IOFile, so .format() can be called on it directly."""
+    flagged = temp("results/{sample}.txt")
+    assert isinstance(flagged, AnnotatedString)
+
+    formatted = flagged.format(sample="foo")
+    assert formatted == "results/foo.txt"
+    assert is_flagged(formatted, "temp")
+
+    # a plain, unflagged AnnotatedString has nothing to preserve, so .format() keeps
+    # working as ordinary str.format() -- this override must not affect that case.
+    unflagged = AnnotatedString("results/{sample}.txt")
+    assert unflagged.format(sample="foo") == "results/foo.txt"
+    assert not is_flagged(unflagged.format(sample="foo"), "temp")
+
+
+def test_annotated_string_format_preserves_multiple_flags():
+    flagged = directory(temp("results/{sample}"))
+    assert isinstance(flagged, AnnotatedString)
+
+    formatted = flagged.format(sample="foo")
+    assert formatted == "results/foo"
+    assert is_flagged(formatted, "temp")
+    assert is_flagged(formatted, "directory")
+
+
+def test_annotated_string_format_raises_on_storage_flag():
+    """Mirrors test_iofile_format_raises_on_storage_file(), but for the AnnotatedString
+    that storage() returns directly, before it is ever wrapped in an _IOFile."""
+
+    class FakeStorageObject:
+        def __init__(self, query):
+            self.query = query
+
+    flagged_storage = flag(
+        "results/{sample}.txt",
+        "storage_object",
+        FakeStorageObject("s3://bucket/{sample}.txt"),
+    )
+    assert isinstance(flagged_storage, AnnotatedString)
+
+    try:
+        flagged_storage.format(sample="foo")
+        raise AssertionError(
+            ".format() on a storage-flagged AnnotatedString should raise WorkflowError"
+        )
+    except WorkflowError as e:
+        # AnnotatedString has no apply_wildcards(), so it must not get the _IOFile-
+        # specific message that points users to it.
+        assert "apply_wildcards" not in str(e)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,7 @@
 from pathlib import PosixPath
 
-from snakemake.io import WILDCARD_REGEX, expand
-from snakemake.exceptions import WildcardError
+from snakemake.io import WILDCARD_REGEX, IOFile, expand, temp
+from snakemake.exceptions import WildcardError, WorkflowError
 
 
 def test_wildcard_regex():
@@ -105,3 +105,33 @@ def test_expand():
 
     # expand on pathlib.Path objects
     assert expand(PosixPath() / "{x}" / "{y}", x="Hello", y="world") == ["Hello/world"]
+
+
+def test_iofile_format_raises_on_flagged_file():
+    """.format() on a flagged _IOFile (e.g. temp(), storage.s3()) must not silently drop the
+    flag. It's an inherited plain str.format() call, which has no notion of flags at all and
+    returns a bare str -- unlike apply_wildcards(), which snakemake's own expand() uses
+    internally and which correctly preserves flags across wildcard substitution. Mirrors the
+    existing guard in expand() itself (see test_expand's lack of coverage for this -- expand()
+    raises WorkflowError for an already-flagged pattern rather than silently mishandling it;
+    .format() previously had no equivalent protection)."""
+    flagged = IOFile(temp("results/{sample}.txt"), rule=None)
+
+    # apply_wildcards() is the correct, flag-preserving way to do this -- confirm it actually
+    # works as the baseline this test is protecting.
+    substituted = flagged.apply_wildcards({"sample": "foo"})
+    assert substituted == "results/foo.txt"
+    assert substituted.is_temp
+
+    # .format() must refuse rather than silently return an unflagged (and not even _IOFile)
+    # result.
+    try:
+        flagged.format(sample="foo")
+        assert False, ".format() on a flagged _IOFile should raise WorkflowError"
+    except WorkflowError:
+        pass
+
+    # a plain, unflagged file has nothing to lose, so .format() keeps working as ordinary
+    # str.format() -- this override must not affect the common, harmless case.
+    unflagged = IOFile("results/{sample}.txt", rule=None)
+    assert unflagged.format(sample="foo") == "results/foo.txt"


### PR DESCRIPTION
the _IOFile.format() method is inherited from str.format(), which has no concept of flags and silently returns a plain string with the storage_object/temp/etc. flag gone entirely. For example, apply_wildcards() preserves flags across wildcard substitution. This fix mirrors the existing guard already in expand() (which rejects an already-flagged pattern outright) by raising a clear WorkflowError pointing at apply_wildcards() instead, rather than letting the mistake silently corrupt downstream existence/storage semantics.

First pushed the tests that break currently (see red check), then pushed the fix.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary and directory-marked files during formatting.
  * Formatting now preserves applicable file flags.
  * Formatting storage-backed files now reports a clear workflow error and recommends wildcard substitution instead.
  * Standard formatting continues to work as expected when no restricted flags are present.

* **Tests**
  * Added coverage for multiple file flags, path-modifying flags, wildcard substitution, and formatting error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->