### PR TITLE
feat: show diffs in unit tests

### DIFF
--- a/src/snakemake/unit_tests/templates/common.py.jinja2
+++ b/src/snakemake/unit_tests/templates/common.py.jinja2
@@ -3,8 +3,9 @@ Common code for unit testing of rules generated with Snakemake {{ version }}.
 """
 
 import os
+import pytest
 from pathlib import Path
-from subprocess import check_output, PIPE
+from subprocess import check_output, CalledProcessError, PIPE
 
 
 cmp_cmds = {

--- a/src/snakemake/unit_tests/templates/common.py.jinja2
+++ b/src/snakemake/unit_tests/templates/common.py.jinja2
@@ -5,7 +5,7 @@ Common code for unit testing of rules generated with Snakemake {{ version }}.
 import os
 import pytest
 from pathlib import Path
-from subprocess import check_output, CalledProcessError, PIPE
+from subprocess import check_output, CalledProcessError, STDOUT
 
 
 cmp_cmds = {
@@ -58,7 +58,8 @@ class OutputChecker:
             check_output(
                 cmp_cmds.get(expected_file.suffix, ["cmp"])
                 + [expected_file, generated_file],
-                stderr=PIPE,
+                stderr=STDOUT,
+                text=True,
             )
         except CalledProcessError as e:
             pytest.fail(

--- a/src/snakemake/unit_tests/templates/common.py.jinja2
+++ b/src/snakemake/unit_tests/templates/common.py.jinja2
@@ -53,8 +53,14 @@ class OutputChecker:
             self.compare_files(self.expected_path / f, self.workdir / f, cmp_cmds)
 
     def compare_files(self, expected_file, generated_file, cmp_cmds):
-        check_output(
-            cmp_cmds.get(expected_file.suffix, ["cmp"])
-            + [expected_file, generated_file],
-            stderr=PIPE,
-        )
+        try:
+            check_output(
+                cmp_cmds.get(expected_file.suffix, ["cmp"])
+                + [expected_file, generated_file],
+                stderr=PIPE,
+            )
+        except CalledProcessError as e:
+            pytest.fail(
+                f"{expected_file} differs:\n\n{e.output}",
+                pytrace=False,
+            )


### PR DESCRIPTION
<!--Add a description of your PR here-->
Would it make sense to add an explicit print of the cmp/diff stdout?

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file comparison test reporting by presenting comparison differences as clear test failures.
  * Suppressed unnecessary internal traceback details for cleaner error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->