### PR TITLE
feat: Print job params in log

### DIFF
--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -1084,6 +1084,7 @@ class Job(
                 log=format_files(self.log, as_output=True),
                 benchmark=benchmark,
                 wildcards=self.wildcards_dict,
+                params=self.params,
                 reason=str(self.dag.reason(self)),
                 resources=self.resources,
                 priority=(

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -81,7 +81,19 @@ def format_dict(dict_like, omit_keys=None, omit_values=None) -> str:
 
 format_resources = partial(format_dict, omit_keys={"_cores", "_nodes"})
 format_wildcards = format_dict
-format_params = format_dict
+
+
+def format_params(params) -> str:
+    from snakemake.iocontainers import Namedlist
+
+    if isinstance(params, Namedlist):
+        items = params._allitems()
+    elif isinstance(params, Mapping):
+        items = params.items()
+    else:
+        raise ValueError("params neither a dict nor a Namedlist")
+
+    return ", ".join(f"{name}={value}" if name else str(value) for name, value in items)
 
 
 def format_resource_names(resources, omit_resources="_cores _nodes".split()):

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -81,6 +81,7 @@ def format_dict(dict_like, omit_keys=None, omit_values=None) -> str:
 
 format_resources = partial(format_dict, omit_keys={"_cores", "_nodes"})
 format_wildcards = format_dict
+format_params = format_dict
 
 
 def format_resource_names(resources, omit_resources="_cores _nodes".split()):
@@ -280,7 +281,7 @@ SNAKEMAKE
         if wildcards:
             output.append(f"    wildcards: {wildcards}")
 
-        params = format_dict(msg["params"])
+        params = format_params(msg["params"])
         if params:
             output.append(f"    params: {params}")
 

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -280,6 +280,10 @@ SNAKEMAKE
         if wildcards:
             output.append(f"    wildcards: {wildcards}")
 
+        params = format_dict(msg["params"])
+        if params:
+            output.append(f"    params: {params}")
+
         for item, omit in zip("priority threads".split(), [0, 1]):
             fmt = format_item(item, omit=omit)
             if fmt:

--- a/src/snakemake/logging.py
+++ b/src/snakemake/logging.py
@@ -67,11 +67,9 @@ def format_dict(dict_like, omit_keys=None, omit_values=None) -> str:
 
     if isinstance(dict_like, (Namedlist, Mapping)):
         items = dict_like.items()
-
     else:
-        raise ValueError(
-            "bug: format_dict applied to something neither a dict nor a Namedlist"
-        )
+        raise ValueError("bug: format_dict applied to neither a dict nor a Namedlist")
+
     return ", ".join(
         f"{name}={value}"
         for name, value in items
@@ -91,7 +89,7 @@ def format_params(params) -> str:
     elif isinstance(params, Mapping):
         items = params.items()
     else:
-        raise ValueError("params neither a dict nor a Namedlist")
+        raise ValueError("bug: format_params applied to neither a dict nor a Namedlist")
 
     return ", ".join(f"{name}={value}" if name else str(value) for name, value in items)
 

--- a/tests/logging/test_logfile/Snakefile
+++ b/tests/logging/test_logfile/Snakefile
@@ -10,6 +10,7 @@ rule a:
     output:
         "results/{i}.txt",
     params:
+        "fixed",
         value=lambda wildcards: wildcards.i,
     shell:
         "echo {wildcards.i} > {output}"

--- a/tests/logging/test_logfile/Snakefile
+++ b/tests/logging/test_logfile/Snakefile
@@ -9,5 +9,7 @@ rule all:
 rule a:
     output:
         "results/{i}.txt",
+    params:
+        value=lambda wildcards: wildcards.i,
     shell:
         "echo {wildcards.i} > {output}"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -383,6 +383,7 @@ def test_log_events(
             "SNAKEMAKE",  # WORKFLOW_STARTED
             "Job stats:",  # RUN_INFO
             "localrule all:",  # JOB_INFO
+            "params: value=0",  # JOB_INFO
             "Shell command:",  # SHELLCMD
             "Provided cores:",  # RESOURCES_INFO
             re.compile(r"\d+ of \d+ steps \(\d+%\) done"),  # PROGRESS

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -383,7 +383,7 @@ def test_log_events(
             "SNAKEMAKE",  # WORKFLOW_STARTED
             "Job stats:",  # RUN_INFO
             "localrule all:",  # JOB_INFO
-            "params: value=0",  # JOB_INFO
+            "params: fixed, value=0",  # JOB_INFO
             "Shell command:",  # SHELLCMD
             "Provided cores:",  # RESOURCES_INFO
             re.compile(r"\d+ of \d+ steps \(\d+%\) done"),  # PROGRESS


### PR DESCRIPTION
<!--Add a description of your PR here-->
Closes #4290 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Job information logs now include configured rule parameters when available.
  - Named and unnamed parameters are displayed in a clearer, more readable format.
  - Parameter values from mappings and structured objects, including tabular data, are supported.

- **Bug Fixes**
  - Improved the completeness and consistency of parameter details in workflow log events.
  - Unsupported parameter values now produce clearer error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->