### PR TITLE
feat: Allow attempt in params

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -1466,7 +1466,7 @@ Similar to ``input``, ``params`` can take functions as well (see :ref:`snakefile
 
 Above example mimics a case where one would have to look up the value of some threshold in a config dictionary.
 Note that in contrast to the ``input`` directive, functions passed to the
-``params`` directive can optionally take more arguments than only ``wildcards``, namely ``input``, ``output``, ``threads``, and ``resources``.
+``params`` directive can optionally take more arguments than only ``wildcards``, namely ``input``, ``output``, ``threads``, ``resources``, and ``attempt``.
 Their order does not matter, apart from the fact that ``wildcards`` has to be the first argument.
 This way, params can be used to dynamically adjust those values into whatever format is needed for your command or script.
 

--- a/src/snakemake/jobs.py
+++ b/src/snakemake/jobs.py
@@ -448,7 +448,7 @@ class Job(
 
     def _expand_params(self):
         self._params, self._non_derived_params = self.rule.expand_params(
-            self.wildcards_dict, self.input, self.output, self
+            self.wildcards_dict, self.input, self.output, self, self.attempt
         )
 
     @property
@@ -484,8 +484,10 @@ class Job(
 
     @attempt.setter
     def attempt(self, attempt):
-        # reset resources
+        # reset properties that can depend on the attempt
         self._resources = None
+        self._params = None
+        self._non_derived_params = None
         self._attempt = attempt
 
     @property

--- a/src/snakemake/rules.py
+++ b/src/snakemake/rules.py
@@ -933,7 +933,9 @@ class Rule(RuleInterface):
             )
         return False
 
-    def expand_params(self, wildcards, input, output, job, omit_callable=False):
+    def expand_params(
+        self, wildcards, input, output, job, attempt, omit_callable=False
+    ):
         def concretize_param(p, wildcards, is_from_callable, incomplete):
             if not is_from_callable:
                 if isinstance(p, str):
@@ -986,6 +988,7 @@ class Rule(RuleInterface):
                     "resources": resources,
                     "output": output._plainstrings(),
                     "threads": threads,
+                    "attempt": attempt,
                 },
                 incomplete_checkpoint_func=handle_incomplete_checkpoint,
                 non_derived_items=non_derived_params,

--- a/tests/test_retries/Snakefile
+++ b/tests/test_retries/Snakefile
@@ -1,11 +1,13 @@
 rule a:
     output:
-        "test.txt"
-    resources:
-        shouldfail=lambda w, attempt: attempt < 3
+        "test.txt",
     retries: 3
+    resources:
+        shouldfail=lambda w, attempt: attempt < 3,
+    params:
+        shouldfail=lambda w, attempt: attempt < 3,
     run:
-        if resources.shouldfail:
+        if resources.shouldfail and params.shouldfail:
             raise ValueError("not enough attempts")
         with open(output[0], "w") as out:
             print("test", file=out)


### PR DESCRIPTION
<!--Add a description of your PR here-->
Closes #499 

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [x] Code generation (e.g., when writing an implementation or fixing a bug)
* [x] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Parameter functions can access the current job attempt number, enabling attempt-specific values during retries.
  - Resources, parameters, and conda environment settings are recalculated when a retry begins.

- **Bug Fixes**
  - Improved retry behavior by ensuring job configuration reflects the current attempt.

- **Documentation**
  - Documented the optional `attempt` argument for rule parameter functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->