### PR TITLE
feat: add support for marimo notebooks

### DIFF
--- a/docs/snakefiles/rules.rst
+++ b/docs/snakefiles/rules.rst
@@ -2006,14 +2006,17 @@ For technical reasons, scripts are executed in ``.snakemake/scripts``. The origi
 
 .. _snakefiles_notebook-integration:
 
-Jupyter notebook integration
-----------------------------
+Notebook integration
+--------------------
 
-Instead of plain scripts (see above), one can integrate Jupyter_ Notebooks.
+Instead of plain scripts (see above), one can integrate notebooks.
 This enables the interactive development of data analysis components (e.g. for plotting).
-Integration works as follows (note the use of `notebook:` instead of `script:`):
 
-.. _Jupyter: https://jupyter.org/
+Using notebooks
+~~~~~~~~~~~~~~~
+
+Notebook integration works using the ``notebook:`` directive (instead of ``script:``):
+
 
 .. code-block:: python
 
@@ -2028,33 +2031,52 @@ Integration works as follows (note the use of `notebook:` instead of `script:`):
 
 .. note::
 
-    Consider Jupyter notebook integration as a way to get the best of both worlds.
-    A modular, readable workflow definition with Snakemake, and the ability to quickly explore and plot data with Jupyter.
-    The benefit will be maximal when integrating many small notebooks that each do a particular job, hence allowing to get away from large monolithic, and therefore unreadable notebooks.
+    It is possible to refer to wildcards and params in the notebook path, e.g. by specifying ``"notebook/{params.name}.py"`` or ``"notebook/{wildcards.name}.py"``.
 
-It is recommended to prefix the ``.ipynb`` suffix with either ``.py`` or ``.r`` to indicate the notebook language.
-In the notebook, a snakemake object is available, which can be accessed in the same way as the with :ref:`script integration <snakefiles-external_scripts>`.
-In other words, you have access to input files via ``snakemake.input`` (in the Python case) and ``snakemake@input`` (in the R case) etc..
-Optionally it is possible to automatically store the processed notebook.
-This can be achieved by adding a named logfile ``notebook=...`` to the ``log`` directive.
+
+
+* The filename determines the type of notebook:
+  
+  * Jupyter_: It is recommended to prefix the ``.ipynb`` suffix with either ``.py`` or ``.r`` to indicate the notebook language.
+  * Marimo_: The filename must end in ``.marimo.py``.
+
+.. _Jupyter: https://jupyter.org/
+.. _Marimo: https://marimo.io/
+
+* In the notebook, a snakemake object is available, which can be accessed in the same way as with the :ref:`script integration <snakefiles-external_scripts>`.
+  In other words, you have access to input files via ``snakemake.input`` (in the Python case) and ``snakemake@input`` (in the R case), etc.
+
+* Optionally it is possible to automatically store the processed notebook.
+  This can be achieved by adding a named logfile ``notebook=...`` to the ``log`` directive.
 
 .. note::
 
-    It is possible to refer to wildcards and params in the notebook path, e.g. by specifying ``"notebook/{params.name}.py"`` or ``"notebook/{wildcards.name}.py"``.
+    Consider notebook integration as a way to get the best of both scripts and notebooks.
+    A modular, readable workflow definition with Snakemake, and the ability to quickly explore and plot data. 
+    The benefit will be maximal when integrating many small notebooks that each do a particular job, hence allowing to get away from large monolithic, and therefore unreadable notebooks.
 
-Normally, notebooks are executed headlessly (without a Jupyter interface being presented to you).
-This is achieved with Papermill_ if that is installed in your software environment,
-or `nbconvert`_ otherwise.
-The latter will be installed automatically along with Jupyter, but will not output
-an executed (logfile) notebook until the entire execution is complete, and won't output
-a notebook if execution encounters an error.
+Normally, notebooks are executed headlessly (without an interface being presented to you).
 
-.. _Papermill: https://github.com/nteract/papermill
+* **Jupyter notebook**: Headless execution is achieved with Papermill_ if that is installed in your software environment,
+  or `nbconvert`_ otherwise. The latter will be installed automatically along with Jupyter, but will not output
+  an executed (logfile) notebook until the entire execution is complete, and won't output a notebook if execution encounters an error.
 
-.. _nbconvert: https://nbconvert.readthedocs.io/en/latest/
+  .. _Papermill: https://github.com/nteract/papermill
+
+  .. _nbconvert: https://nbconvert.readthedocs.io/en/latest/
+
+* **Marimo notebook**: The notebook is executed as a regular Python script, unless:
+
+  * If ``--edit-notebook`` is specified (see below), the notebook is run using ``marimo edit``.
+  * If you want to store the processed notebook, add ``notebook=<filename>.html`` to the ``log`` directive.
+    The notebook will then be exported using ``marimo export html``.
+
+
+Editing notebooks interactively
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to simplify the coding of notebooks given the automatically inserted ``snakemake`` object, Snakemake provides an interactive edit mode for notebook rules.
-Let us assume you have written above rule, but the notebook does not yet exist.
+Let us assume you have written a rule, but the notebook does not yet exist.
 By running
 
 .. code-block:: console
@@ -2063,10 +2085,10 @@ By running
 
 you instruct Snakemake to allow interactive editing of the notebook needed to create the file ``test.txt``.
 Snakemake will run all dependencies of the notebook rule, such that all input files are present.
-Then, it will start a jupyter notebook server with an empty draft of the notebook, in which you can interactively program everything needed for this particular step.
-Once done, you should save the notebook from the jupyter web interface, go to the jupyter dashboard and hit the ``Quit`` button on the top right in order to shut down the jupyter server.
+Then, it will start a notebook server with an empty draft of the notebook, in which you can interactively program everything needed for this particular step.
+Once done, you should save the notebook and shut down the server.
 Snakemake will detect that the server is closed and automatically store the drafted notebook into the path given in the rule (here ``hello.py.ipynb``).
-If the notebook already exists, above procedure can be used to easily modify it.
+If the notebook already exists, the above procedure can be used to easily modify it.
 Note that Snakemake requires local execution for the notebook edit mode.
 On a cluster or the cloud, you can generate all dependencies of the notebook rule via
 
@@ -2075,7 +2097,8 @@ On a cluster or the cloud, you can generate all dependencies of the notebook rul
     snakemake --cluster ... --jobs 100 --until test.txt
 
 Then, the notebook rule can easily be executed locally.
-An demo of the entire interactive editing process can be found by clicking below:
+
+A demo of the entire interactive editing process can be found by clicking below:
 
 .. image:: images/snakemake-notebook-demo.gif
     :scale: 20%
@@ -2083,7 +2106,7 @@ An demo of the entire interactive editing process can be found by clicking below
     :align: center
 
 Finally, it is advisable to combine the ``notebook`` directive with the ``conda`` directive (see :ref:`integrated_package_management`) in order to define a software stack to use.
-At least, this software stack should contain jupyter and the language to use (e.g. Python or R).
+For example, this software stack should contain Jupyter and the language to use (e.g. Python or R).
 For the above case, this means
 
 .. code-block:: python
@@ -2110,7 +2133,7 @@ with
 The last dependency is advisable in order to enable autoformatting of notebook cells when editing.
 When using other languages than Python in the notebook, one needs to additionally add the respective kernel, e.g. ``r-irkernel`` for R support.
 
-When using an IDE with built-in Jupyter support, an alternative to ``--edit-notebook`` is ``--draft-notebook``.
+When using an IDE with built-in notebook support, an alternative to ``--edit-notebook`` is ``--draft-notebook``.
 Instead of firing up a notebook server, ``--draft-notebook`` just creates a skeleton notebook for editing within the IDE.
 In addition, it prints instructions for configuring the IDE's notebook environment to use the interpreter from the
 Conda environment defined in the corresponding rule.
@@ -2120,13 +2143,7 @@ For example, running
 
     snakemake --cores 1 --draft-notebook test.txt --software-deployment-method conda
 
-or the short form
-
-.. code-block:: console
-
-    snakemake -c 1 --draft-notebook test.txt --sdm conda
-
-will generate skeleton code in ``notebooks/hello.py.ipynb`` and additionally print instructions on how to open and execute the notebook in VSCode.
+will generate skeleton code in ``notebooks/hello.py.ipynb`` and additionally print instructions on how to open and execute the notebook in VSCode.  
 
 
 .. _snakefiles_protected_temp:

--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -258,31 +258,35 @@ class MarimoNotebook(PythonScript):
                 "@app.cell(hide_code=True)",
                 "def snakemake_preamble():",
                 *[f"    {line}" for line in fixed_preamble.splitlines()],
-                "    return",
+                "    return\n\n",
             ]
         )
 
         notebook_with_preamble = re.sub(
-            '(if __name__ == "__main__":)', rf"{preamble_cell}\n\n\g<1>", notebook
+            '(if __name__ == "__main__":)', rf"{preamble_cell}\g<1>", notebook
         )
 
         if not re.search("def snakemake_preamble", notebook_with_preamble):
-            raise ValueError(
-                dedent("""\
+            raise ValueError(dedent("""\
                     Could not inject Snakemake preamble into marimo notebook.
                     Are you sure it is a valid marimo notebook?
                     Hint: Use `marimo check` to check the format of the file.
-                    """)
-            )
+                    """))
 
         return notebook_with_preamble
 
     def remove_preamble_cell(self, notebook):
         return re.sub(
-            r"@app\.cell[^\n]*\ndef snakemake_preamble.*return[^\n]*\n\s*",
+            r"""
+            ^@app\.cell.*\n
+            def\ snakemake_preamble.*\n
+            (?:(?!\s{4}return).*\n)+
+            \s{4}return.*$
+            \s+
+            """,
             "",
             notebook,
-            flags=re.M | re.S,
+            flags=re.M | re.X,
         )
 
     def draft(self):
@@ -332,7 +336,7 @@ class MarimoNotebook(PythonScript):
 
         if edit is not None:
             assert not edit.draft_only
-            cmd = "marimo edit {fname:q} --port {edit.port}"
+            cmd = "marimo edit {fname:q} --port {edit.port} --host {edit.ip}"
             if fname_out is not None:
                 cmd += f" && {export_cmd}"
         elif fname_out is not None:

--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -268,13 +268,11 @@ class MarimoNotebook(PythonScript):
 
         if not re.search("def snakemake_preamble", notebook_with_preamble):
             raise ValueError(
-                dedent(
-                    """\
+                dedent("""\
                     Could not inject Snakemake preamble into marimo notebook.
                     Are you sure it is a valid marimo notebook?
                     Hint: Use `marimo check` to check the format of the file.
-                    """
-                )
+                    """)
             )
 
         return notebook_with_preamble

--- a/src/snakemake/notebook.py
+++ b/src/snakemake/notebook.py
@@ -5,6 +5,7 @@ import subprocess as sp
 import shutil
 import tempfile
 import re
+from textwrap import dedent
 
 from snakemake.exceptions import WorkflowError
 from snakemake.script import get_source, ScriptBase, PythonScript, RScript
@@ -88,8 +89,9 @@ class JupyterNotebook(ScriptBase):
                 else:
                     output_parameter = "{fname_out}"
                 cmd = (
-                    "papermill --log-level ERROR {{fname:q}} "
-                    "{output_parameter}".format(output_parameter=output_parameter)
+                    "papermill --log-level ERROR {{fname:q}} {output_parameter}".format(
+                        output_parameter=output_parameter
+                    )
                 )
             else:
                 if fname_out is None:
@@ -240,13 +242,126 @@ class RJupyterNotebook(JupyterNotebook):
         return "RScript"
 
 
+class MarimoNotebook(PythonScript):
+    editable = True
+
+    def get_interpreter_exec(self):
+        return "marimo"
+
+    def insert_preamble_cell(self, preamble, notebook):
+        fixed_preamble = re.sub(
+            "__real_file__ = __file__", "__real_file__ = __name__", preamble
+        ).replace("\\", r"\\")
+
+        preamble_cell = "\n".join(
+            [
+                "@app.cell(hide_code=True)",
+                "def snakemake_preamble():",
+                *[f"    {line}" for line in fixed_preamble.splitlines()],
+                "    return",
+            ]
+        )
+
+        notebook_with_preamble = re.sub(
+            '(if __name__ == "__main__":)', rf"{preamble_cell}\n\n\g<1>", notebook
+        )
+
+        if not re.search("def snakemake_preamble", notebook_with_preamble):
+            raise ValueError(
+                dedent(
+                    """\
+                    Could not inject Snakemake preamble into marimo notebook.
+                    Are you sure it is a valid marimo notebook?
+                    Hint: Use `marimo check` to check the format of the file.
+                    """
+                )
+            )
+
+        return notebook_with_preamble
+
+    def remove_preamble_cell(self, notebook):
+        return re.sub(
+            r"@app\.cell[^\n]*\ndef snakemake_preamble.*return[^\n]*\n\s*",
+            "",
+            notebook,
+            flags=re.M | re.S,
+        )
+
+    def draft(self):
+        minimal_notebook = dedent("""\
+            import marimo
+
+            app = marimo.App()
+
+            @app.cell
+            def _():
+                # start coding here
+                return
+
+            if __name__ == "__main__":
+                app.run()
+        """)
+        notebook_with_preamble = self.insert_preamble_cell(
+            self.get_preamble(), minimal_notebook
+        )
+
+        os.makedirs(os.path.dirname(self.local_path), exist_ok=True)
+
+        with open(self.local_path, "wb") as out:
+            out.write(notebook_with_preamble.encode())
+
+    def draft_and_edit(self, listen):
+        self.draft()
+        self.source = open(self.local_path).read()
+        self.evaluate(edit=listen)
+
+    def write_script(self, preamble, fd):
+        source_without_preamble = self.remove_preamble_cell(self.source)
+        source_with_preamble = self.insert_preamble_cell(
+            preamble, source_without_preamble
+        )
+        fd.write(source_with_preamble.encode())
+
+    def execute_script(self, fname, edit=None):
+        fname_out = self.log.get("notebook", None)
+        if fname_out is not None:
+            if not fname_out.endswith(".html"):
+                raise ValueError(
+                    "Only `html` is supported for saving processed marimo notebooks."
+                )
+            fname_out = os.path.abspath(fname_out)
+        export_cmd = "marimo export html {fname:q} -o {fname_out:q}"
+
+        if edit is not None:
+            assert not edit.draft_only
+            cmd = "marimo edit {fname:q} --port {edit.port}"
+            if fname_out is not None:
+                cmd += f" && {export_cmd}"
+        elif fname_out is not None:
+            cmd = export_cmd
+        else:
+            cmd = "python {fname:q}"
+
+        self._execute_cmd(cmd, fname=fname, fname_out=fname_out, edit=edit)
+
+        if edit:
+            logger.info("Saving modified notebook.")
+            with open(fname, "r") as file:
+                notebook = self.remove_preamble_cell(file.read())
+            with open(self.local_path, "w") as out_file:
+                out_file.write(notebook)
+
+
 def get_exec_class(language):
     exec_class = {
         "jupyter_python": PythonJupyterNotebook,
         "jupyter_r": RJupyterNotebook,
+        "marimo_python": MarimoNotebook,
     }.get(language, None)
     if exec_class is None:
-        raise ValueError("Unsupported notebook: Expecting Jupyter Notebook (.ipynb).")
+        raise ValueError(
+            "Unsupported notebook: Expecting Jupyter (.ipynb) or marimo (.py) notebook."
+        )
     return exec_class
 
 
@@ -299,6 +414,8 @@ def notebook(
                     language = "jupyter_python"
                 elif path.endswith(".r.ipynb"):
                     language = "jupyter_r"
+                elif path.endswith(".marimo.py"):
+                    language = "marimo_python"
                 else:
                     raise WorkflowError(
                         "Notebook to edit has to end on .py.ipynb or .r.ipynb in order "
@@ -366,10 +483,17 @@ def notebook(
                     str(Path(conda_env) / "bin" / executor.get_interpreter_exec())
                 )
             )
-            msg += (
-                "\nEditing with Jupyter CLI:"
-                "\nconda activate {}\njupyter notebook {}\n".format(conda_env, path)
-            )
+            if language in ["jupyter_python", "jupyter_r"]:
+                msg += (
+                    "\nEditing with Jupyter CLI:"
+                    "\nconda activate {}\njupyter notebook {}\n".format(conda_env, path)
+                )
+            elif language in ["marimo_python"]:
+                msg += (
+                    "\nEditing with marimo CLI:"
+                    "\nconda activate {}\nmarimo edit {}\n".format(conda_env, path)
+                )
+
         logger.info(msg)
     elif draft:
         executor.draft_and_edit(listen=edit)

--- a/src/snakemake/script/__init__.py
+++ b/src/snakemake/script/__init__.py
@@ -1423,6 +1423,10 @@ def get_language(source_file, source):
 
         language += "_" + kernel_language.lower()
 
+    # detect marimo notebooks
+    if filename.endswith(".marimo.py"):
+        language = "marimo_python"
+
     return language
 
 

--- a/tests/test_marimo_notebook/Snakefile
+++ b/tests/test_marimo_notebook/Snakefile
@@ -1,0 +1,7 @@
+rule test_marimo:
+    output:
+        "snakemake_plus_marimo.txt",
+    conda:
+        "env.yaml"
+    notebook:
+        "notebook.marimo.py"

--- a/tests/test_marimo_notebook/env.yaml
+++ b/tests/test_marimo_notebook/env.yaml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+dependencies:
+  - marimo

--- a/tests/test_marimo_notebook/expected-results/snakemake_plus_marimo.txt
+++ b/tests/test_marimo_notebook/expected-results/snakemake_plus_marimo.txt
@@ -1,0 +1,1 @@
+Snakemake + marimo!

--- a/tests/test_marimo_notebook/notebook.marimo.py
+++ b/tests/test_marimo_notebook/notebook.marimo.py
@@ -1,0 +1,15 @@
+import marimo
+
+__generated_with = "0.19.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _(snakemake):
+    with open(snakemake.output[0], "w") as out_file:
+        print("Snakemake + marimo!", file=out_file)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2009,6 +2009,10 @@ def test_jupyter_notebook_draft():
     )
 
 
+def test_marimo_notebook():
+    run(dpath("test_marimo_notebook"), deployment_method={DeploymentMethod.CONDA})
+
+
 def test_github_issue456():
     run(dpath("test_github_issue456"))
 


### PR DESCRIPTION
<!--Add a description of your PR here-->

This PR adds support for marimo notebooks.

It is a reworking of #3930.

### QC
<!-- Make sure that you can tick the boxes below. -->

* [x] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [ ] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Marimo notebooks using `.marimo.py` files.
  * Automatically detects notebook type from the file name.
  * Supports running Marimo notebooks as scripts, editing them interactively, and using processed HTML exports.
  * Preserves the requested host address when launching Marimo editing sessions.

* **Documentation**
  * Updated notebook integration guidance for Jupyter and Marimo workflows.
  * Clarified execution, editing, and software environment instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->