### PR TITLE
fix: guard is_edit_notebook_job check to prevent crash

### DIFF
--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -628,7 +628,8 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
 
     def is_draft_notebook_job(self, job):
         return (
-            self.workflow.execution_settings.edit_notebook
+            self.workflow.execution_settings is not None
+            and self.workflow.execution_settings.edit_notebook
             and self.workflow.execution_settings.edit_notebook.draft_only
             and job.targetfile in self.targetfiles
         )

--- a/src/snakemake/dag.py
+++ b/src/snakemake/dag.py
@@ -621,7 +621,8 @@ class DAG(DAGExecutorInterface, DAGReportInterface, DAGSchedulerInterface):
 
     def is_edit_notebook_job(self, job):
         return (
-            self.workflow.execution_settings.edit_notebook
+            self.workflow.execution_settings is not None
+            and self.workflow.execution_settings.edit_notebook
             and job.targetfile in self.targetfiles
         )
 


### PR DESCRIPTION
Fixes a crash when using `--rulegraph` under some conditions. Unfortunately, I have not been able to find a reproducible example of this situation so I cannot easily add a test case. The pipeline I encounter it in is not easily minimized. Another user also encountered this error recently: https://stackoverflow.com/questions/79999901/issue-with-rulegraph-for-v9-20

The error this avoids is:
```
File "[...]/lib/python3.12/site-packages/snakemake/dag.py", line 612, in is_edit_notebook_job
    self.workflow.execution_settings.edit_notebook
AttributeError: 'NoneType' object has no attribute 'edit_notebook''
```

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
* [x] I, as a human being, have checked each line of code in this pull request

### AI-assistance disclosure
<!--
If AI tools were involved in creating this PR, please check all boxes that apply
below and make sure that you adhere to our AI-assisted contributions policy:
https://github.com/snakemake/snakemake/blob/main/docs/project_info/contributing.rst
-->
I used AI assistance for:
* [ ] Code generation (e.g., when writing an implementation or fixing a bug)
* [ ] Test/benchmark generation
* [ ] Documentation (including examples)
* [x] Research and understanding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when notebook editing is checked without execution settings configured.
  * Notebook editing is now treated as unavailable when execution settings are not present.
  * Improved handling of notebook-related workflow checks in configurations without execution settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->