### PR TITLE
perf: speed up snakemake via avoid importing yte unless profile config requires it

### DIFF
--- a/src/snakemake/profiles.py
+++ b/src/snakemake/profiles.py
@@ -67,7 +67,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                 for key2, val2 in val.items()
             ]
 
-        def resolve_path(raw):
+        def resolve_path(value: str):
             """
             Adjust path if it exists in the profile dir.
             Otherwise value is not a file or not existing in the profile dir.
@@ -75,15 +75,15 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
             Cache files in the profile directory for performance.
             Otherwise fall back to search in the filesystem.
             """
-            value = os.path.expanduser(os.path.expandvars(str(raw)))
             file = profile_dir / value
             if file.parent == profile_dir:
                 if not profile_cache:
                     profile_cache.update(os.listdir(profile_dir))
-                if value in profile_cache:
+                if file.name in profile_cache:
                     return str(file)
             elif file.exists():
                 return str(file)
+            return value
 
         profile_dir = Path(profile_name).parent
         profile_cache = set()
@@ -112,8 +112,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                     elif key == "set-resources":
                         result[key] = format_two_level_dict(value, "set-resources")
                 else:
-                    value = resolve_path(value)
-                    if value:
-                        result[key] = value
+                    value = os.path.expanduser(os.path.expandvars(str(value)))
+                    result[key] = resolve_path(value)
 
         return result

--- a/src/snakemake/profiles.py
+++ b/src/snakemake/profiles.py
@@ -11,33 +11,33 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
         # taken from configargparse and modified to add special handling for key-value pairs
         import yaml
 
+        profile_name = getattr(stream, "name", "<stream>")
         try:
             text = stream.read()
             parsed_obj = yaml.load(text, Loader=yaml.FullLoader)
 
-            if not isinstance(parsed_obj, dict):
-                raise ConfigFileParserException(
-                    "The config file doesn't appear to "
-                    "contain 'key: value' pairs (aka. a YAML mapping). "
-                    "yaml.load('%s') returned type '%s' instead of 'dict'."
-                    % (getattr(stream, "name", "stream"), type(parsed_obj).__name__)
-                )
-
-            is_use_yte = parsed_obj.pop("__use_yte__", None)
-            if is_use_yte:
+            if parsed_obj.pop("__use_yte__", False):
                 try:
                     import yte
+                except ImportError as e:
+                    raise WorkflowError(
+                        f"Config file '{profile_name}' requires the missing package 'yte'. "
+                        f"Please install it with 'pip install yte'."
+                    ) from e
 
-                    parsed_obj = yte.process_yaml(text, require_use_yte=True)
-                except ImportError:
-                    raise
-        except ImportError as e:
-            raise WorkflowError(
-                "The config file requires the 'yte' package to be installed. "
-                "Please install it with 'pip install yte'."
-            ) from e
+                parsed_obj = yte.process_yaml(text, require_use_yte=True)
+
+            if not isinstance(parsed_obj, dict):
+                raise KeyError(
+                    f"It doesn't appear to contain 'key: value' pairs (aka. a YAML mapping). "
+                    f"Got '{type(parsed_obj).__name__}' instead of 'dict'."
+                )
+        except WorkflowError:
+            raise
         except Exception as e:
-            raise ConfigFileParserException(f"Couldn't parse config file: {e}")
+            raise ConfigFileParserException(
+                f"Couldn't parse config file '{profile_name}'."
+            ) from e
 
         def format_val(val):
             def repr_if_numeric(val, numtype):
@@ -67,7 +67,26 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                 for key2, val2 in val.items()
             ]
 
-        profile_dir = Path(stream.name).parent
+        def resolve_path(raw):
+            """
+            Adjust path if it exists in the profile dir.
+            Otherwise value is not a file or not existing in the profile dir.
+
+            Cache files in the profile directory for performance.
+            Otherwise fall back to search in the filesystem.
+            """
+            value = os.path.expanduser(os.path.expandvars(str(raw)))
+            file = profile_dir / value
+            if file.parent == profile_dir:
+                if not profile_cache:
+                    profile_cache.update(os.listdir(profile_dir))
+                if value in profile_cache:
+                    return str(file)
+            elif file.exists():
+                return str(file)
+
+        profile_dir = Path(profile_name).parent
+        profile_cache = set()
         result = OrderedDict()
         for key, value in parsed_obj.items():
             if isinstance(value, list):
@@ -93,13 +112,8 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                     elif key == "set-resources":
                         result[key] = format_two_level_dict(value, "set-resources")
                 else:
-                    value = os.path.expanduser(os.path.expandvars(str(value)))
-
-                    # Adjust path if it exists in the profile dir.
-                    # Otherwise value is not a file or not existing in the profile dir.
-                    if (profile_dir / value).exists():
-                        value = str(profile_dir / value)
-
-                    result[key] = value
+                    value = resolve_path(value)
+                    if value:
+                        result[key] = value
 
         return result

--- a/src/snakemake/profiles.py
+++ b/src/snakemake/profiles.py
@@ -14,26 +14,30 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
         try:
             text = stream.read()
             parsed_obj = yaml.load(text, Loader=yaml.FullLoader)
-            if isinstance(parsed_obj, dict) and parsed_obj.get("__use_yte__"):
+
+            if not isinstance(parsed_obj, dict):
+                raise ConfigFileParserException(
+                    "The config file doesn't appear to "
+                    "contain 'key: value' pairs (aka. a YAML mapping). "
+                    "yaml.load('%s') returned type '%s' instead of 'dict'."
+                    % (getattr(stream, "name", "stream"), type(parsed_obj).__name__)
+                )
+
+            is_use_yte = parsed_obj.pop("__use_yte__", None)
+            if is_use_yte:
                 try:
                     import yte
 
                     parsed_obj = yte.process_yaml(text, require_use_yte=True)
-                except ImportError as e:
-                    raise ConfigFileParserException(
-                        "The config file requires the 'yte' package to be installed. "
-                        "Please install it with 'pip install yte'."
-                    ) from e
+                except ImportError:
+                    raise
+        except ImportError as e:
+            raise WorkflowError(
+                "The config file requires the 'yte' package to be installed. "
+                "Please install it with 'pip install yte'."
+            ) from e
         except Exception as e:
             raise ConfigFileParserException(f"Couldn't parse config file: {e}")
-
-        if not isinstance(parsed_obj, dict):
-            raise ConfigFileParserException(
-                "The config file doesn't appear to "
-                "contain 'key: value' pairs (aka. a YAML mapping). "
-                "yaml.load('%s') returned type '%s' instead of 'dict'."
-                % (getattr(stream, "name", "stream"), type(parsed_obj).__name__)
-            )
 
         def format_val(val):
             def repr_if_numeric(val, numtype):

--- a/src/snakemake/profiles.py
+++ b/src/snakemake/profiles.py
@@ -9,13 +9,23 @@ from snakemake_interface_common.exceptions import WorkflowError
 class ProfileConfigFileParser(YAMLConfigFileParser):
     def parse(self, stream):
         # taken from configargparse and modified to add special handling for key-value pairs
-        import yte
+        import yaml
 
-        profile_dir = Path(stream.name).parent
         try:
-            parsed_obj = yte.process_yaml(stream, require_use_yte=True)
+            text = stream.read()
+            parsed_obj = yaml.load(text, Loader=yaml.FullLoader)
+            if isinstance(parsed_obj, dict) and parsed_obj.get("__use_yte__"):
+                try:
+                    import yte
+
+                    parsed_obj = yte.process_yaml(text, require_use_yte=True)
+                except ImportError as e:
+                    raise ConfigFileParserException(
+                        "The config file requires the 'yte' package to be installed. "
+                        "Please install it with 'pip install yte'."
+                    ) from e
         except Exception as e:
-            raise ConfigFileParserException("Couldn't parse config file: %s" % e)
+            raise ConfigFileParserException(f"Couldn't parse config file: {e}")
 
         if not isinstance(parsed_obj, dict):
             raise ConfigFileParserException(
@@ -53,6 +63,7 @@ class ProfileConfigFileParser(YAMLConfigFileParser):
                 for key2, val2 in val.items()
             ]
 
+        profile_dir = Path(stream.name).parent
         result = OrderedDict()
         for key, value in parsed_obj.items():
             if isinstance(value, list):

--- a/src/snakemake/report/__init__.py
+++ b/src/snakemake/report/__init__.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 import hashlib
 from pathlib import Path
 import numbers
-from yte import process_yaml
 
 from docutils.parsers.rst.directives.images import Image, Figure
 from docutils.parsers.rst import directives
@@ -751,8 +750,9 @@ async def auto_report(
     if global_report_settings.metadata_template:
         # parse metadata from yte template
         with open(global_report_settings.metadata_template, "r") as template:
-            metadata = process_yaml(template)
+            import yte
 
+            metadata = yte.process_yaml(template)
             # ensure that metadata is a key value dictionary
             # allowed values: str, int, float, list[str|int|float]
             if not _validate_flat_dict(metadata):

--- a/tests/test_profile_double_dash/profile/config.yaml
+++ b/tests/test_profile_double_dash/profile/config.yaml
@@ -1,2 +1,5 @@
+__use_yte__: true
+cores: ?1+1
+
 default-resources:
   runtime: 10

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -980,7 +980,7 @@ def test_profile_double_dash():
     """Test that -- target separator works correctly with --profile (issue #3642)."""
     run(
         dpath("test_profile_double_dash"),
-        shellcmd="snakemake -c1 --profile profile -- done.txt",
+        shellcmd="snakemake --profile profile -- done.txt",
     )
 
 


### PR DESCRIPTION
On HPC, snakemake sometimes run slowly and I found the import of `yte` itself can take 0.3~2s (5%-6% of total dry-run, see #4220). This PR make `yte` optional and only required when profile requires it.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile configuration parsing when YTE templating is enabled.
  * Added clearer errors and installation guidance when YTE is unavailable.
  * Improved handling of profile-relative paths while preserving unresolved scalar values.
  * Added validation and clearer errors for invalid profile configuration formats.
  * Preserved report template processing with optional YTE handling.

* **Tests**
  * Expanded coverage for templated core settings and command-line argument handling.
  * Verified profile usage with targets following the `--` separator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->