### PR TITLE
fix: update shadow directory handling and logging for incomplete jobs

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -2318,10 +2318,9 @@ unless you reference parent directories relative to your workdir in a rule.
         shadow: "shallow"
         shell: "somecommand --other_outputs other.txt {input} {output}"
 
-Shadow directories are stored one per rule execution in ``.snakemake/shadow/``,
-and are cleared on successful execution.
-Consider running with the ``--cleanup-shadow`` argument every now and then
-to remove any remaining shadow directories from aborted jobs.
+Shadow directories are stored one per rule execution in ``.snakemake/shadow/``, and are cleared on successful execution.
+For debugging purposes, ``--keep-incomplete`` command line argument can be used to keep the shadow directories of failed jobs.
+Consider running with the ``--cleanup-shadow`` argument every now and then to remove any remaining shadow directories from aborted jobs.
 The base shadow directory can be changed with the ``--shadow-prefix`` command line argument.
 
 .. _snakefiles_retries:

--- a/src/snakemake/scheduling/job_scheduler.py
+++ b/src/snakemake/scheduling/job_scheduler.py
@@ -7,10 +7,9 @@ __license__ = "MIT"
 
 import asyncio
 from bisect import bisect
-from collections import defaultdict, deque
+from collections import deque
 import copy
-import math
-import os, signal, sys
+import signal, sys
 import threading
 
 from itertools import chain, accumulate, filterfalse, repeat
@@ -46,7 +45,7 @@ def cumsum(iterable, zero=[0]):
 
 
 _ERROR_MSG_FINAL = (
-    "Exiting because a job execution failed. Look below for error messages"
+    "Exiting because a job execution failed. Look above for error messages"
 )
 
 _ERROR_MSG_ISSUE_823 = (
@@ -253,8 +252,6 @@ class JobScheduler(JobSchedulerExecutorInterface):
                         self._executor.shutdown()
                         if not user_kill:
                             logger.error(_ERROR_MSG_FINAL)
-                            for job in self.failed:
-                                job.log_error()
                         return False
                     continue
 
@@ -270,8 +267,6 @@ class JobScheduler(JobSchedulerExecutorInterface):
                     self._executor.shutdown()
                     if errors:
                         logger.error(_ERROR_MSG_FINAL)
-                        for job in self.failed:
-                            job.log_error()
                     # we still have unfinished jobs. this is not good. direct
                     # user to github issue
                     if self.remaining_jobs and not self.keepgoing:

--- a/src/snakemake/workflow.py
+++ b/src/snakemake/workflow.py
@@ -1552,6 +1552,11 @@ class Workflow(WorkflowExecutorInterface):
                 if not self.dryrun and not self.execution_settings.no_hooks:
                     self._onerror(self.logger_manager.get_logfile())
                 self.logger_manager.logfile_hint()
+                if self.execution_settings.keep_incomplete:
+                    logger.warning(
+                        "--keep-incomplete mode is set, so incomplete output files "
+                        "and shadow directories of failed jobs are not removed."
+                    )
                 raise WorkflowError("At least one job did not complete successfully.")
 
     def log_metadata_info(self, metadata_attr, description):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -413,7 +413,7 @@ def test_rule_failure(
             LogEvent.SHELLCMD: 3,
             LogEvent.RESOURCES_INFO: 2,
             LogEvent.JOB_STARTED: None,
-            LogEvent.JOB_ERROR: 6,
+            LogEvent.JOB_ERROR: 3,
         },
     )
 
@@ -453,7 +453,7 @@ def test_group_job_failure_events(
         event_counts,
         {
             LogEvent.GROUP_INFO: 3,
-            LogEvent.GROUP_ERROR: 6,
+            LogEvent.GROUP_ERROR: 3,
         },
         partial=True,
     )


### PR DESCRIPTION
Closes #4281: documents the shadow-directory behavior under `--keep-incomplete`, and emits a closing `--keep-incomplete` warning.

Meanwhile, @cademirch I proposed to revert the failed-job reprint that was added at scheduler shutdown in PR #3107 (inside commit 8d874322c326ac9f74f47d089e43717de8b65531)

The failed-job reprint introduced in PR #3107 duplicates error messages that are already emitted when the jobs fail, and it cannot surface failure details that only exist in the spawned job process, such as 'Keeping shadow directory: ... Run snakemake with --cleanup-shadow to clean up shadow directories'.
Instead, users who want an end-of-run recap of warnings and errors can enable the opt-in logger plugin [snakemake-logger-plugin-sumerrs](https://pypi.org/project/snakemake-logger-plugin-sumerrs/), which collects warnings, errors and job failures during the run and reprints them once when the run ends, without duplicating them into the logfile or other log handlers.


### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added clearer warnings when incomplete outputs and shadow directories are preserved after failed jobs.
  * Documented that `--keep-incomplete` preserves shadow directories from failed jobs.

* **Bug Fixes**
  * Improved workflow failure messaging by directing users to the relevant error messages above.
  * Reduced duplicate failed-job error reporting during workflow shutdown.
  * Updated error event reporting to prevent repeated failure notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->